### PR TITLE
feat(auth): Tep::AuthSessionCookie (Battery 1, chunk 1.3)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -36,6 +36,7 @@ require_relative "tep/app"
 # because the references are inside method bodies (resolved at
 # runtime), not class-body literals (resolved at load time).
 require_relative "tep/auth_bearer_token"
+require_relative "tep/auth_session_cookie"
 require_relative "tep/auth"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"

--- a/lib/tep/auth.rb
+++ b/lib/tep/auth.rb
@@ -35,8 +35,17 @@ module Tep
     # Walk the provider chain. First provider that returns a non-nil
     # Identity wins. Returns nil if no provider matched -- caller is
     # responsible for substituting Tep::Identity.anonymous.
+    #
+    # Order: BearerToken first (an explicit Authorization header is
+    # a stronger signal of caller intent than a passively-replayed
+    # cookie), then SessionCookie. Apps that want cookie-wins-bearer
+    # semantics can post-process req.identity in a before-filter.
     def self.identify(req)
       ident = Tep::AuthBearerToken.try(req)
+      if ident != nil
+        return ident
+      end
+      ident = Tep::AuthSessionCookie.try(req)
       if ident != nil
         return ident
       end

--- a/lib/tep/auth_session_cookie.rb
+++ b/lib/tep/auth_session_cookie.rb
@@ -1,0 +1,132 @@
+# Tep::AuthSessionCookie -- the SessionCookie provider for the Auth
+# battery. Reads identity fields off the signed session cookie that
+# Tep::Session already round-trips through Tep::App#dispatch.
+#
+# Configuration:
+#
+#   Tep.session_secret = ENV["TEP_SESSION_SECRET"]
+#   Tep::Auth.install!     # enables both Bearer + SessionCookie
+#
+# Identity in the session is stored as four keys (identity_sub /
+# identity_caps / identity_delegate / identity_exp). The whole
+# cookie is HMAC-signed (Tep::Session's existing payload+sig
+# format), so forgery requires the secret. The identity payload IS
+# visible to the client -- the cookie is signed, not encrypted --
+# so don't put secrets in caps or in the delegate fields. Standard
+# session-cookie tradeoff.
+#
+# Login / logout:
+#
+#   post '/login' do
+#     # ... verify the user's password / OAuth handshake / etc ...
+#     ident = Tep::Identity.new("user:42", nil, [:read, :write])
+#     Tep::AuthSessionCookie.set(req, ident)
+#     # The session will be re-signed + emitted via Set-Cookie by
+#     # tep's normal session lifecycle (App#dispatch end).
+#     ""
+#   end
+#
+#   post '/logout' do
+#     Tep::AuthSessionCookie.clear(req)
+#     ""
+#   end
+#
+# Provider-chain order: tried AFTER Tep::AuthBearerToken in
+# Tep::Auth.identify. Bearer wins if both present, on the
+# principle that an explicit Authorization header is a stronger
+# signal of caller intent than a passively-replayed cookie.
+#
+# Flat namespacing (Tep::AuthSessionCookie, not
+# Tep::Auth::SessionCookie) mirrors Tep::AuthBearerToken for the
+# same spinel cls_id reasons -- see memory note
+# [[spinel_widening_dispatch]].
+module Tep
+  class AuthSessionCookie
+    # Write an Identity into req.session. Caller is responsible for
+    # ensuring Tep.session_secret is configured -- otherwise the
+    # response cookie won't get signed and the next request can't
+    # round-trip the identity back.
+    #
+    # `exp` is unix epoch seconds; nil disables expiry (the cookie
+    # itself still expires per its own Max-Age / Expires headers
+    # or browser session lifetime).
+    def self.set(req, identity, exp)
+      req.session.set("identity_sub", identity.principal_id)
+      req.session.set("identity_caps",
+        Tep::AuthSessionCookie.format_caps(identity.capabilities))
+      delegate = identity.acting_via
+      if delegate == nil
+        req.session.set("identity_delegate", "")
+      else
+        req.session.set("identity_delegate",
+          Tep::AuthSessionCookie.format_delegate(delegate))
+      end
+      if exp > 0
+        req.session.set("identity_exp", exp.to_s)
+      else
+        req.session.set("identity_exp", "")
+      end
+      0
+    end
+
+    # Drop the identity fields from req.session. The session itself
+    # stays valid (signed cookie continues to round-trip), but any
+    # subsequent try() returns nil because identity_sub is empty.
+    def self.clear(req)
+      req.session.set("identity_sub", "")
+      req.session.set("identity_caps", "")
+      req.session.set("identity_delegate", "")
+      req.session.set("identity_exp", "")
+      0
+    end
+
+    # Attempt to recover an Identity from req.session. Returns nil
+    # if the session has no identity (no prior #set call, or after
+    # #clear) or the stored identity is expired.
+    def self.try(req)
+      sub = req.session.get("identity_sub")
+      if sub.length == 0
+        return nil
+      end
+
+      exp_str = req.session.get("identity_exp")
+      if exp_str.length > 0
+        exp = exp_str.to_i
+        if exp > 0 && Time.now.to_i >= exp
+          return nil
+        end
+      end
+
+      caps_str = req.session.get("identity_caps")
+      caps = Tep::AuthBearerToken.parse_caps(caps_str)
+
+      delegate_str = req.session.get("identity_delegate")
+      delegation = Tep::AuthBearerToken.parse_delegate(delegate_str)
+
+      Tep::Identity.new(sub, delegation, caps)
+    end
+
+    # [:read, :write, :post_summary] -> "read,write,post_summary"
+    def self.format_caps(caps)
+      out = ""
+      first = true
+      caps.each do |c|
+        if !first
+          out = out + ","
+        end
+        out = out + c.to_s
+        first = false
+      end
+      out
+    end
+
+    # AgentDelegation -> "agent_id|issued_at|expires_at|origin".
+    # Inverse of Tep::AuthBearerToken.parse_delegate.
+    def self.format_delegate(deleg)
+      deleg.agent_id + "|" +
+        deleg.issued_at.to_s + "|" +
+        deleg.expires_at.to_s + "|" +
+        deleg.origin.to_s
+    end
+  end
+end

--- a/sig/tep/auth_session_cookie.rbs
+++ b/sig/tep/auth_session_cookie.rbs
@@ -1,0 +1,29 @@
+# Signed-session-cookie auth provider. Reads identity fields off
+# req.session (which Tep::App#dispatch already loads from the
+# tep.session cookie + verifies the HMAC on). See
+# lib/tep/auth_session_cookie.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class AuthSessionCookie
+    # Write `identity` into req.session under the canonical
+    # identity_* keys. `exp` is unix epoch seconds for the identity's
+    # validity window; pass 0 to disable identity-level expiry (the
+    # cookie itself still expires per browser session / Max-Age).
+    def self.set: (Tep::Request req, Tep::Identity identity, Integer exp) -> Integer
+
+    # Drop the identity fields from req.session. Subsequent try()
+    # calls return nil. The underlying session cookie keeps round-
+    # tripping.
+    def self.clear: (Tep::Request req) -> Integer
+
+    # Recover an Identity from req.session. Returns nil if no
+    # identity is present (no prior set, or post-clear) or the
+    # stored identity has expired.
+    def self.try: (Tep::Request req) -> Tep::Identity?
+
+    # Format helpers used by `set` to encode caps + delegation into
+    # the session's string/string store. Inverse of
+    # Tep::AuthBearerToken.parse_caps / parse_delegate.
+    def self.format_caps: (Array[Symbol] caps) -> String
+    def self.format_delegate: (Tep::AgentDelegation deleg) -> String
+  end
+end

--- a/test/test_auth_session_cookie.rb
+++ b/test/test_auth_session_cookie.rb
@@ -1,0 +1,198 @@
+require_relative "helper"
+
+# Tep::AuthSessionCookie: signed-session-cookie auth provider.
+# Round-trip an Identity via the tep.session cookie + verify it's
+# read back through req.identity on the next request.
+class TestAuthSessionCookie < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    Tep.session_secret = "test-session-secret-do-not-use-in-prod"
+    Tep::Auth.install!
+
+    # ---- write paths: the test harness calls these to seed a
+    # session cookie. POST body is irrelevant; the route hardcodes
+    # the identity it sets so the test can predict the readback.
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    post '/login_human' do
+      caps = [:read, :write]
+      ident = Tep::Identity.new("user:42", nil, caps)
+      Tep::AuthSessionCookie.set(req, ident, 0)
+      "ok"
+    end
+
+    post '/login_human_with_exp' do
+      # Expiry 600s in the future -- valid for the immediate readback.
+      caps = [:read]
+      ident = Tep::Identity.new("user:42", nil, caps)
+      Tep::AuthSessionCookie.set(req, ident, Time.now.to_i + 600)
+      "ok"
+    end
+
+    post '/login_human_expired' do
+      # Expiry 60s in the PAST -- readback rejects.
+      caps = [:read]
+      ident = Tep::Identity.new("user:42", nil, caps)
+      Tep::AuthSessionCookie.set(req, ident, Time.now.to_i - 60)
+      "ok"
+    end
+
+    post '/login_agent' do
+      caps = [:read]
+      delegation = Tep::AgentDelegation.new(
+        "summarizer-bot", 1000, 9999999999, :token)
+      ident = Tep::Identity.new("user:42", delegation, caps)
+      Tep::AuthSessionCookie.set(req, ident, 0)
+      "ok"
+    end
+
+    post '/logout' do
+      Tep::AuthSessionCookie.clear(req)
+      "ok"
+    end
+
+    # ---- read paths ----
+
+    get '/whoami' do
+      req.identity.subject
+    end
+
+    get '/is_human' do
+      req.identity.human? ? "yes" : "no"
+    end
+
+    get '/is_agent' do
+      req.identity.agent? ? "yes" : "no"
+    end
+
+    get '/may_read' do
+      req.identity.may?(:read) ? "yes" : "no"
+    end
+
+    get '/may_write' do
+      req.identity.may?(:write) ? "yes" : "no"
+    end
+
+    get '/agent_id' do
+      if req.identity.acting_via == nil
+        ""
+      else
+        req.identity.acting_via.agent_id
+      end
+    end
+  RB
+
+  # Pull the tep.session cookie out of a Set-Cookie header and
+  # return the "tep.session=..." string suitable for a Cookie:
+  # request header.
+  def session_cookie_from(res)
+    raw = res["set-cookie"]
+    return nil if raw.nil? || raw.empty?
+    pair = raw.split(";").first
+    pair.strip
+  end
+
+  # POST to a login route, then GET `path` with the resulting
+  # session cookie. Returns the GET response.
+  def with_session_from(login_path, path)
+    login_res = post(login_path)
+    cookie = session_cookie_from(login_res)
+    assert cookie, "expected tep.session cookie in #{login_path} response, got: #{login_res['set-cookie'].inspect}"
+    get(path, "Cookie" => cookie)
+  end
+
+  # ---- anonymous (no session cookie at all) ----
+
+  def test_anonymous_when_no_cookie
+    assert_equal "user:", get("/whoami").body
+  end
+
+  def test_anonymous_has_no_caps
+    assert_equal "no", get("/may_read").body
+  end
+
+  # ---- human identity round-trips through the session ----
+
+  def test_human_subject_round_trips
+    res = with_session_from("/login_human", "/whoami")
+    assert_equal "user:user:42", res.body
+  end
+
+  def test_human_marked_human
+    res = with_session_from("/login_human", "/is_human")
+    assert_equal "yes", res.body
+  end
+
+  def test_human_caps_round_trip
+    res = with_session_from("/login_human", "/may_read")
+    assert_equal "yes", res.body
+    res = with_session_from("/login_human", "/may_write")
+    assert_equal "yes", res.body
+  end
+
+  # ---- agent identity round-trips ----
+
+  def test_agent_subject_round_trips
+    res = with_session_from("/login_agent", "/whoami")
+    assert_equal "agent:summarizer-bot/user:42", res.body
+  end
+
+  def test_agent_marked_agent
+    res = with_session_from("/login_agent", "/is_agent")
+    assert_equal "yes", res.body
+  end
+
+  def test_agent_id_round_trips
+    res = with_session_from("/login_agent", "/agent_id")
+    assert_equal "summarizer-bot", res.body
+  end
+
+  # ---- expiry ----
+
+  def test_valid_exp_still_works
+    res = with_session_from("/login_human_with_exp", "/whoami")
+    assert_equal "user:user:42", res.body
+  end
+
+  def test_expired_identity_falls_back_to_anonymous
+    res = with_session_from("/login_human_expired", "/whoami")
+    assert_equal "user:", res.body
+  end
+
+  # ---- logout ----
+
+  def test_logout_clears_identity
+    # Step 1: log in
+    login_res = post("/login_human")
+    logged_in_cookie = session_cookie_from(login_res)
+
+    # Step 2: verify identity is set
+    res = get("/whoami", "Cookie" => logged_in_cookie)
+    assert_equal "user:user:42", res.body
+
+    # Step 3: logout (server clears the identity_* keys; the response
+    # re-signs the cleared cookie and returns it).
+    logout_res = post("/logout", "", "Cookie" => logged_in_cookie)
+    logged_out_cookie = session_cookie_from(logout_res)
+
+    # Step 4: subsequent request with the post-logout cookie sees
+    # anonymous.
+    res = get("/whoami", "Cookie" => logged_out_cookie)
+    assert_equal "user:", res.body
+  end
+
+  # ---- tampering ----
+
+  def test_tampered_cookie_falls_back_to_anonymous
+    login_res = post("/login_human")
+    cookie = session_cookie_from(login_res)
+    # Mangle the signature half (everything after the last dot).
+    tampered = cookie.sub(/\.[^.]+\z/, ".aaaaaaaa")
+    res = get("/whoami", "Cookie" => tampered)
+    assert_equal "user:", res.body
+  end
+end


### PR DESCRIPTION
Second auth provider in Battery 1's fixed chain. Reads identity off the signed session cookie that `Tep::App#dispatch` already loads + verifies.

Provider order in `Tep::Auth.identify` is now BearerToken first, SessionCookie second — an explicit `Authorization` header beats a passively-replayed cookie. Apps can ignore either by simply not configuring its secret.

## Public surface

```ruby
# Configuration (once at boot):
Tep.session_secret = ENV["TEP_SESSION_SECRET"]
Tep::Auth.install!    # enables both Bearer + SessionCookie

# Login:
post '/login' do
  # ... verify password / OAuth handshake / etc ...
  ident = Tep::Identity.new("user:42", nil, [:read, :write])
  Tep::AuthSessionCookie.set(req, ident, 0)   # 0 = no identity expiry
  ""
end

# Logout:
post '/logout' do
  Tep::AuthSessionCookie.clear(req)
  ""
end

# Every subsequent handler:
req.identity            # Tep::Identity (anonymous if no cookie / expired / tampered)
```

## Wire format

Identity in the session lives under four canonical keys:

| Key | Format |
|---|---|
| `identity_sub` | `"user:42"` (principal_id; empty means no identity) |
| `identity_caps` | comma-separated symbols, e.g. `"read,write,post_summary"` |
| `identity_delegate` | pipe-encoded `"agent_id\|issued_at\|expires_at\|origin"` or empty |
| `identity_exp` | unix epoch seconds, or empty for no identity-level expiry |

The encoding inversers `Tep::AuthBearerToken.parse_caps` / `parse_delegate` — the two providers share decode logic via direct cmeth calls. One layer of cross-class coupling beats a separate shared module for this scope.

**Security caveat**: the cookie is HMAC-signed but not encrypted. The identity payload is visible to the client (principal_id, caps, agent_id). Don't put secrets in caps or delegate fields. Standard session-cookie tradeoff.

## Design notes

- **Required `exp` param** (not defaulted): class cmeth default args (`def self.foo(x = 0)` inside a `class`) are unverified ground in spinel — the only default-arg paths exercised in tep so far are module-level (`Tep.run!`) and instance constructor (`Counter.new(start = 0)`). Keeping `exp` required sidesteps the same-class default-arg codegen surface. Callers pass `0` to mean "no expiry."
- **Flat namespacing** (`Tep::AuthSessionCookie`, not `Tep::Auth::SessionCookie`) matches `Tep::AuthBearerToken` for the same spinel `cls_id` reasons (memory `spinel_widening_dispatch`).

## Validation

- `test/test_auth_session_cookie.rb`: 12 runs / 23 assertions / 0 failures. Covers anonymous (no cookie), human round-trip, agent round-trip with delegation, valid expiry, expired-identity rejection, logout clearing, tampered-cookie rejection.
- Full suite: 283 / 570 green. 6 errors all pre-existing (3 TestScheduler pre-#641, 3 TestParallel matz/spinel#643). No new regressions.

## Battery 1 progress

| Chunk | Status |
|---|---|
| 1.1 Identity types | shipped in v0.6.0 |
| 1.2 BearerToken provider | shipped in v0.6.0 |
| **1.3 SessionCookie provider** | **this PR** |
| 1.4 OAuth2 + consent UI | queued (separate design pass) |
| Capability registry + extension hook | small follow-up, can land any time |

After merge, Battery 1 is feature-complete for the "API tokens + session-cookie sign-in" case. OAuth2 is the remaining heavy lift.