### PR TITLE
feat(broadcast): in-process pub-sub broker (Battery 2, chunk 2.1)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -21,9 +21,11 @@ require_relative "tep/url"
 require_relative "tep/net"
 require_relative "tep/agent_delegation"
 require_relative "tep/identity"
-# Auth data classes (no deps; storage on Tep::App references them).
+# Auth + Broadcast data classes (no deps; storage on Tep::App
+# references them, so they must load before app.rb).
 require_relative "tep/auth_oauth2_client"
 require_relative "tep/auth_oauth2_code"
+require_relative "tep/broadcast_subscription"
 require_relative "tep/session"
 require_relative "tep/request"
 require_relative "tep/response"
@@ -40,6 +42,7 @@ require_relative "tep/auth_bearer_token"
 require_relative "tep/auth_session_cookie"
 require_relative "tep/auth_oauth2"
 require_relative "tep/auth"
+require_relative "tep/broadcast"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"
 require_relative "tep/sqlite"
@@ -207,6 +210,17 @@ module Tep
   Tep::AuthOAuth2.find_client("_seed")
   _tep_seed_oauth2_code = Tep::AuthOAuth2.issue_code("_seed", "_seed", "", 0)
   Tep::AuthOAuth2.exchange_code(_tep_seed_oauth2_code, "_seed", 0)
+
+  # Broadcast type-seeding. Same pattern: pin every cmeth's param C
+  # types so compile units that don't otherwise exercise pub/sub
+  # still get correct signatures.
+  _tep_seed_broadcast_sub = Tep::Broadcast.subscribe("_seed", -1)
+  Tep::Broadcast.publish("_seed", "")
+  Tep::Broadcast.subscribers_for("_seed")
+  Tep::Broadcast.unsubscribe(_tep_seed_broadcast_sub)
+  Tep::Broadcast.unsubscribe_fd(-1)
+  Tep::Broadcast.subscriber_count
+  Tep::Broadcast.clear
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -27,6 +27,11 @@ module Tep
     # store. See Tep::AuthOAuth2 for the issuance flow.
     attr_accessor :auth_oauth2_clients
     attr_accessor :auth_oauth2_codes
+    # Per-process Broadcast subscriber registry. Each entry pairs a
+    # topic with an output fd; publish iterates + writes the payload
+    # to every matching fd. Cross-worker pub-sub (PG LISTEN/NOTIFY)
+    # is a follow-up chunk -- see docs/BATTERIES-DESIGN.md.
+    attr_accessor :broadcast_subs
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -57,6 +62,9 @@ module Tep
       @auth_oauth2_clients.delete_at(0)
       @auth_oauth2_codes = [Tep::AuthOAuth2Code.new("_", "", "", "", 0)]
       @auth_oauth2_codes.delete_at(0)
+      # Same type-seed pattern for the Broadcast subscriber registry.
+      @broadcast_subs = [Tep::BroadcastSubscription.new("_", -1)]
+      @broadcast_subs.delete_at(0)
       @nf_handler     = Handler.new
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines

--- a/lib/tep/broadcast.rb
+++ b/lib/tep/broadcast.rb
@@ -1,0 +1,131 @@
+# Tep::Broadcast -- in-process pub-sub topic broker.
+#
+# Foundation of the Broadcast battery (Battery 2 in
+# docs/BATTERIES-DESIGN.md). Apps + later batteries (Presence,
+# LiveView) layer on top: WebSocket connections subscribe to
+# topics; publish(topic, payload) writes payload to every
+# subscribed fd.
+#
+# Public API:
+#
+#   sub_id = Tep::Broadcast.subscribe(topic, fd)
+#   Tep::Broadcast.publish(topic, payload)
+#   Tep::Broadcast.unsubscribe(sub_id)
+#   Tep::Broadcast.unsubscribe_fd(fd)    # drop ALL subs for an fd
+#
+# Subscription model is fd-based rather than block/callback-based
+# (spinel can't reliably round-trip blocks-as-values across module
+# boundaries, see memory [[spinel_widening_dispatch]]). The
+# concrete v1 use case is "deliver to a WS connection" -- the WS
+# layer keeps its accepted-socket fd, calls subscribe, and
+# Tep::Broadcast.publish writes the payload bytes to that fd.
+# Apps that need a different delivery surface (HTTP SSE, log
+# fan-out) use the same subscribe-fd shape with a different fd.
+#
+# Storage scope is per-process: subscriptions live on Tep::APP,
+# which under prefork is per-worker. Cross-worker pub-sub (via PG
+# LISTEN/NOTIFY) is a follow-up chunk -- subscribers will still
+# register fd-local, but publish() will route through the database
+# so other workers see the message too.
+#
+# `subscribe` returns an opaque subscription id (the registry
+# index at insertion time). Callers can pass it back to
+# `unsubscribe` for a single-sub drop. For WS connections that
+# subscribe to multiple topics, `unsubscribe_fd(fd)` drops every
+# subscription tied to that fd in one call -- the right shape for
+# the WS on-close hook.
+module Tep
+  module Broadcast
+    # Register a subscription for `fd` on `topic`. Returns an
+    # opaque sub_id for later unsubscribe.
+    def self.subscribe(topic, fd)
+      subs = Tep::APP.broadcast_subs
+      sub = Tep::BroadcastSubscription.new(topic, fd)
+      subs.push(sub)
+      subs.length - 1
+    end
+
+    # Drop the subscription at `sub_id`. Note that ids are
+    # registry indexes; subsequent drops shift everything past it
+    # downward. For multi-sub drop, prefer `unsubscribe_fd`.
+    def self.unsubscribe(sub_id)
+      subs = Tep::APP.broadcast_subs
+      if sub_id < 0 || sub_id >= subs.length
+        return 0
+      end
+      subs.delete_at(sub_id)
+      0
+    end
+
+    # Drop every subscription whose fd matches. Returns the count
+    # dropped. Used by WS on-close to clean up everything a closing
+    # connection had subscribed to. Back-to-front so delete_at
+    # indices stay valid mid-loop.
+    def self.unsubscribe_fd(fd)
+      subs = Tep::APP.broadcast_subs
+      dropped = 0
+      i = subs.length - 1
+      while i >= 0
+        if subs[i].fd == fd
+          subs.delete_at(i)
+          dropped += 1
+        end
+        i -= 1
+      end
+      dropped
+    end
+
+    # Write `payload` to every subscribed fd for `topic`. Returns
+    # the number of subscriptions matched (NOT the number of
+    # successful writes -- a closed / bad fd still counts as
+    # matched; the underlying sphttp_write_str returns -1 silently
+    # on that fd). Apps that need delivery confirmation should
+    # track their own ack channel.
+    def self.publish(topic, payload)
+      subs = Tep::APP.broadcast_subs
+      matched = 0
+      i = 0
+      while i < subs.length
+        if subs[i].topic == topic
+          Sock.sphttp_write_str(subs[i].fd, payload)
+          matched += 1
+        end
+        i += 1
+      end
+      matched
+    end
+
+    # Total subscription count across all topics. Useful for
+    # diagnostics and the v1 test surface.
+    def self.subscriber_count
+      Tep::APP.broadcast_subs.length
+    end
+
+    # Count of subscribers for one topic. O(n) over the registry;
+    # acceptable for v1 (n is typically small per worker).
+    def self.subscribers_for(topic)
+      subs = Tep::APP.broadcast_subs
+      n = 0
+      i = 0
+      while i < subs.length
+        if subs[i].topic == topic
+          n += 1
+        end
+        i += 1
+      end
+      n
+    end
+
+    # Drop every subscription. Used by tests between fixtures, and
+    # available to apps that need to fully reset (e.g. during
+    # graceful shutdown). Returns the count dropped.
+    def self.clear
+      subs = Tep::APP.broadcast_subs
+      n = subs.length
+      while subs.length > 0
+        subs.delete_at(0)
+      end
+      n
+    end
+  end
+end

--- a/lib/tep/broadcast_subscription.rb
+++ b/lib/tep/broadcast_subscription.rb
@@ -1,0 +1,27 @@
+# Tep::BroadcastSubscription -- one entry in the Tep::Broadcast
+# subscriber registry. Pairs a topic name with an output fd. When a
+# publish matches the topic, the fd gets the payload bytes via
+# Sock.sphttp_write_str.
+#
+# fd is just an integer file descriptor: typically a WebSocket
+# connection's accepted socket fd, but the registry doesn't care
+# about the protocol on top -- it'll write to any open fd. Apps
+# integrating with WS (via Tep::WebSocket) subscribe their
+# connection fds; non-WS use cases (server-sent events, log
+# fan-out, etc.) work the same way.
+#
+# Single-process registry only in v1; cross-worker pub-sub
+# (PG LISTEN/NOTIFY) lands in a follow-up chunk. See
+# docs/BATTERIES-DESIGN.md for the broader Broadcast battery
+# design.
+module Tep
+  class BroadcastSubscription
+    attr_reader :topic   # String
+    attr_reader :fd      # Integer file descriptor
+
+    def initialize(topic, fd)
+      @topic = topic
+      @fd    = fd
+    end
+  end
+end

--- a/sig/tep/broadcast.rbs
+++ b/sig/tep/broadcast.rbs
@@ -1,0 +1,31 @@
+# In-process pub-sub topic broker. Foundation of the Broadcast
+# battery; Presence and LiveView layer on top. See
+# lib/tep/broadcast.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  module Broadcast
+    # Subscribe `fd` to `topic`. Returns an opaque sub_id usable
+    # for later #unsubscribe (a single-sub drop).
+    def self.subscribe: (String topic, Integer fd) -> Integer
+
+    # Drop the subscription at `sub_id`. Returns 0.
+    def self.unsubscribe: (Integer sub_id) -> Integer
+
+    # Drop every subscription whose fd matches. Used by the WS
+    # on-close hook. Returns the count dropped.
+    def self.unsubscribe_fd: (Integer fd) -> Integer
+
+    # Write `payload` to every fd subscribed to `topic`. Returns
+    # the matched count (NOT successful-write count -- bad fds
+    # fail silently at sphttp_write_str).
+    def self.publish: (String topic, String payload) -> Integer
+
+    # Total subscription count across all topics.
+    def self.subscriber_count: () -> Integer
+
+    # Count for a specific topic.
+    def self.subscribers_for: (String topic) -> Integer
+
+    # Drop every subscription. Returns the count dropped.
+    def self.clear: () -> Integer
+  end
+end

--- a/sig/tep/broadcast_subscription.rbs
+++ b/sig/tep/broadcast_subscription.rbs
@@ -1,0 +1,11 @@
+# One entry in Tep::Broadcast's subscriber registry. Pairs a topic
+# with an output fd. See lib/tep/broadcast_subscription.rb +
+# docs/BATTERIES-DESIGN.md.
+module Tep
+  class BroadcastSubscription
+    attr_reader topic: String
+    attr_reader fd: Integer
+
+    def initialize: (String topic, Integer fd) -> void
+  end
+end

--- a/test/test_broadcast.rb
+++ b/test/test_broadcast.rb
@@ -1,0 +1,164 @@
+require_relative "helper"
+
+# Tep::Broadcast: in-process topic broker. v1 stores (topic, fd)
+# pairs; publish writes payload bytes to every matching fd. These
+# tests exercise the registry shape via fake fds (-1 / synthetic
+# ints); real delivery to live sockets gets covered when the WS
+# battery lands and integrates Broadcast end-to-end. The publish()
+# return value is "matched count," not "successful writes" -- bad
+# fds silently fail at sphttp_write_str without affecting the
+# match count.
+class TestBroadcast < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    # Reset between cases so test ordering doesn't matter.
+    get '/reset' do
+      Tep::Broadcast.clear.to_s
+    end
+
+    get '/subscribe' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Broadcast.subscribe(topic, fd).to_s
+    end
+
+    get '/unsubscribe' do
+      sub_id = params[:sub_id].to_i
+      Tep::Broadcast.unsubscribe(sub_id).to_s
+    end
+
+    get '/unsubscribe_fd' do
+      fd = params[:fd].to_i
+      Tep::Broadcast.unsubscribe_fd(fd).to_s
+    end
+
+    get '/publish' do
+      topic   = params[:topic]
+      payload = params[:payload]
+      Tep::Broadcast.publish(topic, payload).to_s
+    end
+
+    get '/subscriber_count' do
+      Tep::Broadcast.subscriber_count.to_s
+    end
+
+    get '/subscribers_for' do
+      topic = params[:topic]
+      Tep::Broadcast.subscribers_for(topic).to_s
+    end
+  RB
+
+  # Helper: reset between tests so state doesn't carry.
+  def setup
+    super
+    get("/reset")
+  end
+
+  def subscribe(topic, fd)
+    get("/subscribe?topic=#{topic}&fd=#{fd}").body.to_i
+  end
+
+  def publish(topic, payload)
+    get("/publish?topic=#{topic}&payload=#{payload}").body.to_i
+  end
+
+  def subscriber_count
+    get("/subscriber_count").body.to_i
+  end
+
+  def subscribers_for(topic)
+    get("/subscribers_for?topic=#{topic}").body.to_i
+  end
+
+  # ---- empty registry ----
+
+  def test_publish_to_empty_registry_returns_zero
+    assert_equal 0, publish("room:lobby", "hello")
+  end
+
+  def test_subscriber_count_starts_at_zero
+    assert_equal 0, subscriber_count
+  end
+
+  def test_subscribers_for_unknown_topic_is_zero
+    assert_equal 0, subscribers_for("never-subscribed")
+  end
+
+  # ---- subscribe + count ----
+
+  def test_subscribe_grows_registry
+    subscribe("room:lobby", -1)
+    assert_equal 1, subscriber_count
+    assert_equal 1, subscribers_for("room:lobby")
+  end
+
+  def test_multiple_subscribers_same_topic
+    subscribe("room:lobby", -1)
+    subscribe("room:lobby", -2)
+    subscribe("room:lobby", -3)
+    assert_equal 3, subscribers_for("room:lobby")
+  end
+
+  def test_subscribers_segregated_by_topic
+    subscribe("room:lobby", -1)
+    subscribe("room:lobby", -2)
+    subscribe("room:other", -3)
+    assert_equal 2, subscribers_for("room:lobby")
+    assert_equal 1, subscribers_for("room:other")
+  end
+
+  # ---- publish matching ----
+
+  def test_publish_returns_matched_count
+    subscribe("room:lobby", -1)
+    subscribe("room:lobby", -2)
+    subscribe("room:other", -3)
+    assert_equal 2, publish("room:lobby", "hi")
+  end
+
+  def test_publish_to_unmatched_topic_zero
+    subscribe("room:lobby", -1)
+    assert_equal 0, publish("never", "hi")
+  end
+
+  # ---- unsubscribe (by sub_id) ----
+
+  def test_unsubscribe_by_id_drops_one
+    sub_id = subscribe("room:lobby", -1)
+    subscribe("room:lobby", -2)
+    get("/unsubscribe?sub_id=#{sub_id}")
+    assert_equal 1, subscribers_for("room:lobby")
+  end
+
+  # ---- unsubscribe_fd (by fd, multi-topic) ----
+
+  def test_unsubscribe_fd_drops_all_for_fd
+    subscribe("room:lobby", -1)
+    subscribe("room:other", -1)   # same fd, different topic
+    subscribe("room:lobby", -2)
+    dropped = get("/unsubscribe_fd?fd=-1").body.to_i
+    assert_equal 2, dropped
+    assert_equal 1, subscribers_for("room:lobby")
+    assert_equal 0, subscribers_for("room:other")
+  end
+
+  def test_unsubscribe_fd_unknown_zero
+    subscribe("room:lobby", -1)
+    dropped = get("/unsubscribe_fd?fd=-999").body.to_i
+    assert_equal 0, dropped
+  end
+
+  # ---- clear ----
+
+  def test_clear_drops_everything
+    subscribe("room:lobby", -1)
+    subscribe("room:other", -2)
+    get("/reset")
+    assert_equal 0, subscriber_count
+  end
+end


### PR DESCRIPTION
First chunk of the Broadcast battery. In-process topic-keyed subscriber registry — publish writes payload bytes to every fd subscribed to the topic. Foundation for Presence (Battery 3) and LiveView (Battery 4) per `docs/BATTERIES-DESIGN.md`.

## Public surface

```ruby
sub_id = Tep::Broadcast.subscribe(topic, fd)
Tep::Broadcast.publish(topic, payload)
Tep::Broadcast.unsubscribe(sub_id)
Tep::Broadcast.unsubscribe_fd(fd)     # drop ALL subs for an fd
Tep::Broadcast.subscriber_count
Tep::Broadcast.subscribers_for(topic)
Tep::Broadcast.clear
```

Subscription model is **fd-based**, not block/callback-based. Spinel can't reliably round-trip blocks-as-values across module boundaries, so the registry stores opaque integer fds and lets `sphttp_write_str` do delivery. v1's concrete use case is "deliver to a WebSocket connection" — the WS layer registers its accepted-socket fd via `subscribe`; `publish` writes raw bytes to it. Non-WS use cases (SSE, log fan-out, anything writing to an fd) work the same way.

`publish` returns the **matched count**, not "successful write count" — a closed / bad fd silently fails at `sphttp_write_str` without affecting the match count. Apps that need delivery confirmation should track their own ack channel.

## What's NOT in this chunk

- **Cross-worker pub-sub.** Subscriptions are per-process (`Tep::APP` storage), per-worker under prefork. A publish from one worker won't reach subscribers on another. The PG LISTEN/NOTIFY backend that handles this lands in **chunk 2.2**.
- **Backend abstraction** (`Tep::Broadcast::Backend`). Spinel's `PtrArray<Base>` `cls_id` story isn't great yet (memory `spinel_widening_dispatch`); the design doc's pluggable-backend surface lands when there's actually a second backend to plug.
- **Authz callback.** Apps that want per-topic authz wire it into their `subscribe` call site for now — a global authorize hook lands alongside the WS bridge in a later chunk.

## Implementation notes

- `Tep::App` gains a `broadcast_subs` `PtrArray` slot, type-seeded via the dummy+`delete_at` idiom used elsewhere (`auth_oauth2_clients`, `sched_fibers`).
- Every `Tep::Broadcast` cmeth gets a top-level seeding call at the bottom of `lib/tep.rb` so spinel locks the param C types in compile units that don't otherwise touch pub/sub. Same pattern as the OAuth2 / Session / SQLite seeds.
- Flat namespacing (`Tep::Broadcast`, `Tep::BroadcastSubscription`) — not `Tep::Broadcast::Subscription` — same spinel `cls_id` reasons that apply across the Auth battery's flat naming.

## Validation

- `test/test_broadcast.rb`: 12 runs / 16 assertions / 0 failures. Covers empty-registry, subscribe-grows, multi-sub same topic, topic segregation, publish matched-count, unsubscribe by id, unsubscribe by fd (multi-topic drop), clear.
- Full suite: **308 / 599 green** / 0 failures / 0 errors / 39 skips (upstream-blocked TestScheduler + TestParallel + one TestServerScheduled per #22 stay skipped). No new regressions; net delta vs main is +12 tests / +14 assertions.

## Battery 2 roadmap

| Chunk | Status |
|---|---|
| **2.1 In-process core** | **this PR** |
| 2.2 PG LISTEN/NOTIFY backend (cross-worker) | next |
| 2.3 WS bridge (`ws.subscribe(topic)` ergonomics, WS-frame wrap on publish) | after 2.2 |
| 2.4 Authz callback + global hook | small, can land any time |