### PR TITLE
fix: restore 3-arg Tep.run!(port, workers, quiet) compat (#13)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -10,7 +10,7 @@
 #   end
 #   Tep.get "/", Root.new
 #
-#   Tep.run!(4567, 1)
+#   Tep.run!(4567, 1, false)
 #
 # Sinatra-classic source (with `do ... end` blocks) is supported via
 # `bin/tep build app.rb`, which translates blocks into Handler
@@ -559,7 +559,13 @@ module Tep
   # both branches reference `quiet` as a heap-cell but only the first
   # path declares it. Bundling the decision inside one method
   # sidesteps the codegen miss.
-  def self.run!(port, workers, quiet, scheduled)
+  #
+  # `scheduled` defaults to false so apps that ship the historical
+  # 3-arg call (Tep.run!(port, workers, quiet)) keep building. Spinel
+  # accepts the call without the 4th arg only because it supports
+  # default-value params; without this, the 3-arg call silently
+  # miscompiled (matz/spinel arity-warning shape, tep#13).
+  def self.run!(port, workers, quiet, scheduled = false)
     if scheduled
       Server::Scheduled.new(APP).run(port, workers, quiet)
     else


### PR DESCRIPTION
Closes #13.

## The bug

When `Tep.run!` grew its 4th `scheduled` parameter (alongside the `Tep::Server::Scheduled` rollout), every user app calling the historical 3-arg form silently miscompiled. Spinel emitted a `cannot resolve call to 'run!' on int (emitting 0)` warning, produced a buildable binary, and the binary returned a fixed 6-byte body (`h1= ok`) for every matched route — handler bodies and Content-Type headers ignored. The sibling toy-NN project caught it; precise reporter-side bisect at #13.

## The fix

```ruby
def self.run!(port, workers, quiet, scheduled = false)
```

One-character change. Spinel supports default-value params (verified via `test/default_args.rb` in spinel master). The 3-arg form keeps building, the 4-arg form (which `Tep::Server::Scheduled` apps use) still works.

## Validation

Built `examples/hello.rb` (3-arg call site) with current spinel master + this patch:

- No spinel arity warning at build time.
- `curl /` returns the actual handler body (792 bytes), not the broken `h1= ok`.
- `curl /hi/world` returns `<p>hi, world!</p>` with proper status / headers.
- Same for `bench/hello_bench.rb`.

## Out of scope here

The underlying spinel behaviour — silently miscompiling on arity mismatch instead of refusing to build — is a real problem the reporter flagged. Filing that as a separate spinel issue. The tep-side fix here restores compat regardless of how that lands.