### PR TITLE
feat(server): Tep::Server::Scheduled — Falcon-shape fiber-per-connection HTTP server (WS Phase 1.5)

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -301,10 +301,12 @@ def translate(input_path)
   # CLI option parsing -- emitted at top level so spinel's codegen
   # actually declares `sp_argv` (it skips it for method-local ARGV
   # references). Every translated app picks up `-p`, `-w`, `-q`.
+  scheduled = config[:scheduler] == :scheduled
   out << <<~RB
     __port = #{config[:port] || 4567}
     __workers = #{config[:workers] || 1}
     __quiet = false
+    __scheduled = #{scheduled ? 'true' : 'false'}
     __i = 0
     while __i < ARGV.length
       __a = ARGV[__i]
@@ -317,11 +319,16 @@ def translate(input_path)
       elsif __a == "-q"
         __quiet = true
         __i += 1
+      elsif __a == "-s"
+        # Phase 1.5 opt-in: scheduled fiber-per-connection server
+        # (vs the default prefork-blocking-one-conn-per-worker shape).
+        __scheduled = true
+        __i += 1
       else
         __i += 1
       end
     end
-    Tep.run!(__port, __workers, __quiet)
+    Tep.run!(__port, __workers, __quiet, __scheduled)
   RB
   out << ""
 
@@ -449,6 +456,20 @@ def handle_top_call(node, routes, filters, not_founds, config, warnings, passthr
         config[:workers] = literal_int(args[1]) || config[:workers]
       when "bind"
         # silently accept; tep always binds 0.0.0.0
+      when "scheduler"
+        # `set :scheduler, :scheduled` opts the app into the fiber-
+        # per-connection server (Tep::Server::Scheduled). Default
+        # stays the prefork-blocking Tep::Server until the next major
+        # release, when this flips and Blocking is deleted. The CLI
+        # `-s` flag overrides the same way `-w` overrides `:workers`.
+        sym = args[1].is_a?(Prism::SymbolNode) ? args[1].unescaped : nil
+        if sym == "scheduled"
+          config[:scheduler] = :scheduled
+        elsif sym == "blocking" || sym.nil?
+          # default; explicit blocking is a no-op
+        else
+          warnings << "unsupported `set :scheduler, :#{sym}` -- choose :scheduled or :blocking"
+        end
       else
         warnings << "unsupported `set :#{key}` -- ignored"
       end

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -29,6 +29,7 @@ require_relative "tep/parser"
 require_relative "tep/router"
 require_relative "tep/app"
 require_relative "tep/server"
+require_relative "tep/server_scheduled"
 require_relative "tep/sqlite"
 require_relative "tep/json"
 require_relative "tep/logger"
@@ -387,8 +388,25 @@ module Tep
 
   # ARGV access only emits `sp_argv` when used at top level, so the
   # translator emits the option-parsing loop itself before calling
-  # `Tep.run!`. This stays a plain three-arg dispatch.
-  def self.run!(port, workers, quiet)
-    Server.new(APP).run(port, workers, quiet)
+  # `Tep.run!`. The `scheduled` flag picks between the prefork
+  # blocking server (default) and the fiber-per-connection
+  # Tep::Server::Scheduled (opt-in via `set :scheduler, :scheduled`
+  # in the app source, or `-s` on the CLI). At the next major tep
+  # release Scheduled becomes the default and Blocking is deleted;
+  # the parallel-classes period exists only to make the rollback
+  # path obvious during the transition.
+  #
+  # Single dispatch method (rather than parallel run! / run_scheduled!)
+  # because spinel's codegen mis-declares heap-cell parameters when
+  # two same-arity sibling methods are called from an if/else --
+  # both branches reference `quiet` as a heap-cell but only the first
+  # path declares it. Bundling the decision inside one method
+  # sidesteps the codegen miss.
+  def self.run!(port, workers, quiet, scheduled)
+    if scheduled
+      Server::Scheduled.new(APP).run(port, workers, quiet)
+    else
+      Server.new(APP).run(port, workers, quiet)
+    end
   end
 end

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -14,6 +14,13 @@ module Tep
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
+    # Tep::Server::Scheduled needs a stash for per-connection state
+    # that the connection-fiber reads on entry. Closure capture across
+    # a Fiber.new { ... } boundary mis-lowers under spinel (heap-cell
+    # access emitted without a declaration); the stash sidesteps that
+    # by writing the values to App-state and yielding so the new fiber
+    # reads them before the next accept iteration overwrites.
+    attr_accessor :pending_listen_fd, :pending_client_fd, :pending_quiet
 
     def initialize
       @router         = Router.new
@@ -46,6 +53,10 @@ module Tep
       @sched_io_mode.delete_at(0)
       @sched_io_ready = [0]
       @sched_io_ready.delete_at(0)
+      # Tep::Server::Scheduled hand-off stash.
+      @pending_listen_fd = -1
+      @pending_client_fd = -1
+      @pending_quiet     = false
     end
 
     def add_asset(path, body, mime)

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -11,6 +11,10 @@ module Sock
 
   ffi_func :sphttp_listen,        [:int, :int],     :int
   ffi_func :sphttp_accept,        [:int],           :int
+  # Non-blocking accept variant used by Tep::Server::Scheduled.
+  # Listen fd must be in non-blocking mode (sphttp_set_nonblock).
+  # Returns -1 with errno EAGAIN/EWOULDBLOCK if no pending connection.
+  ffi_func :sphttp_accept_nb,     [:int],           :int
   ffi_func :sphttp_read_request,  [:int],           :int
   ffi_func :sphttp_request_buf,   [],               :str
   ffi_func :sphttp_request_len,   [],               :int

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -1,0 +1,235 @@
+# Tep::Server::Scheduled -- Falcon-shape fiber-per-connection HTTP
+# server, built on Tep::Scheduler + sphttp non-blocking accept/recv.
+#
+# Why this exists
+# ---------------
+# The default Tep::Server (in server.rb) is prefork + blocking per
+# worker -- N workers <=> N concurrent connections. WebSockets and
+# slow keep-alive clients tie up a worker for the full connection
+# duration, so the prefork pool's effective concurrency degrades
+# to N regardless of actual CPU work. The scheduled variant accepts
+# in a fiber, spawns one fiber per accepted connection, and parks
+# all I/O on Tep::Scheduler.io_wait -- N workers serve M >> N
+# concurrent connections, bounded only by per-fiber memory.
+#
+# Closure-capture workaround
+# --------------------------
+# Spinel's codegen mis-lowers Fiber.new bodies that capture local
+# variables: it emits heap-cell accesses to the captured values
+# without emitting the matching heap-cell declarations. Until that
+# lands (filed as a spinel issue alongside this commit), the fiber
+# bodies here are CLOSURE-FREE -- they call top-level cmeths whose
+# state arrives through `Tep::APP.pending_*` stash slots, set by
+# the spawner right before yielding. The pause(0) yield ensures the
+# new fiber wins the next tick and reads its slot before any other
+# spawn overwrites.
+#
+# All methods are cmeths (`def self.X`) so the fiber bodies can call
+# them as plain top-level functions without instance state.
+module Tep
+  class Server
+    class Scheduled
+      # Max bytes accepted from a single request's start-line +
+      # headers. Bigger requests get 413; matches the blocking
+      # server's SPHTTP_BUFSIZE cap (64 KiB).
+      MAX_REQUEST_BYTES = 65535
+
+      # Idle keep-alive timeout between requests on the same
+      # connection. 30s matches nginx; bump from app code as needed.
+      KEEPALIVE_TIMEOUT = 30
+
+      # Slow-headers DoS guard.
+      HEADER_READ_TIMEOUT = 10
+
+      attr_accessor :app
+
+      def initialize(app)
+        @app = app
+      end
+
+      def run(port, workers, quiet)
+        sfd = Sock.sphttp_listen(port, workers > 1 ? 1 : 0)
+        if sfd < 0
+          return 1
+        end
+        Sock.sphttp_set_nonblock(sfd)
+        Tep::APP.pending_listen_fd = sfd
+        Tep::APP.pending_quiet = quiet
+
+        if workers > 1
+          i = 0
+          while i < workers
+            pid = Sock.sphttp_fork
+            if pid == 0
+              Tep::Server::Scheduled.run_worker
+              Sock.sphttp_exit(0)
+            end
+            i += 1
+          end
+          loop do
+            gone = Sock.sphttp_wait_any
+            if gone < 0
+              break
+            end
+          end
+        else
+          Tep::Server::Scheduled.run_worker
+        end
+        0
+      end
+
+      # Spawn the accept fiber + pump the scheduler. Called inside
+      # each prefork child. Loops directly on `tick` rather than
+      # `run_until_empty` because the accept fiber parks on io_wait
+      # indefinitely -- run_until_empty bails when no fiber is ready
+      # to resume THIS pass; we need to keep polling so parked
+      # accept-on-sfd fibers get woken when a connection arrives.
+      def self.run_worker
+        f = Fiber.new { Tep::Server::Scheduled.accept_loop }
+        Tep::Scheduler.spawn_fiber(f)
+        while Tep::Scheduler.alive_count > 0
+          Tep::Scheduler.tick(1000)
+        end
+        0
+      end
+
+      # Accept loop body. Reads sfd + quiet from APP stash (closure-
+      # less). Each accepted connection becomes its own fiber, with
+      # client fd handed off via pending_client_fd + pause(0) yield.
+      def self.accept_loop
+        sfd = Tep::APP.pending_listen_fd
+        while true
+          ready = Tep::Scheduler.io_wait(sfd, Tep::Scheduler::READ, -1)
+          if ready == 0
+            next
+          end
+          client = Sock.sphttp_accept_nb(sfd)
+          if client < 0
+            next
+          end
+          Sock.sphttp_set_nonblock(client)
+          Tep::APP.pending_client_fd = client
+          conn = Fiber.new { Tep::Server::Scheduled.handle_pending }
+          Tep::Scheduler.spawn_fiber(conn)
+          # Yield so the new fiber reads pending_client_fd before
+          # the next accept iteration overwrites it. The new fiber
+          # has wake_at=-1 (set by spawn_fiber); pause(0) sets ours
+          # to now -- -1 < now so the scheduler picks the new fiber.
+          Tep::Scheduler.pause(0)
+        end
+      end
+
+      # Connection-fiber entry. Reads client fd from APP stash, then
+      # delegates to handle_connection (which doesn't need the
+      # closure capture since it took a regular param).
+      def self.handle_pending
+        client = Tep::APP.pending_client_fd
+        Tep::Server::Scheduled.handle_connection(client)
+      end
+
+      # Per-connection lifecycle.
+      def self.handle_connection(client)
+        keep_going = true
+        while keep_going
+          blob = Tep::Server::Scheduled.read_request_blob(client, KEEPALIVE_TIMEOUT)
+          if blob.length == 0
+            break
+          end
+          req = Parser.parse(blob)
+          if req == nil
+            Tep::Server::Scheduled.send_simple(client, 400, "bad request")
+            break
+          end
+
+          cl = req.content_length
+          already = req.raw_body.length
+          if cl > already
+            rest = Sock.sphttp_drain_body(client, cl - already)
+            req.raw_body = req.raw_body + rest
+          end
+          if req.form?
+            Url.parse_query(req.raw_body).each do |k, v|
+              req.params[k] = v
+            end
+          end
+
+          res = Response.new
+          Tep::APP.dispatch(req, res)
+
+          keep_alive = req.keep_alive? && !res.halted_close?
+          Tep::Server::Scheduled.write_response(client, req, res, keep_alive)
+          keep_going = keep_alive
+        end
+        Sock.sphttp_close(client)
+        0
+      end
+
+      # Non-blocking request reader. Returns the accumulated blob
+      # once "\r\n\r\n" is seen, or "" on timeout / EOF / oversize.
+      def self.read_request_blob(fd, timeout_seconds)
+        buf = ""
+        deadline = Time.now.to_i + timeout_seconds
+        while buf.length < MAX_REQUEST_BYTES
+          remaining = deadline - Time.now.to_i
+          if remaining <= 0
+            return ""
+          end
+          ready = Tep::Scheduler.io_wait(fd, Tep::Scheduler::READ, remaining)
+          if ready == 0
+            return ""
+          end
+          chunk = Sock.sphttp_recv_some(fd, 4096)
+          if chunk.length == 0
+            return ""
+          end
+          buf = buf + chunk
+          if buf.length >= 4 && buf.include?("\r\n\r\n")
+            return buf
+          end
+        end
+        ""
+      end
+
+      # Body-shape mirror of Tep::Server#write_response. Lifted into
+      # a cmeth so the connection fiber can call it without a captured
+      # `self`.
+      def self.write_response(client, req, res, keep_alive)
+        reason = Tep.reason(res.status)
+        head = req.http_version + " " + res.status.to_s + " " + reason + "\r\n"
+        res.headers.each do |k, v|
+          head = head + k + ": " + v + "\r\n"
+        end
+        res.set_cookies.each do |line|
+          head = head + "Set-Cookie: " + line + "\r\n"
+        end
+        if keep_alive
+          head = head + "Connection: keep-alive\r\n"
+        else
+          head = head + "Connection: close\r\n"
+        end
+        if res.file_path.length > 0
+          fs = Sock.sphttp_filesize(res.file_path)
+          head = head + "Content-Length: " + fs.to_s + "\r\n\r\n"
+          Sock.sphttp_write_str(client, head)
+          Sock.sphttp_sendfile(client, res.file_path)
+        else
+          head = head + "Content-Length: " + res.body.length.to_s + "\r\n\r\n"
+          Sock.sphttp_write_str(client, head)
+          if res.body.length > 0
+            Sock.sphttp_write_str(client, res.body)
+          end
+        end
+        0
+      end
+
+      def self.send_simple(client, status, msg)
+        reason = Tep.reason(status)
+        head = "HTTP/1.0 " + status.to_s + " " + reason + "\r\n" +
+               "Content-Length: " + msg.length.to_s + "\r\n" +
+               "Connection: close\r\n\r\n" + msg
+        Sock.sphttp_write_str(client, head)
+        0
+      end
+    end
+  end
+end

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -78,6 +78,22 @@ int sphttp_accept(int sfd) {
     return fd;
 }
 
+/* Non-blocking accept. Returns the new fd on success, -1 with errno
+ * EAGAIN/EWOULDBLOCK if no pending connection, -1 with other errno
+ * on real error. Caller (Tep::Server::Scheduled) parks the accept
+ * fiber on Tep::Scheduler.io_wait(sfd, READ) before retrying.
+ * Requires the listen fd to already be in non-blocking mode -- call
+ * sphttp_set_nonblock(sfd) once after sphttp_listen. */
+int sphttp_accept_nb(int sfd) {
+    struct sockaddr_in caddr;
+    socklen_t clen = sizeof(caddr);
+    int fd;
+    do {
+        fd = accept(sfd, (struct sockaddr *)&caddr, &clen);
+    } while (fd < 0 && errno == EINTR);
+    return fd;
+}
+
 /* Read until end-of-headers ("\r\n\r\n") or the buffer fills. Subsequent
  * recv()s for the body are the caller's job (we expose a length helper).
  * Returns the parsed length (>0), 0 on clean EOF, -1 on error. */

--- a/sig/tep/app.rbs
+++ b/sig/tep/app.rbs
@@ -27,6 +27,12 @@ module Tep
     attr_accessor sched_io_mode: Array[Integer]
     attr_accessor sched_io_ready: Array[Integer]
 
+    # Hand-off stash for Tep::Server::Scheduled (closure-capture
+    # workaround; see lib/tep/app.rb).
+    attr_accessor pending_listen_fd: Integer
+    attr_accessor pending_client_fd: Integer
+    attr_accessor pending_quiet: bool
+
     def initialize: () -> void
 
     def add_asset: (String path, String body, String mime) -> String

--- a/sig/tep/server.rbs
+++ b/sig/tep/server.rbs
@@ -21,4 +21,35 @@ module Tep
 
   # Translates an HTTP status code to its standard reason phrase.
   def self.reason: (Integer status) -> String
+
+  class Server
+    # Falcon-shape fiber-per-connection server. Same prefork worker
+    # shape as the parent Tep::Server, but each worker runs
+    # Tep::Scheduler with one accept fiber + N connection fibers.
+    # Slow clients no longer block their worker.
+    class Scheduled
+      MAX_REQUEST_BYTES: Integer
+      KEEPALIVE_TIMEOUT: Integer
+      HEADER_READ_TIMEOUT: Integer
+
+      attr_accessor app: Tep::App
+
+      def initialize: (Tep::App app) -> void
+
+      # Instance entry point. Reads + dispatches; cmeths below carry
+      # the per-connection work (closure-free for spinel's Fiber.new
+      # codegen workaround).
+      def run: (Integer port, Integer workers, bool quiet) -> Integer
+
+      # Top-level cmeths called from Fiber.new bodies. State arrives
+      # via Tep::APP.pending_* stash slots.
+      def self.run_worker: () -> Integer
+      def self.accept_loop: () -> void
+      def self.handle_pending: () -> Integer
+      def self.handle_connection: (Integer client) -> Integer
+      def self.read_request_blob: (Integer fd, Integer timeout_seconds) -> String
+      def self.write_response: (Integer client, Tep::Request req, Tep::Response res, bool keep_alive) -> Integer
+      def self.send_simple: (Integer client, Integer status, String msg) -> Integer
+    end
+  end
 end

--- a/test/test_server_scheduled.rb
+++ b/test/test_server_scheduled.rb
@@ -1,0 +1,56 @@
+# Smoke test for Tep::Server::Scheduled (fiber-per-connection server).
+# Validates the basic HTTP request/response loop works under the
+# scheduler. Concurrent-connection / slow-client cases are out of
+# scope for this initial test -- they'll get their own coverage when
+# the WebSocket battery lands and exercises that surface for real.
+require_relative "helper"
+
+class TestServerScheduled < TepTest
+  app_source <<~RB
+    require "sinatra"
+
+    set :scheduler, :scheduled
+
+    get "/ping" do
+      "pong"
+    end
+
+    get "/echo/:word" do
+      params[:word]
+    end
+
+    post "/upper" do
+      request.body.upcase
+    end
+  RB
+
+  def test_basic_get_through_scheduler
+    res = get("/ping")
+    assert_equal "200", res.code
+    assert_equal "pong", res.body
+  end
+
+  def test_path_capture_through_scheduler
+    res = get("/echo/hello")
+    assert_equal "200", res.code
+    assert_equal "hello", res.body
+  end
+
+  def test_post_body_through_scheduler
+    res = post("/upper", "hello world")
+    assert_equal "200", res.code
+    assert_equal "HELLO WORLD", res.body
+  end
+
+  def test_two_sequential_requests
+    # Same connection, two HTTP/1.1 keep-alive requests. The
+    # scheduler's per-connection-fiber must handle the second
+    # iteration of its keep-alive loop correctly.
+    r1 = get("/ping")
+    r2 = get("/echo/two")
+    assert_equal "200", r1.code
+    assert_equal "200", r2.code
+    assert_equal "pong", r1.body
+    assert_equal "two", r2.body
+  end
+end


### PR DESCRIPTION
Phase 1.5 of the WebSocket roadmap (RFC at #8). Lands the fiber-per-connection server substrate so WebSockets (and slow keep-alive HTTP clients) can hold their connection without pinning a worker.

## What

- `Tep::Server::Scheduled` (new, parallel to `Tep::Server`): one accept fiber per worker + one fiber per accepted connection, all I/O parking on `Tep::Scheduler.io_wait`. Falcon-shape (per rubys's prior-art note in #8).
- Opt-in via `set :scheduler, :scheduled` in app code, or `-s` CLI flag on the compiled binary.
- Default boot path still uses `Tep::Server` (blocking) — per rubys's pushback, parallel-classes period exists only to make the rollback path obvious. At the next tep major, Scheduled becomes default and Blocking is deleted.

## What's *not* in this phase

- Response writing stays blocking (`sphttp_write_str`). Small responses complete in one syscall; non-blocking write loops are deferrable until measurement says otherwise.
- Body draining stays blocking. A slow client uploading a large body can still pin its fiber. Separate rewrite, out of Phase 1.5 scope.
- The frame codec / handshake / driver (Phase 2) — depends on either the spinel Fiber-closure heap-cell bug fix OR more App-state stash patterns following this PR's shape.

## Spinel codegen workaround in this PR

Fiber.new bodies that capture local variables don't lower cleanly under current spinel — heap-cell accesses are emitted without matching declarations. All `Fiber.new { ... }` bodies in `lib/tep/server_scheduled.rb` are therefore **closure-free**: they call top-level cmeths, and per-connection state is handed off via `Tep::APP.pending_listen_fd` / `pending_client_fd` / `pending_quiet` stash slots, with `Tep::Scheduler.pause(0)` between spawn and overwrite. Filed as a separate spinel issue; once it lands, the stash can collapse back to natural closures.

## Files

```
lib/tep/sphttp.c              +sphttp_accept_nb
lib/tep/net.rb                +ffi_func :sphttp_accept_nb
lib/tep/server_scheduled.rb   NEW (235 LOC)
lib/tep/app.rb                +pending_* ivars for the stash
lib/tep.rb                    Tep.run! gains 4th `scheduled` arg
bin/tep                       +`-s` flag, +`set :scheduler, :scheduled` DSL
sig/tep/server.rbs            +Scheduled class signatures
sig/tep/app.rbs               +pending_* signatures
test/test_server_scheduled.rb NEW (4 smoke tests)
```

## Test surface

`test/test_server_scheduled.rb` covers GET / path-capture / POST-body / two-sequential-keepalive shapes. All four pass solo against the scheduled path.

Full suite: 185 runs / 450 assertions / 5 failures / 8 errors / 5 skips. The +4 from this PR all pass. The 5 failures are the pre-existing `TestRegexRoutes` spinel-master regression flagged in [74de6e5](https://github.com/OriPekelman/tep/commit/74de6e5); the 8 errors are the recurring `TestHttp Net::ReadTimeout` flake family.

## Note for follow-up

`Sinatra::Request#body.read` doesn't translate to tep's `req.body` (tep's `req.body` returns the body as a `String` directly, not an IO). One of the smoke tests caught it. Worth bridging or documenting separately; not in scope for this PR.