### PR TITLE
feat(auth): Tep::Auth + Tep::AuthBearerToken (Battery 1, chunk 1.2)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -30,6 +30,13 @@ require_relative "tep/streamer"
 require_relative "tep/parser"
 require_relative "tep/router"
 require_relative "tep/app"
+# Auth lands after App so Tep::AuthFilter < Tep::Filter can resolve
+# and the install! helper can reach Tep::APP. The provider classes
+# reference Tep::Jwt / Tep::Json which come after this -- works
+# because the references are inside method bodies (resolved at
+# runtime), not class-body literals (resolved at load time).
+require_relative "tep/auth_bearer_token"
+require_relative "tep/auth"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"
 require_relative "tep/sqlite"
@@ -161,6 +168,8 @@ module Tep
   APP.set_static_root("")
   APP.set_before(Filter.new)
   APP.set_after(Filter.new)
+  APP.set_auth_filter(Filter.new)
+  APP.set_auth_bearer_secret("")
   APP.set_not_found(Handler.new)
   # Type-seeding: methods that may not be called by a given user app
   # would otherwise default their param C types to mrb_int and

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -11,6 +11,18 @@ module Tep
   class App
     attr_accessor :router, :static_root, :session_secret
     attr_accessor :before_filter, :after_filter, :nf_handler
+    # The auth-filter runs BEFORE before_filter so handler bodies and
+    # user filters always see a populated req.identity. Separate slot
+    # (rather than wedging into before_filter) so user-installed
+    # filters and the auth populate don't fight for the single slot
+    # tep otherwise imposes. Default is a no-op Tep::Filter; the
+    # Auth battery installs Tep::AuthFilter on top via
+    # Tep::Auth.install!.
+    attr_accessor :auth_filter
+    # Shared HS256 secret consumed by Tep::AuthBearerToken. Stored on
+    # APP (rather than a class var) so spinel routes the read through
+    # the canonical instance-attr path.
+    attr_accessor :auth_bearer_secret
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -33,6 +45,8 @@ module Tep
       @session_secret = ""
       @before_filter  = Filter.new   # no-op default
       @after_filter   = Filter.new
+      @auth_filter    = Filter.new   # no-op until Tep::Auth.install!
+      @auth_bearer_secret = ""
       @nf_handler     = Handler.new
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines
@@ -78,10 +92,12 @@ module Tep
       @router.add(verb, pattern, handler)
     end
 
-    def set_static_root(root); @static_root = root; end
-    def set_before(f);         @before_filter = f; end
-    def set_after(f);          @after_filter = f; end
-    def set_not_found(h);      @nf_handler = h; end
+    def set_static_root(root);    @static_root = root; end
+    def set_before(f);            @before_filter = f; end
+    def set_after(f);             @after_filter = f; end
+    def set_auth_filter(f);       @auth_filter = f; end
+    def set_auth_bearer_secret(s); @auth_bearer_secret = s; end
+    def set_not_found(h);         @nf_handler = h; end
 
     def dispatch(req, res)
       # Pull a signed session cookie into req.session, when configured.
@@ -94,6 +110,14 @@ module Tep
       end
 
       asset_served = false
+      # Auth filter populates req.identity (anonymous or matched
+      # provider's Identity) before the user's before-filter runs,
+      # so user code can always rely on req.identity being set.
+      @auth_filter.before(req, res)
+      if res.halted
+        # Auth filter signalled "deny" -- skip the user filter +
+        # route dispatch, fall through to after-filter + session.
+      end
       @before_filter.before(req, res)
       if !res.halted
         # Bundled assets (everything under <app>/assets/, baked into

--- a/lib/tep/auth.rb
+++ b/lib/tep/auth.rb
@@ -1,0 +1,68 @@
+# Tep::Auth -- the entry point for the Auth battery.
+#
+# Sets `req.identity` (a Tep::Identity) on every request, populated
+# by walking a fixed provider chain. v1's chain is one provider:
+# Tep::AuthBearerToken (JWT HS256). SessionCookie and OAuth2 land
+# as separate chunks; each one extends the chain by editing
+# Tep::Auth.identify (rather than via a runtime registry, because
+# spinel's PtrArray<Base> dispatch can't carry cls_id across
+# heterogeneous Provider subclasses -- see memory note
+# [[spinel_widening_dispatch]]). The fixed-chain shape is a v1
+# concession; once spinel resolves the cls_id story the design
+# doc's Tep::Auth.providers.add(...) API will land.
+#
+# Install pattern:
+#
+#   require 'sinatra'
+#   Tep::AuthBearerToken.set_secret(ENV["JWT_SECRET"])
+#   Tep::Auth.install!
+#
+#   # In handlers, req.identity is always populated -- either with
+#   # the bearer's identity or with Tep::Identity.anonymous.
+#   get '/me' do
+#     req.identity.subject
+#   end
+#
+# The auth filter is a SEPARATE slot from the user-installed
+# before-filter (see Tep::App#auth_filter). Both run, in order:
+# auth-filter first (populates req.identity), then user
+# before-filter (sees a fully-populated identity). This avoids the
+# "one filter slot" composition tax tep otherwise imposes.
+module Tep
+  module Auth
+    CORE_CAPABILITIES = [:read, :write, :authn, :authz]
+
+    # Walk the provider chain. First provider that returns a non-nil
+    # Identity wins. Returns nil if no provider matched -- caller is
+    # responsible for substituting Tep::Identity.anonymous.
+    def self.identify(req)
+      ident = Tep::AuthBearerToken.try(req)
+      if ident != nil
+        return ident
+      end
+      nil
+    end
+
+    # Replaces the app's auth-filter slot with the real
+    # populate-req.identity filter. Idempotent.
+    def self.install!
+      Tep::APP.set_auth_filter(Tep::AuthFilter.new)
+      0
+    end
+  end
+
+  # The before-filter that runs the provider chain and writes the
+  # result to req.identity. Lives at top level (not Tep::Auth::Filter)
+  # to keep dispatch simple under spinel.
+  class AuthFilter < Tep::Filter
+    def before(req, res)
+      ident = Tep::Auth.identify(req)
+      if ident == nil
+        req.identity = Tep::Identity.anonymous
+      else
+        req.identity = ident
+      end
+      0
+    end
+  end
+end

--- a/lib/tep/auth_bearer_token.rb
+++ b/lib/tep/auth_bearer_token.rb
@@ -1,0 +1,126 @@
+# Tep::AuthBearerToken -- JWT-HS256 bearer-token provider for the
+# Auth battery. Sniffs `Authorization: Bearer <token>`, verifies
+# the signature with the app's configured secret, decodes the
+# flat-JSON payload, and builds a Tep::Identity (with optional
+# Tep::AgentDelegation when the token represents an agent).
+#
+# Configuration:
+#
+#   Tep::AuthBearerToken.set_secret(ENV["JWT_SECRET"])
+#
+# Token payload schema (flat JSON, single level -- matches
+# Tep::Json's flat-object extraction surface):
+#
+#   {
+#     "sub":      "user:42",                    # principal_id (required)
+#     "exp":      1716396000,                   # unix epoch seconds
+#     "caps":     "read,write,post_summary",    # comma-separated symbols
+#     "delegate": "summarizer-bot|1716392400|1716396000|token"
+#                                               # optional; presence flips
+#                                               # the identity to an agent.
+#                                               # Format:
+#                                               # agent_id|issued_at|expires_at|origin
+#   }
+#
+# Why flat (not nested `acting_via: { ... }`): Tep::Json today
+# extracts flat keys only. A nested-object getter is a separate
+# tiny battery; for v1 of Auth the flat pipe-encoded delegate
+# string is the smallest thing that ships and round-trips
+# cleanly. The Identity / AgentDelegation Ruby surface stays
+# nested -- the encoding is only on the wire.
+#
+# Why a flat top-level class name (not Tep::Auth::BearerToken):
+# two-level namespacing on classes carries spinel cls_id risk
+# (see memory note [[spinel_widening_dispatch]]). The Tep::Auth
+# module owns the conceptual grouping; the class itself lives at
+# Tep:: level so dispatch is shallow.
+module Tep
+  class AuthBearerToken
+    # Set the shared HMAC secret. Apps call once at boot.
+    def self.set_secret(s)
+      Tep::APP.set_auth_bearer_secret(s)
+      0
+    end
+
+    # Attempt to identify the request. Returns a Tep::Identity on
+    # successful verification, nil if no Bearer header / bad
+    # signature / expired / malformed payload.
+    def self.try(req)
+      header = req.req_headers["authorization"]
+      if header.length < 8 || header[0, 7] != "Bearer "
+        return nil
+      end
+      token = header[7, header.length - 7]
+
+      secret = Tep::APP.auth_bearer_secret
+      if secret.length == 0
+        return nil
+      end
+
+      payload = Tep::Jwt.verify_and_decode(token, secret)
+      if payload.length == 0
+        return nil
+      end
+
+      # Check expiry first -- a token whose exp passed gets rejected
+      # even if the signature still verifies. exp is unix epoch sec.
+      exp = Tep::Json.get_int(payload, "exp")
+      if exp > 0 && Time.now.to_i >= exp
+        return nil
+      end
+
+      sub = Tep::Json.get_str(payload, "sub")
+      if sub.length == 0
+        return nil
+      end
+
+      caps_str = Tep::Json.get_str(payload, "caps")
+      caps = Tep::AuthBearerToken.parse_caps(caps_str)
+
+      delegate_str = Tep::Json.get_str(payload, "delegate")
+      delegation = Tep::AuthBearerToken.parse_delegate(delegate_str)
+
+      Tep::Identity.new(sub, delegation, caps)
+    end
+
+    # "read,write,post_summary" -> [:read, :write, :post_summary]
+    def self.parse_caps(s)
+      caps = [:_seed]
+      caps.delete_at(0)
+      if s.length == 0
+        return caps
+      end
+      s.split(",").each do |name|
+        if name.length > 0
+          caps.push(name.to_sym)
+        end
+      end
+      caps
+    end
+
+    # "agent_id|issued_at|expires_at|origin" -> AgentDelegation, or
+    # nil for empty / malformed. The four-segment pipe encoding
+    # avoids the nested-JSON limitation; pipes don't appear in
+    # agent ids (we constrain the issuance side).
+    #
+    # `.to_s` on parts[0] is a no-op type-witness for spinel:
+    # without it the inference for the first AgentDelegation arg
+    # widens to mrb_int in some larger-codebase compile paths (no
+    # other call site constrains agent_id to a String), and the
+    # generated C compares pointer-to-int.
+    def self.parse_delegate(s)
+      if s.length == 0
+        return nil
+      end
+      parts = s.split("|")
+      if parts.length < 4
+        return nil
+      end
+      agent_id   = parts[0].to_s
+      issued_at  = parts[1].to_i
+      expires_at = parts[2].to_i
+      origin     = parts[3].to_sym
+      Tep::AgentDelegation.new(agent_id, issued_at, expires_at, origin)
+    end
+  end
+end

--- a/lib/tep/request.rb
+++ b/lib/tep/request.rb
@@ -5,6 +5,12 @@ module Tep
     attr_accessor :params, :query, :req_headers, :raw_body, :cookies, :session
     attr_accessor :remote_host
     attr_accessor :ivars
+    # Set by the auth-filter (Tep::AuthFilter, run before the user's
+    # before-filter -- see Tep::App#auth_filter). Always populated:
+    # Tep::Identity.anonymous when no provider matched, otherwise
+    # the matched provider's Identity. Handlers and filters can
+    # rely on req.identity being non-nil.
+    attr_accessor :identity
 
     def initialize
       @verb         = ""
@@ -31,6 +37,7 @@ module Tep
                                      # `@x = v` -> `req.ivars["x"] = (v).to_s`
                                      # in handler bodies and `@x` -> `ivars["x"]`
                                      # inside ERB chunks.
+      @identity     = Tep::Identity.anonymous
     end
 
     attr_accessor :passed

--- a/sig/tep/auth.rbs
+++ b/sig/tep/auth.rbs
@@ -1,0 +1,18 @@
+# Entry point for the Auth battery. Sets req.identity on every
+# request via a fixed provider chain (v1: bearer-token only).
+# See lib/tep/auth.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  module Auth
+    CORE_CAPABILITIES: Array[Symbol]
+
+    def self.identify: (Tep::Request req) -> Tep::Identity?
+    def self.install!: () -> Integer
+  end
+
+  # The before-filter that runs the provider chain. Installed onto
+  # Tep::App#auth_filter by Tep::Auth.install!. Runs before the
+  # user-installed before-filter; populates req.identity.
+  class AuthFilter < Filter
+    def before: (Tep::Request req, Tep::Response res) -> Integer
+  end
+end

--- a/sig/tep/auth_bearer_token.rbs
+++ b/sig/tep/auth_bearer_token.rbs
@@ -1,0 +1,23 @@
+# JWT-HS256 bearer-token auth provider. Reads
+# Authorization: Bearer <token>; verifies via Tep::Jwt; decodes
+# the flat-JSON payload (sub / exp / caps / optional delegate)
+# into a Tep::Identity. See lib/tep/auth_bearer_token.rb +
+# docs/BATTERIES-DESIGN.md.
+module Tep
+  class AuthBearerToken
+    # Configure the shared HS256 secret. Apps call once at boot.
+    def self.set_secret: (String s) -> Integer
+
+    # Sniff the Authorization header + verify + decode. Returns
+    # Tep::Identity on success, nil otherwise (no header / bad
+    # prefix / signature mismatch / expired / malformed payload).
+    def self.try: (Tep::Request req) -> Tep::Identity?
+
+    # Comma-separated caps string -> array of symbols.
+    def self.parse_caps: (String s) -> Array[Symbol]
+
+    # Pipe-encoded delegate string (agent_id|issued_at|expires_at|origin)
+    # -> Tep::AgentDelegation, or nil for empty / malformed.
+    def self.parse_delegate: (String s) -> Tep::AgentDelegation?
+  end
+end

--- a/test/test_auth.rb
+++ b/test/test_auth.rb
@@ -1,0 +1,223 @@
+require_relative "helper"
+
+# Tep::Auth + Tep::AuthBearerToken: end-to-end JWT bearer-token
+# auth flow. Boots a tep app that installs the auth filter, mints
+# tokens via Tep::Jwt at request time, and exercises req.identity
+# from handler bodies.
+class TestAuth < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    SECRET = "test-shared-secret-do-not-use-in-prod"
+
+    Tep::AuthBearerToken.set_secret(SECRET)
+    Tep::Auth.install!
+
+    # ---- mint endpoints (test harness uses these to get tokens) ----
+    # The payload is Tep::Json-friendly flat JSON: sub, exp, caps
+    # (comma-separated), and optionally delegate (pipe-encoded).
+
+    post '/mint_human' do
+      res.headers["Content-Type"] = "text/plain"
+      sub = Tep::Json.get_str(req.raw_body, "sub")
+      caps = Tep::Json.get_str(req.raw_body, "caps")
+      exp = Time.now.to_i + 600
+      payload = "{" +
+        Tep::Json.encode_pair_str("sub", sub) + "," +
+        Tep::Json.encode_pair_int("exp", exp) + "," +
+        Tep::Json.encode_pair_str("caps", caps) +
+      "}"
+      Tep::Jwt.encode_hs256(payload, SECRET)
+    end
+
+    post '/mint_agent' do
+      res.headers["Content-Type"] = "text/plain"
+      sub = Tep::Json.get_str(req.raw_body, "sub")
+      caps = Tep::Json.get_str(req.raw_body, "caps")
+      delegate = Tep::Json.get_str(req.raw_body, "delegate")
+      exp = Time.now.to_i + 600
+      payload = "{" +
+        Tep::Json.encode_pair_str("sub", sub) + "," +
+        Tep::Json.encode_pair_int("exp", exp) + "," +
+        Tep::Json.encode_pair_str("caps", caps) + "," +
+        Tep::Json.encode_pair_str("delegate", delegate) +
+      "}"
+      Tep::Jwt.encode_hs256(payload, SECRET)
+    end
+
+    post '/mint_expired' do
+      res.headers["Content-Type"] = "text/plain"
+      sub = Tep::Json.get_str(req.raw_body, "sub")
+      # Issued in the past, expired in the past.
+      exp = Time.now.to_i - 60
+      payload = "{" +
+        Tep::Json.encode_pair_str("sub", sub) + "," +
+        Tep::Json.encode_pair_int("exp", exp) + "," +
+        Tep::Json.encode_pair_str("caps", "read") +
+      "}"
+      Tep::Jwt.encode_hs256(payload, SECRET)
+    end
+
+    # ---- identity-introspection endpoints ----
+    # Every route below reads req.identity (populated by the
+    # auth-filter before this handler runs).
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    get '/whoami' do
+      req.identity.subject
+    end
+
+    get '/is_human' do
+      req.identity.human? ? "yes" : "no"
+    end
+
+    get '/is_agent' do
+      req.identity.agent? ? "yes" : "no"
+    end
+
+    get '/may_read' do
+      req.identity.may?(:read) ? "yes" : "no"
+    end
+
+    get '/may_write' do
+      req.identity.may?(:write) ? "yes" : "no"
+    end
+
+    get '/may_post_summary' do
+      req.identity.may?(:post_summary) ? "yes" : "no"
+    end
+
+    get '/agent_id' do
+      if req.identity.acting_via == nil
+        ""
+      else
+        req.identity.acting_via.agent_id
+      end
+    end
+  RB
+
+  # ---- helper: mint a token, then call a route with it as Bearer ----
+
+  def mint_human(sub, caps)
+    body = "{" +
+      "\"sub\":\"" + sub + "\"," +
+      "\"caps\":\"" + caps + "\"}"
+    post("/mint_human", body).body
+  end
+
+  def mint_agent(sub, caps, delegate)
+    body = "{" +
+      "\"sub\":\"" + sub + "\"," +
+      "\"caps\":\"" + caps + "\"," +
+      "\"delegate\":\"" + delegate + "\"}"
+    post("/mint_agent", body).body
+  end
+
+  def mint_expired(sub)
+    body = "{\"sub\":\"" + sub + "\"}"
+    post("/mint_expired", body).body
+  end
+
+  def authed(path, token)
+    get(path, "Authorization" => "Bearer " + token)
+  end
+
+  # ---- anonymous (no Authorization header) ----
+
+  def test_anonymous_subject
+    assert_equal "user:", get("/whoami").body
+  end
+
+  def test_anonymous_has_no_caps
+    assert_equal "no", get("/may_read").body
+  end
+
+  # ---- valid human token ----
+
+  def test_human_subject_via_bearer
+    token = mint_human("user:42", "read,write")
+    assert_equal "user:user:42", authed("/whoami", token).body
+  end
+
+  def test_human_marked_human
+    token = mint_human("user:42", "read")
+    assert_equal "yes", authed("/is_human", token).body
+  end
+
+  def test_human_not_agent
+    token = mint_human("user:42", "read")
+    assert_equal "no", authed("/is_agent", token).body
+  end
+
+  def test_human_granted_caps
+    token = mint_human("user:42", "read,write")
+    assert_equal "yes", authed("/may_read", token).body
+    assert_equal "yes", authed("/may_write", token).body
+  end
+
+  def test_human_lacks_ungranted_cap
+    token = mint_human("user:42", "read")
+    assert_equal "no", authed("/may_write", token).body
+  end
+
+  # ---- valid agent token ----
+
+  def test_agent_subject_format
+    token = mint_agent(
+      "user:42", "read",
+      "summarizer-bot|1000|9999999999|token")
+    assert_equal "agent:summarizer-bot/user:42",
+      authed("/whoami", token).body
+  end
+
+  def test_agent_marked_agent
+    token = mint_agent(
+      "user:42", "read",
+      "summarizer-bot|1000|9999999999|token")
+    assert_equal "yes", authed("/is_agent", token).body
+  end
+
+  def test_agent_id_exposed
+    token = mint_agent(
+      "user:42", "read",
+      "summarizer-bot|1000|9999999999|token")
+    assert_equal "summarizer-bot", authed("/agent_id", token).body
+  end
+
+  def test_agent_caps_subset_of_principal
+    # Principal would have :read + :write; this token grants :read only.
+    # Auth doesn't enforce subset -- issuer does -- but tests that
+    # whatever the token carries flows through.
+    token = mint_agent(
+      "user:42", "read",
+      "summarizer-bot|1000|9999999999|token")
+    assert_equal "yes", authed("/may_read", token).body
+    assert_equal "no",  authed("/may_write", token).body
+  end
+
+  # ---- token rejections ----
+
+  def test_expired_token_falls_back_to_anonymous
+    token = mint_expired("user:42")
+    assert_equal "user:", authed("/whoami", token).body
+  end
+
+  def test_bad_signature_falls_back_to_anonymous
+    token = mint_human("user:42", "read")
+    tampered = token + "x"
+    assert_equal "user:", authed("/whoami", tampered).body
+  end
+
+  def test_malformed_bearer_header_falls_back_to_anonymous
+    # No "Bearer " prefix.
+    res = get("/whoami", "Authorization" => "Basic abcdef")
+    assert_equal "user:", res.body
+  end
+
+  def test_missing_authorization_falls_back_to_anonymous
+    assert_equal "user:", get("/whoami").body
+  end
+end


### PR DESCRIPTION
Stacked on #15 (chunk 1.1 — Identity types). Base = `feat/identity-types-1.1`; once #15 merges I'll retarget the base to `main`.

End-to-end bearer-token auth flow. Apps configure the secret + install the filter; from then on every handler sees `req.identity` populated.

## Public surface

```ruby
require 'sinatra'
Tep::AuthBearerToken.set_secret(ENV["JWT_SECRET"])
Tep::Auth.install!

# Every handler / filter:
req.identity            # always non-nil
req.identity.subject    # "user:42" or "agent:bot/user:42"
req.identity.human?
req.identity.may?(:read)
```

## JWT payload schema

Flat single-level JSON to match `Tep::Json`'s flat-object extractors:

```json
{
  "sub":      "user:42",
  "exp":      1716396000,
  "caps":     "read,write,post_summary",
  "delegate": "summarizer-bot|1716392400|1716396000|token"
}
```

The `delegate` field is optional. When present, the resulting `req.identity` is a delegated identity (`.agent? == true`). When absent, the token is a plain human session. The Identity / AgentDelegation Ruby API stays nested — the flatness is only on the wire.

## Design notes worth flagging

- **Flat class names** (`Tep::AuthBearerToken`, `Tep::AuthFilter`) instead of `Tep::Auth::BearerToken` etc. The Tep::Auth module owns the conceptual grouping; the classes live at `Tep::` level because two-level namespacing carries spinel `cls_id` dispatch risk (per memory `spinel_widening_dispatch`). Once spinel #637 + its follow-ups stabilise that path, we can move classes under `Tep::Auth::` without API churn — same constants, different parent.
- **`@auth_filter` is a separate slot on `Tep::App`**, not wedged into `@before_filter`. The auth filter runs first and populates `req.identity`; the user's before-filter sees a fully populated identity. This sidesteps tep's single-filter-slot composition tax.
- **Fixed provider chain** (just `BearerToken` for v1). The design doc's `Tep::Auth.providers.add(...)` runtime registry is deferred until spinel's `PtrArray<Base>` cls_id story improves. SessionCookie + OAuth2 will land in their own chunks by extending `Tep::Auth.identify` directly.
- One spinel inference quirk found: `parts[0]` from `String#split` widened to `mrb_int` in `parse_delegate` (no other call site anchors `AgentDelegation`'s `agent_id` to String). Workaround: `.to_s` no-op type-witness. Possibly worth a separate spinel filing once we have a smaller standalone repro — multiple synthetic attempts didn't trigger.

## Validation

- `test/test_auth.rb`: 15 runs / 17 assertions / 0 failures. Covers anonymous fallback, valid human tokens, valid agent tokens with the pipe-encoded delegate, expiry rejection, bad-signature rejection, malformed-Authorization-header rejection.
- Full suite: 271 / 547 green. 6 errors all pre-existing (3 TestScheduler pre-#641, 3 TestParallel matz/spinel#643).

## Out of scope (queued)

- Capability registry + extension hook (`Tep::Auth.register_capability`) — small follow-up.
- `Tep::Auth::SessionCookie` provider — chunk 1.3.
- `Tep::Auth::OAuth2` + consent UI — chunk 1.4 (separate design pass needed on the consent flow).