### PR TITLE
ci: add GitHub Actions workflow tracking matz/spinel master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # Build matz/spinel from tip-of-master and publish the toolchain as
+  # an artifact. Spinel is pre-release and evolves rapidly; tep has a
+  # hard dependency on it, so we deliberately track an unpinned master
+  # to surface upstream breakage early. If this turns flaky, pin a SHA
+  # here (and only here).
+  #
+  # The `spinel` shell wrapper resolves spinel_parse / spinel_analyze /
+  # spinel_codegen / lib/ relative to its own directory, so the tree
+  # ships as a unit.
+  build-spinel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          repository: matz/spinel
+          ref: master
+          path: spinel-src
+      - name: make deps (fetch vendored libprism)
+        run: make -C spinel-src deps
+      - name: make all
+        run: make -C spinel-src all
+      - name: Stage artifact tree
+        run: |
+          mkdir spinel-dist
+          cp spinel-src/spinel             spinel-dist/
+          cp spinel-src/spinel_parse       spinel-dist/
+          cp spinel-src/spinel_analyze     spinel-dist/
+          cp spinel-src/spinel_codegen     spinel-dist/
+          cp spinel-src/spinel_analyze.rb  spinel-dist/
+          cp spinel-src/spinel_codegen.rb  spinel-dist/
+          cp -R spinel-src/lib             spinel-dist/lib
+      - name: Upload spinel toolchain
+        uses: actions/upload-artifact@v4
+        with:
+          name: spinel-dist
+          path: spinel-dist
+          retention-days: 1
+
+  # Build tep's examples/bench + run the full test suite against the
+  # spinel toolchain produced above. TEP_SKIP_SPINEL_FRESH=1 disables
+  # tools/spinel-fresh.sh -- the artifact is already fresh, and the
+  # script would otherwise try to locate a local spinel checkout.
+  test:
+    needs: build-spinel
+    runs-on: ubuntu-latest
+    env:
+      TEP_SKIP_SPINEL_FRESH: "1"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libsqlite3-dev
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+      - uses: actions/download-artifact@v4
+        with:
+          name: spinel-dist
+          path: spinel-dist
+      - name: Restore exec bits and put spinel on PATH
+        run: |
+          chmod +x spinel-dist/spinel \
+                   spinel-dist/spinel_parse \
+                   spinel-dist/spinel_analyze \
+                   spinel-dist/spinel_codegen
+          echo "$GITHUB_WORKSPACE/spinel-dist" >> "$GITHUB_PATH"
+      - name: make all
+        run: make all
+      - name: rake test
+        run: rake test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two jobs: `build-spinel` (clones matz/spinel@master, `make deps && make all`, uploads the toolchain as an artifact) and `test` (downloads it, prepends to `PATH`, runs `make all && rake test`).
- Tracks **unpinned master** deliberately. Spinel is pre-release and evolves rapidly, and tep has a hard dependency on it. The goal is to surface upstream breakage early — exactly the kind of "shake bugs out of Spinel" signal the README calls out as tep's primary purpose. Pin a SHA in `build-spinel` if it turns flaky.
- Sets `TEP_SKIP_SPINEL_FRESH=1` in the test job so `tools/spinel-fresh.sh` no-ops (the artifact is already fresh, and the script would otherwise look for a local checkout).
- Installs `build-essential` + `libsqlite3-dev` per the README's Linux build deps.

## Test plan
- [ ] First CI run on this PR exercises both jobs end-to-end against current matz/spinel master.
- [ ] Confirm artifact upload/download preserves the spinel toolchain tree and the shell wrapper resolves siblings correctly after `chmod +x`.
- [ ] If anything red is upstream-driven, capture the failure for a spinel-side issue rather than working around it here.

Co-authored with Claude Code; pattern adapted from the `build-spinel` job in [rubys/roundhouse](https://github.com/rubys/roundhouse).