### PR TITLE
feat(auth): Tep::Identity + Tep::AgentDelegation (Battery 1, chunk 1.1)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -19,6 +19,8 @@
 require_relative "tep/version"
 require_relative "tep/url"
 require_relative "tep/net"
+require_relative "tep/agent_delegation"
+require_relative "tep/identity"
 require_relative "tep/session"
 require_relative "tep/request"
 require_relative "tep/response"

--- a/lib/tep/agent_delegation.rb
+++ b/lib/tep/agent_delegation.rb
@@ -1,0 +1,35 @@
+# Tep::AgentDelegation -- the "on behalf of" half of a delegated
+# identity. Carries the agent's own id (distinct from the human
+# principal it acts for), the grant timestamps, and the origin
+# label so audit logs can tell apart "issued via OAuth consent" vs
+# "minted from a session handoff" vs "raw API token".
+#
+# Always paired with a Tep::Identity whose principal_id is the
+# human being acted for. An Identity#human? has acting_via == nil;
+# an Identity#agent? has acting_via populated with this struct.
+#
+# Lives in its own file so consumers that want the delegation
+# vocabulary without the full Identity surface can require it
+# narrowly.
+module Tep
+  class AgentDelegation
+    attr_reader :agent_id     # String, e.g. "summarizer-bot"
+    attr_reader :issued_at    # Integer (unix epoch seconds)
+    attr_reader :expires_at   # Integer (unix epoch seconds)
+    attr_reader :origin       # Symbol: :token, :oauth_grant, :session_handoff, ...
+
+    def initialize(agent_id, issued_at, expires_at, origin)
+      @agent_id   = agent_id
+      @issued_at  = issued_at
+      @expires_at = expires_at
+      @origin     = origin
+    end
+
+    # `now` is unix epoch seconds (Time.now.to_i shape). Passed in
+    # rather than read from Time.now so callers control the clock
+    # source (and tests can fast-forward).
+    def expired?(now)
+      now >= @expires_at
+    end
+  end
+end

--- a/lib/tep/identity.rb
+++ b/lib/tep/identity.rb
@@ -1,0 +1,67 @@
+# Tep::Identity -- principal + delegate identity. Identifies who
+# made a request and, optionally, the agent acting on their behalf.
+#
+# Set on `req.identity` by the Tep::Auth provider chain (see
+# docs/BATTERIES-DESIGN.md for the full Auth surface). Consumers
+# (Broadcast, Presence, LiveView) read req.identity and key authz
+# decisions off #may?(cap) plus the human?/agent? split.
+#
+# Agentic shape: a "delegated" identity is one where a non-human
+# agent (LLM-driven bot, scheduled worker, automation client)
+# acts on behalf of a human principal. Both layers are visible:
+#   - principal_id is the human (e.g. "user:42").
+#   - acting_via.agent_id is the agent ("summarizer-bot").
+# Authz checks via #may? gate on the granted capability set, which
+# the issuer is expected to keep as a subset of the principal's
+# own caps -- never a superset. The split lets app code branch
+# tighter on req.identity (e.g. "only humans may revoke other
+# agents") rather than treating every authenticated caller alike.
+module Tep
+  class Identity
+    attr_reader :principal_id   # String, opaque to tep (apps own the format)
+    attr_reader :acting_via     # Tep::AgentDelegation or nil
+    attr_reader :capabilities   # Array of symbols
+
+    def initialize(principal_id, acting_via, capabilities)
+      @principal_id = principal_id
+      @acting_via   = acting_via
+      @capabilities = capabilities
+    end
+
+    # The unauthenticated identity. Used by the Tep::Auth before-
+    # filter when no provider sniffed a credential off the request.
+    # Apps that gate routes on identity check the principal_id ==
+    # "" shape; #may? returns false for everything since the cap
+    # array is empty.
+    def self.anonymous
+      seed = [:_seed]
+      seed.delete_at(0)
+      Identity.new("", nil, seed)
+    end
+
+    def human?
+      @acting_via == nil
+    end
+
+    def agent?
+      @acting_via != nil
+    end
+
+    def may?(cap)
+      @capabilities.include?(cap)
+    end
+
+    # Audit-friendly string. Humans render as "user:<principal>";
+    # agents render as "agent:<agent_id>/<principal>" -- the slash
+    # makes the principal-of-record visible at a glance and is the
+    # standard shape every log line and Broadcast `from` field
+    # should carry.
+    def subject
+      if @acting_via == nil
+        "user:" + @principal_id
+      else
+        "agent:" + @acting_via.agent_id + "/" + @principal_id
+      end
+    end
+  end
+end

--- a/sig/tep/agent_delegation.rbs
+++ b/sig/tep/agent_delegation.rbs
@@ -1,0 +1,22 @@
+# The delegation half of a delegated identity: the agent's id,
+# the grant window, and the origin label. Paired with a
+# Tep::Identity whose principal_id names the human being acted
+# for. See lib/tep/agent_delegation.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class AgentDelegation
+    attr_reader agent_id: String
+    attr_reader issued_at: Integer
+    attr_reader expires_at: Integer
+    attr_reader origin: Symbol
+
+    def initialize: (
+      String agent_id,
+      Integer issued_at,
+      Integer expires_at,
+      Symbol origin
+    ) -> void
+
+    # `now` is unix epoch seconds. Caller controls the clock source.
+    def expired?: (Integer now) -> bool
+  end
+end

--- a/sig/tep/identity.rbs
+++ b/sig/tep/identity.rbs
@@ -1,0 +1,29 @@
+# Principal + delegate identity. Set on req.identity by the
+# Tep::Auth provider chain; consumed by Broadcast / Presence /
+# LiveView. See lib/tep/identity.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class Identity
+    attr_reader principal_id: String
+    attr_reader acting_via: AgentDelegation?
+    attr_reader capabilities: Array[Symbol]
+
+    def initialize: (
+      String principal_id,
+      AgentDelegation? acting_via,
+      Array[Symbol] capabilities
+    ) -> void
+
+    # Unauthenticated identity. Empty principal, no acting_via,
+    # empty capability set. Tep::Auth installs this on req.identity
+    # when no provider sniffs a credential.
+    def self.anonymous: () -> Identity
+
+    def human?: () -> bool
+    def agent?: () -> bool
+    def may?: (Symbol cap) -> bool
+
+    # Audit string. "user:<principal>" for humans;
+    # "agent:<agent_id>/<principal>" for delegated identities.
+    def subject: () -> String
+  end
+end

--- a/test/test_identity.rb
+++ b/test/test_identity.rb
@@ -1,0 +1,165 @@
+require_relative "helper"
+
+# Tep::Identity + Tep::AgentDelegation: the principal+delegate
+# identity types Auth issues and Broadcast/Presence/LiveView consume.
+# See docs/BATTERIES-DESIGN.md for the broader Auth design.
+class TestIdentity < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    HUMAN_CAPS = [:read, :write]
+    AGENT_CAPS = [:read]
+
+    HUMAN = Tep::Identity.new("user:42", nil, HUMAN_CAPS)
+
+    BOT_DELEGATION = Tep::AgentDelegation.new(
+      "summarizer-bot", 1000, 2000, :token)
+    AGENT = Tep::Identity.new("user:42", BOT_DELEGATION, AGENT_CAPS)
+
+    # Plain-text helper so every route returns the answer directly.
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    get '/human/subject' do
+      HUMAN.subject
+    end
+
+    get '/human/is_human' do
+      HUMAN.human? ? "yes" : "no"
+    end
+
+    get '/human/is_agent' do
+      HUMAN.agent? ? "yes" : "no"
+    end
+
+    get '/human/may_read' do
+      HUMAN.may?(:read) ? "yes" : "no"
+    end
+
+    get '/human/may_post_summary' do
+      HUMAN.may?(:post_summary) ? "yes" : "no"
+    end
+
+    get '/agent/subject' do
+      AGENT.subject
+    end
+
+    get '/agent/is_human' do
+      AGENT.human? ? "yes" : "no"
+    end
+
+    get '/agent/is_agent' do
+      AGENT.agent? ? "yes" : "no"
+    end
+
+    get '/agent/may_read' do
+      AGENT.may?(:read) ? "yes" : "no"
+    end
+
+    get '/agent/may_write' do
+      AGENT.may?(:write) ? "yes" : "no"
+    end
+
+    get '/agent/agent_id' do
+      AGENT.acting_via.agent_id
+    end
+
+    get '/agent/origin' do
+      AGENT.acting_via.origin.to_s
+    end
+
+    get '/agent/expired_before' do
+      AGENT.acting_via.expired?(1500) ? "yes" : "no"
+    end
+
+    get '/agent/expired_after' do
+      AGENT.acting_via.expired?(2500) ? "yes" : "no"
+    end
+
+    get '/anonymous/subject' do
+      Tep::Identity.anonymous.subject
+    end
+
+    get '/anonymous/may_read' do
+      Tep::Identity.anonymous.may?(:read) ? "yes" : "no"
+    end
+
+    get '/anonymous/is_human' do
+      Tep::Identity.anonymous.human? ? "yes" : "no"
+    end
+  RB
+
+  def test_human_subject_format
+    assert_equal "user:user:42", get("/human/subject").body
+  end
+
+  def test_human_is_human
+    assert_equal "yes", get("/human/is_human").body
+  end
+
+  def test_human_is_not_agent
+    assert_equal "no", get("/human/is_agent").body
+  end
+
+  def test_human_has_granted_cap
+    assert_equal "yes", get("/human/may_read").body
+  end
+
+  def test_human_lacks_ungranted_cap
+    assert_equal "no", get("/human/may_post_summary").body
+  end
+
+  def test_agent_subject_format
+    assert_equal "agent:summarizer-bot/user:42", get("/agent/subject").body
+  end
+
+  def test_agent_is_not_human
+    assert_equal "no", get("/agent/is_human").body
+  end
+
+  def test_agent_is_agent
+    assert_equal "yes", get("/agent/is_agent").body
+  end
+
+  def test_agent_has_granted_cap
+    assert_equal "yes", get("/agent/may_read").body
+  end
+
+  def test_agent_lacks_principal_cap
+    # Principal HUMAN has :write; AGENT was granted only :read.
+    # Cap subset not superset.
+    assert_equal "no", get("/agent/may_write").body
+  end
+
+  def test_agent_delegation_exposes_agent_id
+    assert_equal "summarizer-bot", get("/agent/agent_id").body
+  end
+
+  def test_agent_delegation_exposes_origin
+    assert_equal "token", get("/agent/origin").body
+  end
+
+  def test_delegation_not_expired_before_window
+    assert_equal "no", get("/agent/expired_before").body
+  end
+
+  def test_delegation_expired_after_window
+    assert_equal "yes", get("/agent/expired_after").body
+  end
+
+  def test_anonymous_subject_is_empty_principal
+    assert_equal "user:", get("/anonymous/subject").body
+  end
+
+  def test_anonymous_has_no_capabilities
+    assert_equal "no", get("/anonymous/may_read").body
+  end
+
+  def test_anonymous_is_human
+    # Without a delegation, anonymous is technically "human" per the
+    # acting_via shape. Apps gating routes by anonymous-vs-not check
+    # principal_id == "" or use a wrapping helper.
+    assert_equal "yes", get("/anonymous/is_human").body
+  end
+end


### PR DESCRIPTION
First chunk of the Auth battery — the principal+delegate identity types every other battery (Broadcast, Presence, LiveView) builds on. Standalone types, no provider chain yet, no `req.identity` wire-up (those land in chunk 1.2 alongside `Tep::Auth::BearerToken`).

Per `docs/BATTERIES-DESIGN.md`:

```ruby
Tep::Identity.new(principal_id, acting_via, capabilities)
Tep::Identity.anonymous

ident.human?         # acting_via.nil?
ident.agent?
ident.may?(:read)
ident.subject        # "user:42" or "agent:bot/user:42"

Tep::AgentDelegation.new(agent_id, issued_at, expires_at, origin)
deleg.expired?(now)
```

## Validation

- `test/test_identity.rb`: 17 runs / 17 assertions / 0 failures. Exercises subject formatting (human + agent shapes), the human?/agent? split, capability checks (granted + ungranted), delegation expiry across the window, anonymous identity.
- Full test suite: no regressions outside `TestScheduler` (known pre-#641 broken `Tep::Server::Scheduled`) and `TestParallel` (a pre-existing spinel codegen issue where `sp_file_write` gets a poly `sp_RbVal` instead of `const char*` — reproduces on clean main without these changes; worth a separate spinel filing).
- Spinel cleanly handles the nullable `acting_via` slot thanks to matz/spinel `c66d00a` (#634-A, nil-default param widens to poly).

## Out of scope for this chunk

- Provider chain (`Tep::Auth.providers`) → chunk 1.2.
- `BearerToken` / `SessionCookie` providers → chunk 1.2.
- OAuth2 + consent UI → chunk 1.4 (separate design pass on the consent flow).
- Capability registry + extension hook → small follow-up, can land anywhere before chunk 1.3.
- `req.identity` accessor on Request → chunk 1.2 alongside the first provider.