### PR TITLE
feat(auth): Tep::AuthOAuth2 -- delegated-grant issuance (Battery 1, chunk 1.4)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -21,6 +21,9 @@ require_relative "tep/url"
 require_relative "tep/net"
 require_relative "tep/agent_delegation"
 require_relative "tep/identity"
+# Auth data classes (no deps; storage on Tep::App references them).
+require_relative "tep/auth_oauth2_client"
+require_relative "tep/auth_oauth2_code"
 require_relative "tep/session"
 require_relative "tep/request"
 require_relative "tep/response"
@@ -30,13 +33,12 @@ require_relative "tep/streamer"
 require_relative "tep/parser"
 require_relative "tep/router"
 require_relative "tep/app"
-# Auth lands after App so Tep::AuthFilter < Tep::Filter can resolve
-# and the install! helper can reach Tep::APP. The provider classes
-# reference Tep::Jwt / Tep::Json which come after this -- works
-# because the references are inside method bodies (resolved at
-# runtime), not class-body literals (resolved at load time).
+# Auth provider classes land after App so Tep::AuthFilter < Tep::Filter
+# resolves and the install! helper can reach Tep::APP. References to
+# Tep::Jwt / Tep::Json inside their method bodies resolve at runtime.
 require_relative "tep/auth_bearer_token"
 require_relative "tep/auth_session_cookie"
+require_relative "tep/auth_oauth2"
 require_relative "tep/auth"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"
@@ -190,6 +192,21 @@ module Tep
   _tep_seed_stream.write("")   # pin the parameter type to :str
   Tep.h("")                    # pin Tep.h(s)'s param to :str
   _tep_seed_res.start_websocket("", Tep::WebSocket::Driver.new(0))
+
+  # AuthOAuth2 type-seeding. Every public cmeth needs at least one
+  # top-level call so spinel locks the param C types in compile
+  # units that don't otherwise exercise OAuth2 (e.g. test_llm.rb
+  # builds an app that never touches Tep::AuthOAuth2; without
+  # these seeds spinel defaults the params to mrb_int and the
+  # AuthOAuth2Client / AuthOAuth2Code constructor calls inside
+  # the methods mismatch the typed ivars).
+  _tep_seed_oauth2_caps = [:_seed]
+  _tep_seed_oauth2_caps.delete_at(0)
+  Tep::AuthOAuth2.register_client("_seed", "", "", _tep_seed_oauth2_caps)
+  Tep::AuthOAuth2.unregister_client("_seed")
+  Tep::AuthOAuth2.find_client("_seed")
+  _tep_seed_oauth2_code = Tep::AuthOAuth2.issue_code("_seed", "_seed", "", 0)
+  Tep::AuthOAuth2.exchange_code(_tep_seed_oauth2_code, "_seed", 0)
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -23,6 +23,10 @@ module Tep
     # APP (rather than a class var) so spinel routes the read through
     # the canonical instance-attr path.
     attr_accessor :auth_bearer_secret
+    # Per-process OAuth2 client registry + ephemeral authorization-code
+    # store. See Tep::AuthOAuth2 for the issuance flow.
+    attr_accessor :auth_oauth2_clients
+    attr_accessor :auth_oauth2_codes
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -47,6 +51,12 @@ module Tep
       @after_filter   = Filter.new
       @auth_filter    = Filter.new   # no-op until Tep::Auth.install!
       @auth_bearer_secret = ""
+      # Type-seed the OAuth2 registries with a single dummy entry +
+      # immediate drop so the PtrArray slot type is pinned.
+      @auth_oauth2_clients = [Tep::AuthOAuth2Client.new("_", "", "", [:_])]
+      @auth_oauth2_clients.delete_at(0)
+      @auth_oauth2_codes = [Tep::AuthOAuth2Code.new("_", "", "", "", 0)]
+      @auth_oauth2_codes.delete_at(0)
       @nf_handler     = Handler.new
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines

--- a/lib/tep/auth_oauth2.rb
+++ b/lib/tep/auth_oauth2.rb
@@ -1,0 +1,189 @@
+# Tep::AuthOAuth2 -- the OAuth2-style authorization-code issuance
+# surface. tep here is the AUTHORIZATION SERVER (not the OAuth
+# client) -- the entity that issues delegated-access tokens to
+# bots / agents / automation clients on behalf of human users.
+#
+# Flow (apps wire their own /oauth/authorize + /oauth/token routes
+# on top of these primitives):
+#
+#   1. Bot redirects the user to /oauth/authorize?client_id=summarizer-bot
+#      &redirect_uri=...&caps=read,post_summary.
+#   2. App's /authorize route looks up the client, checks the
+#      caps subset against allowed_caps, renders a consent
+#      screen ("summarizer-bot wants to act on your behalf...").
+#   3. User clicks "Allow". App calls:
+#        Tep::AuthOAuth2.issue_code(req.identity.principal_id,
+#                                   client_id, caps_str, 600)
+#      and redirects to the bot's redirect_uri with ?code=<code>.
+#   4. Bot exchanges the code at /oauth/token:
+#        Tep::AuthOAuth2.exchange_code(code, client_id)
+#      which returns a JWT whose `delegate` field is populated
+#      (acting_via on the resulting Tep::Identity).
+#   5. Bot uses the JWT as a Bearer token. Tep::AuthBearerToken
+#      parses it; req.identity is a delegated agent identity.
+#
+# The "agentic" framing: this is fundamentally OAuth2 with the
+# semantic shift that the granted token represents an agent
+# delegated by the user, not an "app" the user wants to share
+# data with. The consent UI's wording (rendered by the app, not
+# by tep) should make that clear to the user.
+#
+# Token issuance reuses Tep::Jwt + Tep::AuthBearerToken's wire
+# format -- no new token schema. The downstream Identity surface
+# is the same: `req.identity.agent?` is true, `acting_via.agent_id`
+# is the client_id, `acting_via.origin` is :oauth_grant.
+#
+# Storage is per-process (Tep::APP attrs). High-fanout setups
+# wanting cross-worker code redemption need a PG-backed extension;
+# noted but not in scope for v1.
+module Tep
+  module AuthOAuth2
+    # Default code TTL (seconds). Apps that need shorter / longer
+    # pass an explicit ttl_seconds to issue_code.
+    DEFAULT_CODE_TTL = 600
+
+    # Default token TTL (seconds). The JWT exp claim is set to
+    # `now + this`. Apps that need a different window pass an
+    # explicit token_ttl_seconds to exchange_code.
+    DEFAULT_TOKEN_TTL = 3600
+
+    # Register a client (bot / agent / automation peer) with the
+    # authorization server. Subsequent issue_code and exchange_code
+    # calls reference it by client_id. Re-registering an existing
+    # client_id replaces the prior entry.
+    def self.register_client(client_id, name, redirect_uri, allowed_caps)
+      Tep::AuthOAuth2.unregister_client(client_id)
+      client = Tep::AuthOAuth2Client.new(
+        client_id, name, redirect_uri, allowed_caps)
+      Tep::APP.auth_oauth2_clients.push(client)
+      0
+    end
+
+    def self.unregister_client(client_id)
+      clients = Tep::APP.auth_oauth2_clients
+      i = 0
+      while i < clients.length
+        if clients[i].client_id == client_id
+          clients.delete_at(i)
+          return 0
+        end
+        i += 1
+      end
+      0
+    end
+
+    def self.find_client(client_id)
+      clients = Tep::APP.auth_oauth2_clients
+      i = 0
+      while i < clients.length
+        if clients[i].client_id == client_id
+          return clients[i]
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # Mint a one-time code tied to (principal, client, granted_caps).
+    # Caller (the app's /authorize handler) is responsible for
+    # validating that granted_caps is a subset of the client's
+    # allowed_caps before calling -- the issuance surface itself
+    # trusts the caller.
+    #
+    # `caps_str` is comma-separated (matches Tep::AuthBearerToken's
+    # wire format). `ttl_seconds` is the lifetime; pass 0 for
+    # DEFAULT_CODE_TTL.
+    #
+    # Returns the opaque code string (base64url, ~32 chars).
+    def self.issue_code(principal_id, client_id, caps_str, ttl_seconds)
+      Tep::AuthOAuth2.sweep_expired_codes
+      ttl = ttl_seconds
+      if ttl <= 0
+        ttl = DEFAULT_CODE_TTL
+      end
+      code = Crypto.sp_crypto_random_b64url(24)
+      expires_at = Time.now.to_i + ttl
+      rec = Tep::AuthOAuth2Code.new(
+        code, principal_id, client_id, caps_str, expires_at)
+      Tep::APP.auth_oauth2_codes.push(rec)
+      code
+    end
+
+    # Redeem a code for a JWT. The code MUST have been issued for
+    # this exact client_id (no cross-client redemption). Returns
+    # the JWT string on success, "" on failure (unknown code,
+    # client_id mismatch, expired, already-redeemed).
+    #
+    # The JWT is single-use against the registry: a successful
+    # exchange_code removes the code from the registry.
+    #
+    # `token_ttl_seconds` is the JWT's exp lifetime; pass 0 for
+    # DEFAULT_TOKEN_TTL.
+    def self.exchange_code(code, client_id, token_ttl_seconds)
+      Tep::AuthOAuth2.sweep_expired_codes
+      codes = Tep::APP.auth_oauth2_codes
+      idx = -1
+      i = 0
+      while i < codes.length
+        if codes[i].code == code && codes[i].client_id == client_id
+          idx = i
+          i = codes.length
+        else
+          i += 1
+        end
+      end
+      if idx < 0
+        return ""
+      end
+      rec = codes[idx]
+      codes.delete_at(idx)
+      if rec.expired?(Time.now.to_i)
+        return ""
+      end
+      Tep::AuthOAuth2.mint_jwt(rec, token_ttl_seconds)
+    end
+
+    # Build the JWT payload and sign it. Uses Tep::Jwt with the
+    # same shared secret as Tep::AuthBearerToken, so apps don't
+    # need to manage a second secret -- one HS256 secret signs all
+    # tokens regardless of issuance path.
+    def self.mint_jwt(rec, token_ttl_seconds)
+      secret = Tep::APP.auth_bearer_secret
+      if secret.length == 0
+        return ""
+      end
+      ttl = token_ttl_seconds
+      if ttl <= 0
+        ttl = DEFAULT_TOKEN_TTL
+      end
+      now_ts = Time.now.to_i
+      exp_ts = now_ts + ttl
+      delegate_str = rec.client_id + "|" + now_ts.to_s + "|" +
+                     exp_ts.to_s + "|oauth_grant"
+      payload = "{" +
+        Tep::Json.encode_pair_str("sub", rec.principal_id) + "," +
+        Tep::Json.encode_pair_int("exp", exp_ts) + "," +
+        Tep::Json.encode_pair_str("caps", rec.caps_str) + "," +
+        Tep::Json.encode_pair_str("delegate", delegate_str) +
+      "}"
+      Tep::Jwt.encode_hs256(payload, secret)
+    end
+
+    # Walk the code registry, drop entries whose expires_at has
+    # passed. Called on every issue / exchange so the registry
+    # doesn't grow unboundedly even without explicit pruning.
+    # Back-to-front so delete_at indices stay valid mid-loop.
+    def self.sweep_expired_codes
+      codes = Tep::APP.auth_oauth2_codes
+      now_ts = Time.now.to_i
+      i = codes.length - 1
+      while i >= 0
+        if codes[i].expired?(now_ts)
+          codes.delete_at(i)
+        end
+        i -= 1
+      end
+      0
+    end
+  end
+end

--- a/lib/tep/auth_oauth2_client.rb
+++ b/lib/tep/auth_oauth2_client.rb
@@ -1,0 +1,29 @@
+# Tep::AuthOAuth2Client -- one entry in the OAuth2 client registry.
+# Represents a "bot" / "agent" / "automation client" that can be
+# delegated permissions to act on behalf of a human principal via
+# the OAuth2-style authorization-code flow.
+#
+# Created by Tep::AuthOAuth2.register_client. Apps don't typically
+# instantiate this directly -- the registry takes
+# (client_id, name, redirect_uri, allowed_caps) and stores the
+# resulting Client.
+#
+# `allowed_caps` is the MAXIMUM set of capabilities this client
+# can ever be granted. At consent time the human grants a subset
+# (or all) of these to the specific code being issued. The granted
+# set on the eventual JWT is always a subset of allowed_caps.
+module Tep
+  class AuthOAuth2Client
+    attr_reader :client_id        # String, opaque (e.g. "summarizer-bot")
+    attr_reader :name             # Human-readable display name for consent UI
+    attr_reader :redirect_uri     # Where to redirect with ?code=... after consent
+    attr_reader :allowed_caps     # Array of symbols (ceiling on granted caps)
+
+    def initialize(client_id, name, redirect_uri, allowed_caps)
+      @client_id     = client_id
+      @name          = name
+      @redirect_uri  = redirect_uri
+      @allowed_caps  = allowed_caps
+    end
+  end
+end

--- a/lib/tep/auth_oauth2_code.rb
+++ b/lib/tep/auth_oauth2_code.rb
@@ -1,0 +1,40 @@
+# Tep::AuthOAuth2Code -- one entry in the short-lived
+# authorization-code registry. Created by
+# Tep::AuthOAuth2.issue_code at the moment a human consents to a
+# specific (client, caps) grant; consumed by
+# Tep::AuthOAuth2.exchange_code when the client redeems the code
+# for a JWT.
+#
+# Codes are single-use and short-lived (typically 5-10 minutes).
+# The registry sweeps expired entries on every lookup so
+# memory doesn't accumulate even without explicit pruning.
+#
+# Storage scope is per-process: the registry lives on Tep::APP,
+# which is per-worker under prefork. A bot redeeming a code MUST
+# do so against the same worker that issued it. For most apps
+# that's invisible (one human, one worker handling both the
+# consent submission and the immediate redirect-then-redeem
+# sequence), but high-fanout production setups will want
+# cross-worker code storage (PG-backed) -- a future battery
+# extension.
+module Tep
+  class AuthOAuth2Code
+    attr_reader :code             # opaque base64url string
+    attr_reader :principal_id     # the human granting access
+    attr_reader :client_id        # which client this code was issued for
+    attr_reader :caps_str         # comma-separated symbols (granted subset)
+    attr_reader :expires_at       # unix epoch seconds; >= now means alive
+
+    def initialize(code, principal_id, client_id, caps_str, expires_at)
+      @code         = code
+      @principal_id = principal_id
+      @client_id    = client_id
+      @caps_str     = caps_str
+      @expires_at   = expires_at
+    end
+
+    def expired?(now)
+      now >= @expires_at
+    end
+  end
+end

--- a/sig/tep/auth_oauth2.rbs
+++ b/sig/tep/auth_oauth2.rbs
@@ -1,0 +1,41 @@
+# OAuth2-style authorization-code issuance. tep here is the
+# authorization server; apps wire their own /authorize + /token
+# routes on top of these primitives. The issued JWT plugs into
+# Tep::AuthBearerToken's wire format -- no new token schema. See
+# lib/tep/auth_oauth2.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  module AuthOAuth2
+    DEFAULT_CODE_TTL: Integer    # seconds
+    DEFAULT_TOKEN_TTL: Integer   # seconds
+
+    def self.register_client: (
+      String client_id,
+      String name,
+      String redirect_uri,
+      Array[Symbol] allowed_caps
+    ) -> Integer
+
+    def self.unregister_client: (String client_id) -> Integer
+    def self.find_client: (String client_id) -> AuthOAuth2Client?
+
+    # Mint a one-time code tied to (principal, client, caps).
+    # `ttl_seconds == 0` uses DEFAULT_CODE_TTL.
+    def self.issue_code: (
+      String principal_id,
+      String client_id,
+      String caps_str,
+      Integer ttl_seconds
+    ) -> String
+
+    # Redeem a code for a JWT. Returns "" on any failure.
+    # `token_ttl_seconds == 0` uses DEFAULT_TOKEN_TTL.
+    def self.exchange_code: (
+      String code,
+      String client_id,
+      Integer token_ttl_seconds
+    ) -> String
+
+    def self.mint_jwt: (AuthOAuth2Code rec, Integer token_ttl_seconds) -> String
+    def self.sweep_expired_codes: () -> Integer
+  end
+end

--- a/sig/tep/auth_oauth2_client.rbs
+++ b/sig/tep/auth_oauth2_client.rbs
@@ -1,0 +1,18 @@
+# One entry in Tep::AuthOAuth2's client registry. Represents a bot
+# / agent / automation client that can be granted delegated access.
+# See lib/tep/auth_oauth2_client.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class AuthOAuth2Client
+    attr_reader client_id: String
+    attr_reader name: String
+    attr_reader redirect_uri: String
+    attr_reader allowed_caps: Array[Symbol]
+
+    def initialize: (
+      String client_id,
+      String name,
+      String redirect_uri,
+      Array[Symbol] allowed_caps
+    ) -> void
+  end
+end

--- a/sig/tep/auth_oauth2_code.rbs
+++ b/sig/tep/auth_oauth2_code.rbs
@@ -1,0 +1,23 @@
+# One entry in Tep::AuthOAuth2's short-lived authorization-code
+# registry. Single-use; sweeps on every lookup. See
+# lib/tep/auth_oauth2_code.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class AuthOAuth2Code
+    attr_reader code: String
+    attr_reader principal_id: String
+    attr_reader client_id: String
+    attr_reader caps_str: String
+    attr_reader expires_at: Integer
+
+    def initialize: (
+      String code,
+      String principal_id,
+      String client_id,
+      String caps_str,
+      Integer expires_at
+    ) -> void
+
+    # `now` is unix epoch seconds.
+    def expired?: (Integer now) -> bool
+  end
+end

--- a/test/test_auth_oauth2.rb
+++ b/test/test_auth_oauth2.rb
@@ -1,0 +1,208 @@
+require_relative "helper"
+
+# Tep::AuthOAuth2: OAuth2-style authorization-code issuance. tep
+# acts as the authorization server -- registers bot clients, issues
+# short-lived codes after consent, exchanges codes for JWTs. The
+# downstream identity surface is the same as direct bearer-token
+# auth: the resulting JWT carries `delegate` and BearerToken parses
+# it into a delegated Tep::Identity.
+class TestAuthOAuth2 < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    SECRET = "test-oauth2-shared-secret"
+    Tep::AuthBearerToken.set_secret(SECRET)
+    Tep::Auth.install!
+
+    # Register one bot client at boot.
+    Tep::AuthOAuth2.register_client(
+      "summarizer-bot",
+      "Summarizer Bot",
+      "https://bot.example/oauth/callback",
+      [:read, :post_summary])
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    # ---- consent endpoint: caller passes the principal + granted
+    # caps; app's real implementation would render a consent UI +
+    # only reach here on user-approve. The test stub skips the UI.
+
+    post '/consent' do
+      principal_id = Tep::Json.get_str(req.raw_body, "principal_id")
+      client_id    = Tep::Json.get_str(req.raw_body, "client_id")
+      caps_str     = Tep::Json.get_str(req.raw_body, "caps")
+      Tep::AuthOAuth2.issue_code(principal_id, client_id, caps_str, 0)
+    end
+
+    # ---- token-exchange endpoint: bot redeems code for JWT.
+
+    post '/token' do
+      code      = Tep::Json.get_str(req.raw_body, "code")
+      client_id = Tep::Json.get_str(req.raw_body, "client_id")
+      Tep::AuthOAuth2.exchange_code(code, client_id, 0)
+    end
+
+    # ---- client lookup (sanity check the registry).
+
+    get '/client/:id' do
+      c = Tep::AuthOAuth2.find_client(params[:id])
+      if c == nil
+        "missing"
+      else
+        c.name + "|" + c.redirect_uri
+      end
+    end
+
+    # ---- identity-introspection endpoints (mirrors test_auth).
+
+    get '/whoami' do
+      req.identity.subject
+    end
+
+    get '/is_agent' do
+      req.identity.agent? ? "yes" : "no"
+    end
+
+    get '/agent_id' do
+      if req.identity.acting_via == nil
+        ""
+      else
+        req.identity.acting_via.agent_id
+      end
+    end
+
+    get '/origin' do
+      if req.identity.acting_via == nil
+        ""
+      else
+        req.identity.acting_via.origin.to_s
+      end
+    end
+
+    get '/may_read' do
+      req.identity.may?(:read) ? "yes" : "no"
+    end
+
+    get '/may_post_summary' do
+      req.identity.may?(:post_summary) ? "yes" : "no"
+    end
+
+    get '/may_write' do
+      req.identity.may?(:write) ? "yes" : "no"
+    end
+  RB
+
+  # ---- helpers ----
+
+  def consent_body(principal_id, client_id, caps)
+    "{" +
+      "\"principal_id\":\"" + principal_id + "\"," +
+      "\"client_id\":\"" + client_id + "\"," +
+      "\"caps\":\"" + caps + "\"}"
+  end
+
+  def token_body(code, client_id)
+    "{\"code\":\"" + code + "\",\"client_id\":\"" + client_id + "\"}"
+  end
+
+  def consent(principal_id, client_id, caps)
+    post("/consent", consent_body(principal_id, client_id, caps)).body
+  end
+
+  def exchange(code, client_id)
+    post("/token", token_body(code, client_id)).body
+  end
+
+  def authed(path, token)
+    get(path, "Authorization" => "Bearer " + token)
+  end
+
+  # ---- client registry ----
+
+  def test_registered_client_lookup
+    assert_equal "Summarizer Bot|https://bot.example/oauth/callback",
+      get("/client/summarizer-bot").body
+  end
+
+  def test_unregistered_client_lookup
+    assert_equal "missing", get("/client/never-registered").body
+  end
+
+  # ---- happy path: issue + exchange ----
+
+  def test_issue_code_returns_nonempty
+    code = consent("user:42", "summarizer-bot", "read")
+    refute_equal "", code
+    # base64url, 24 random bytes -> ~32 chars
+    assert code.length >= 28, "code too short: #{code.inspect}"
+  end
+
+  def test_exchange_code_returns_jwt
+    code = consent("user:42", "summarizer-bot", "read,post_summary")
+    token = exchange(code, "summarizer-bot")
+    refute_equal "", token
+    # JWT shape: three dot-separated segments.
+    assert_equal 2, token.count("."), "token: #{token.inspect}"
+  end
+
+  def test_exchanged_jwt_authenticates_as_agent
+    code = consent("user:42", "summarizer-bot", "read,post_summary")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "agent:summarizer-bot/user:42",
+      authed("/whoami", token).body
+  end
+
+  def test_exchanged_jwt_marked_agent
+    code = consent("user:42", "summarizer-bot", "read")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "yes", authed("/is_agent", token).body
+  end
+
+  def test_exchanged_jwt_carries_agent_id
+    code = consent("user:42", "summarizer-bot", "read")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "summarizer-bot", authed("/agent_id", token).body
+  end
+
+  def test_exchanged_jwt_origin_is_oauth_grant
+    code = consent("user:42", "summarizer-bot", "read")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "oauth_grant", authed("/origin", token).body
+  end
+
+  def test_exchanged_jwt_caps_granted
+    code = consent("user:42", "summarizer-bot", "read,post_summary")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "yes", authed("/may_read", token).body
+    assert_equal "yes", authed("/may_post_summary", token).body
+  end
+
+  def test_exchanged_jwt_caps_not_in_grant_are_rejected
+    # User granted only :read. The JWT should NOT carry :write.
+    code = consent("user:42", "summarizer-bot", "read")
+    token = exchange(code, "summarizer-bot")
+    assert_equal "no", authed("/may_write", token).body
+  end
+
+  # ---- rejections ----
+
+  def test_exchange_unknown_code_returns_empty
+    assert_equal "", exchange("never-issued-code", "summarizer-bot")
+  end
+
+  def test_exchange_wrong_client_id_returns_empty
+    code = consent("user:42", "summarizer-bot", "read")
+    # Try to redeem against a different client_id.
+    assert_equal "", exchange(code, "different-bot")
+  end
+
+  def test_exchange_is_single_use
+    code = consent("user:42", "summarizer-bot", "read")
+    # First exchange succeeds.
+    refute_equal "", exchange(code, "summarizer-bot")
+    # Second exchange of the same code fails.
+    assert_equal "", exchange(code, "summarizer-bot")
+  end
+end


### PR DESCRIPTION
OAuth2-shaped authorization-code issuance. tep acts as the authorization server here — registering bot/agent clients, minting short-lived codes after consent, exchanging codes for JWTs.

The issued JWT plugs straight into `Tep::AuthBearerToken`'s wire format. **No new token schema** — same `delegate` pipe-encoded field, same downstream `req.identity` surface. Bots that complete the OAuth flow then use the resulting token exactly like a direct-issued bearer token.

## Public surface

```ruby
# Boot:
Tep::AuthBearerToken.set_secret(ENV["JWT_SECRET"])
Tep::Auth.install!

Tep::AuthOAuth2.register_client(
  "summarizer-bot",
  "Summarizer Bot",
  "https://bot.example/oauth/callback",
  [:read, :post_summary])

# After your /authorize handler shows consent UI and the user clicks Allow:
code = Tep::AuthOAuth2.issue_code(
  req.identity.principal_id,
  "summarizer-bot",
  "read,post_summary",
  0)   # 0 = DEFAULT_CODE_TTL (600s)
# ... redirect to client.redirect_uri + "?code=" + code ...

# Bot's /token handler redeems:
token = Tep::AuthOAuth2.exchange_code(code, "summarizer-bot", 0)
# 0 = DEFAULT_TOKEN_TTL (3600s)
# Bot uses `Authorization: Bearer <token>` from here on.
```

## Resulting identity (from BearerToken on the exchanged JWT)

```ruby
req.identity.subject              # "agent:summarizer-bot/user:42"
req.identity.agent?               # true
req.identity.acting_via.agent_id  # "summarizer-bot"
req.identity.acting_via.origin    # :oauth_grant
req.identity.may?(:post_summary)  # true (granted at consent time)
req.identity.may?(:write)         # false (not granted)
```

## What's NOT in this chunk

- **HTTP routes for `/authorize` and `/token`** — app wires its own. The app's `/authorize` handler is where consent UI lives and where the issued code becomes a URL redirect.
- **Consent UI rendering** — app's responsibility. Tep provides the issuance primitives; the user-facing 'X (an agent) wants to act on your behalf' page is app HTML.
- **Cross-worker code storage** — per-process registry only. Prefork apps must handle the code-issuance + code-redeem sequence on the same worker (typically invisible: consent submit and immediate redirect-then-redeem flow through the same worker).
- **Refresh tokens** — post-v1.

## Spinel notes

Five new top-level type-seed calls at the bottom of `lib/tep.rb` cover the `Tep::AuthOAuth2` cmeths (`register_client`, `unregister_client`, `find_client`, `issue_code`, `exchange_code`). Without these, compile units that don't otherwise touch OAuth2 (e.g. `test/test_llm.rb`) default the cmeth params to `mrb_int` and the `AuthOAuth2Client` / `AuthOAuth2Code` constructor calls inside the method bodies mismatch the typed ivars. Same pattern as the existing seeding for Session / Streamer / SQLite.

`Tep::App` gains two `PtrArray` slots (`auth_oauth2_clients`, `auth_oauth2_codes`), each type-seeded via the `[Tep::AuthX.new(...)].delete_at(0)` idiom that exists elsewhere in the codebase for `sched_fibers`.

## Validation

- `test/test_auth_oauth2.rb`: 13 runs / 17 assertions / 0 failures. Covers client-registry lookup, code issuance + exchange happy path, downstream Bearer-auth on the exchanged JWT (agent? / agent_id / origin / caps), unknown-code rejection, wrong-client_id rejection, single-use enforcement.
- Full suite: 296 / 585 green. 7 errors all in pre-existing Scheduler/Parallel zones (matz/spinel#641 + #643) — no regressions outside the known-broken set.

## Battery 1 progress

| Chunk | Status |
|---|---|
| 1.1 Identity types | shipped in v0.6.0 |
| 1.2 BearerToken provider | shipped in v0.6.0 |
| 1.3 SessionCookie provider | shipped (post-v0.6.0) |
| **1.4 OAuth2 issuance** | **this PR** |
| Capability registry + extension hook | small follow-up |

After merge, Battery 1 is feature-complete. Apps can authenticate humans via session cookies, agents via direct bearer tokens, and bots via delegated OAuth2 grants — all through one unified `req.identity` surface where the same handler code reads identity the same way regardless of provider.