### PR TITLE
feat(broadcast): PG LISTEN/NOTIFY backend (Battery 2, chunk 2.2)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -176,6 +176,13 @@ module Tep
   APP.set_after(Filter.new)
   APP.set_auth_filter(Filter.new)
   APP.set_auth_bearer_secret("")
+  # Broadcast PG-backend setter seeds. enable_pg_backend reaches
+  # these via set_broadcast_pg_conn / _channel / _enabled when a
+  # connect succeeds; the empty-conninfo seed below short-circuits
+  # before getting there, so we exercise the setters directly.
+  APP.set_broadcast_pg_enabled(0)
+  APP.set_broadcast_pg_channel("")
+  APP.set_broadcast_pg_conn(PG::Connection.new(""))
   APP.set_not_found(Handler.new)
   # Type-seeding: methods that may not be called by a given user app
   # would otherwise default their param C types to mrb_int and
@@ -221,6 +228,20 @@ module Tep
   Tep::Broadcast.unsubscribe_fd(-1)
   Tep::Broadcast.subscriber_count
   Tep::Broadcast.clear
+
+  # Broadcast PG-backend seeds. enable_pg_backend("", "") tries to
+  # open a PG connection -- empty conninfo behaves the same as the
+  # PG::Connection.new("") seed above: connect fails, returns -1.
+  # The point is to pin parameter types on every cmeth.
+  Tep::Broadcast.enable_pg_backend("", "")
+  Tep::Broadcast.poll_pg_once(0)
+  Tep::Broadcast.disable_pg_backend
+  Tep::Broadcast.encode_wire("", "")
+  Tep::Broadcast.deliver_wire_local("0:")
+  Tep::Broadcast.publish_local_only("_seed", "")
+  # The new PG::Connection LISTEN/NOTIFY method seeds live further
+  # down with the rest of the PG seeds, where _tep_seed_pg_conn is
+  # already defined.
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct
@@ -277,6 +298,13 @@ module Tep
   # non-scheduled context (the shim's PQconnectStart-then-FAILED
   # path), which is type-equivalent to the success path.
   PG::Connection.async_connect("")
+  # LISTEN / NOTIFY surface (Tep::Broadcast PG backend lands here).
+  _tep_seed_pg_conn.listen("_seed")
+  _tep_seed_pg_conn.unlisten("_seed")
+  _tep_seed_pg_conn.notify("_seed", "")
+  _tep_seed_pg_conn.poll_notification(0)
+  _tep_seed_pg_conn.last_notify_channel
+  _tep_seed_pg_conn.last_notify_payload
   _tep_seed_pg_res = PG::Result.new(-1)
   _tep_seed_pg_res.ntuples
   _tep_seed_pg_res.nfields

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -29,9 +29,16 @@ module Tep
     attr_accessor :auth_oauth2_codes
     # Per-process Broadcast subscriber registry. Each entry pairs a
     # topic with an output fd; publish iterates + writes the payload
-    # to every matching fd. Cross-worker pub-sub (PG LISTEN/NOTIFY)
-    # is a follow-up chunk -- see docs/BATTERIES-DESIGN.md.
+    # to every matching fd.
     attr_accessor :broadcast_subs
+    # PG-backed cross-worker pub/sub state. `broadcast_pg_enabled`
+    # is 0 when off, 1 when on. The dedicated LISTEN connection
+    # lives in `broadcast_pg_conn`; channel name in
+    # `broadcast_pg_channel`. Configured by
+    # Tep::Broadcast.enable_pg_backend.
+    attr_accessor :broadcast_pg_enabled
+    attr_accessor :broadcast_pg_channel
+    attr_accessor :broadcast_pg_conn
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -65,6 +72,12 @@ module Tep
       # Same type-seed pattern for the Broadcast subscriber registry.
       @broadcast_subs = [Tep::BroadcastSubscription.new("_", -1)]
       @broadcast_subs.delete_at(0)
+      @broadcast_pg_enabled = 0
+      @broadcast_pg_channel = ""
+      # Seed broadcast_pg_conn later via lib/tep.rb's setter seed
+      # (APP.set_broadcast_pg_conn(PG::Connection.new(""))) -- module
+      # load order means PG::Connection isn't safely callable from
+      # App#initialize when this is loaded before pg.rb's full surface.
       @nf_handler     = Handler.new
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines
@@ -115,6 +128,9 @@ module Tep
     def set_after(f);             @after_filter = f; end
     def set_auth_filter(f);       @auth_filter = f; end
     def set_auth_bearer_secret(s); @auth_bearer_secret = s; end
+    def set_broadcast_pg_enabled(v); @broadcast_pg_enabled = v; end
+    def set_broadcast_pg_channel(s); @broadcast_pg_channel = s; end
+    def set_broadcast_pg_conn(c);    @broadcast_pg_conn    = c; end
     def set_not_found(h);         @nf_handler = h; end
 
     def dispatch(req, res)

--- a/lib/tep/broadcast.rb
+++ b/lib/tep/broadcast.rb
@@ -81,16 +81,18 @@ module Tep
     # matched; the underlying sphttp_write_str returns -1 silently
     # on that fd). Apps that need delivery confirmation should
     # track their own ack channel.
+    #
+    # When the PG backend is enabled (Tep::Broadcast.enable_pg_backend),
+    # publish ALSO NOTIFY's the configured channel so other workers
+    # subscribed via poll_pg_once can deliver to their local
+    # subscribers. Match count returned is the LOCAL match count;
+    # remote deliveries are best-effort and not counted here.
     def self.publish(topic, payload)
-      subs = Tep::APP.broadcast_subs
-      matched = 0
-      i = 0
-      while i < subs.length
-        if subs[i].topic == topic
-          Sock.sphttp_write_str(subs[i].fd, payload)
-          matched += 1
-        end
-        i += 1
+      matched = Tep::Broadcast.publish_local_only(topic, payload)
+      if Tep::APP.broadcast_pg_enabled != 0
+        wire = Tep::Broadcast.encode_wire(topic, payload)
+        Tep::APP.broadcast_pg_conn.notify(
+          Tep::APP.broadcast_pg_channel, wire)
       end
       matched
     end
@@ -126,6 +128,102 @@ module Tep
         subs.delete_at(0)
       end
       n
+    end
+
+    # ---- PG backend (cross-worker pub/sub) ----
+    #
+    # Opens a dedicated PG connection and issues `LISTEN <channel>`.
+    # Subsequent publishes NOTIFY this channel too -- other workers
+    # subscribed to the same channel can receive the message via
+    # poll_pg_once.
+    #
+    # `conninfo` is the libpq connect string. `channel` must be a
+    # safe SQL identifier (e.g. "tep_broadcast") since it lands
+    # inside a LISTEN / NOTIFY command unescaped.
+    #
+    # Returns 0 on success, -1 on connection or LISTEN failure.
+    def self.enable_pg_backend(conninfo, channel)
+      conn = PG::Connection.new(conninfo)
+      if conn.pgh < 0
+        return -1
+      end
+      if conn.listen(channel) < 0
+        return -1
+      end
+      Tep::APP.set_broadcast_pg_conn(conn)
+      Tep::APP.set_broadcast_pg_channel(channel)
+      Tep::APP.set_broadcast_pg_enabled(1)
+      0
+    end
+
+    def self.disable_pg_backend
+      if Tep::APP.broadcast_pg_enabled == 0
+        return 0
+      end
+      Tep::APP.broadcast_pg_conn.unlisten(Tep::APP.broadcast_pg_channel)
+      Tep::APP.broadcast_pg_conn.finish
+      Tep::APP.set_broadcast_pg_enabled(0)
+      0
+    end
+
+    # Process one notification from the PG channel: parse the wire
+    # format, dispatch to local subscribers as if `publish` had
+    # been called locally (but WITHOUT re-NOTIFYing -- that would
+    # loop). Returns 1 if a notification was processed, 0 on
+    # timeout, -1 on connection error or unenabled backend.
+    def self.poll_pg_once(timeout_ms)
+      if Tep::APP.broadcast_pg_enabled == 0
+        return -1
+      end
+      r = Tep::APP.broadcast_pg_conn.poll_notification(timeout_ms)
+      if r != 1
+        return r
+      end
+      wire = Tep::APP.broadcast_pg_conn.last_notify_payload
+      Tep::Broadcast.deliver_wire_local(wire)
+      1
+    end
+
+    # Wire format: "<topic_byte_length>:<topic><payload>".
+    # Length-prefixed so topics and payloads with arbitrary chars
+    # (commas, colons, embedded quotes, newlines) round-trip
+    # unambiguously. Encoded by `publish` when the PG backend is
+    # enabled; decoded by `deliver_wire_local`.
+    def self.encode_wire(topic, payload)
+      topic.length.to_s + ":" + topic + payload
+    end
+
+    def self.deliver_wire_local(wire)
+      colon = Tep.str_find(wire, ":", 0)
+      if colon <= 0
+        return -1
+      end
+      len_str = wire[0, colon]
+      tlen    = len_str.to_i
+      if tlen < 0 || colon + 1 + tlen > wire.length
+        return -1
+      end
+      topic   = wire[colon + 1, tlen]
+      payload = wire[colon + 1 + tlen, wire.length - colon - 1 - tlen]
+      Tep::Broadcast.publish_local_only(topic, payload)
+    end
+
+    # Same fan-out as #publish but skips the PG NOTIFY step. Used
+    # internally by poll_pg_once when delivering a cross-worker
+    # message that already came in via PG -- re-NOTIFY would cause
+    # an infinite loop.
+    def self.publish_local_only(topic, payload)
+      subs = Tep::APP.broadcast_subs
+      matched = 0
+      i = 0
+      while i < subs.length
+        if subs[i].topic == topic
+          Sock.sphttp_write_str(subs[i].fd, payload)
+          matched += 1
+        end
+        i += 1
+      end
+      matched
     end
   end
 end

--- a/lib/tep/pg.rb
+++ b/lib/tep/pg.rb
@@ -97,6 +97,17 @@ module Pg
   ffi_func :tep_pg_is_busy,                [:int],             :int
   ffi_func :tep_pg_get_result,             [:int],             :int
 
+  # LISTEN / NOTIFY. Used by Tep::Broadcast's PG backend
+  # (Battery 2 chunk 2.2) for cross-worker pub/sub. Channel names
+  # are SQL identifiers (caller's responsibility to keep safe);
+  # payloads are escaped server-side via PQescapeLiteral.
+  ffi_func :tep_pg_listen,                 [:int, :str],       :int
+  ffi_func :tep_pg_unlisten,               [:int, :str],       :int
+  ffi_func :tep_pg_notify,                 [:int, :str, :str], :int
+  ffi_func :tep_pg_poll_notification,      [:int, :int],       :int
+  ffi_func :tep_pg_notify_channel,         [],                 :str
+  ffi_func :tep_pg_notify_payload,         [],                 :str
+
   # Version
   ffi_func :tep_pg_libpq_version,          [],                 :str
 end
@@ -247,6 +258,44 @@ module PG
 
     def error_message
       @pgh < 0 ? "" : Pg.tep_pg_error_message(@pgh)
+    end
+
+    # LISTEN / NOTIFY (Battery 2 chunk 2.2). Used by
+    # Tep::Broadcast's PG backend for cross-worker pub/sub.
+    # Channel names must be safe SQL identifiers (no caller-
+    # controlled interpolation -- use a hard-coded constant).
+    # Payload max size is 8000 bytes per PG default.
+    def listen(channel)
+      return -1 if @pgh < 0
+      Pg.tep_pg_listen(@pgh, channel)
+    end
+
+    def unlisten(channel)
+      return -1 if @pgh < 0
+      Pg.tep_pg_unlisten(@pgh, channel)
+    end
+
+    def notify(channel, payload)
+      return -1 if @pgh < 0
+      Pg.tep_pg_notify(@pgh, channel, payload)
+    end
+
+    # Block up to `timeout_ms` waiting for one notification on the
+    # connection. Returns 1 on receipt (caller then reads
+    # #last_notify_channel + #last_notify_payload), 0 on timeout,
+    # -1 on connection error. Connection must already be in LISTEN
+    # mode for the channel of interest.
+    def poll_notification(timeout_ms)
+      return -1 if @pgh < 0
+      Pg.tep_pg_poll_notification(@pgh, timeout_ms)
+    end
+
+    def last_notify_channel
+      Pg.tep_pg_notify_channel
+    end
+
+    def last_notify_payload
+      Pg.tep_pg_notify_payload
     end
 
     # Run a no-params query. Returns a PG::Result. On error the

--- a/lib/tep/tep_pg.c
+++ b/lib/tep/tep_pg.c
@@ -602,6 +602,149 @@ int tep_pg_get_result(int h) {
     return tep_pg_stash_result(r, h);
 }
 
+/* --- LISTEN / NOTIFY ---
+ *
+ * Connection-level async-notification surface. Used by
+ * Tep::Broadcast's PG backend (Battery 2 chunk 2.2) to cross-worker
+ * pub/sub: worker A's publish runs NOTIFY on a shared channel;
+ * worker B's poll_notification picks up the delivery and dispatches
+ * to local subscribers. The C side just exposes PQexec-shaped
+ * LISTEN / NOTIFY and a poll loop around PQconsumeInput + PQnotifies.
+ *
+ * Channel names are SQL identifiers, NOT escaped here -- the
+ * caller is responsible for passing a safe identifier (typically
+ * a hard-coded constant like "tep_broadcast"). Payloads ARE
+ * escaped via PQescapeLiteral so arbitrary bytes (with quotes,
+ * backslashes, NULs up to PG's payload-size limit) round-trip
+ * cleanly. */
+
+int tep_pg_listen(int h, const char *channel) {
+    PGconn *c = tep_pg_conn_for(h);
+    if (c == NULL) return -1;
+    /* LISTEN <identifier> -- channel must be a safe SQL identifier. */
+    char buf[256];
+    snprintf(buf, sizeof(buf), "LISTEN %s", channel);
+    PGresult *r = PQexec(c, buf);
+    int ok = (PQresultStatus(r) == PGRES_COMMAND_OK) ? 0 : -1;
+    PQclear(r);
+    return ok;
+}
+
+int tep_pg_unlisten(int h, const char *channel) {
+    PGconn *c = tep_pg_conn_for(h);
+    if (c == NULL) return -1;
+    char buf[256];
+    snprintf(buf, sizeof(buf), "UNLISTEN %s", channel);
+    PGresult *r = PQexec(c, buf);
+    int ok = (PQresultStatus(r) == PGRES_COMMAND_OK) ? 0 : -1;
+    PQclear(r);
+    return ok;
+}
+
+int tep_pg_notify(int h, const char *channel, const char *payload) {
+    PGconn *c = tep_pg_conn_for(h);
+    if (c == NULL) return -1;
+    /* PQescapeLiteral wraps payload in single quotes + escapes
+     * embedded quotes/backslashes. Returns a malloc'd string the
+     * caller must PQfreemem. */
+    char *esc = PQescapeLiteral(c, payload, strlen(payload));
+    if (esc == NULL) return -1;
+    /* "NOTIFY <channel>, <escaped_payload>" -- max payload size is
+     * 8000 bytes per PG (configurable, but the default cap is
+     * load-bearing). Larger payloads get rejected at PQexec time. */
+    size_t need = strlen(channel) + strlen(esc) + 32;
+    char *buf = (char *)malloc(need);
+    if (buf == NULL) { PQfreemem(esc); return -1; }
+    snprintf(buf, need, "NOTIFY %s, %s", channel, esc);
+    PGresult *r = PQexec(c, buf);
+    int ok = (PQresultStatus(r) == PGRES_COMMAND_OK) ? 0 : -1;
+    PQclear(r);
+    PQfreemem(esc);
+    free(buf);
+    return ok;
+}
+
+/* Stash for the most recently consumed notification. */
+static char tep_pg_notify_channel_buf[256];
+static char tep_pg_notify_payload_buf[16384];
+
+/* Block up to `timeout_ms` waiting for a notification on `h`.
+ * Returns 1 if one was received (channel + payload available via
+ * tep_pg_notify_channel / tep_pg_notify_payload), 0 on timeout, -1
+ * on connection error.
+ *
+ * Uses select() on PQsocket(conn) to wait, then PQconsumeInput +
+ * PQnotifies to read pending notifications. The connection MUST
+ * already be in LISTEN mode (via tep_pg_listen) for the channel
+ * the caller cares about.
+ *
+ * Single-notification per call by design -- the caller drives the
+ * loop, calling repeatedly to drain any accumulated notifications.
+ * Returns 1 + sets a fresh stash on every notification received. */
+#include <sys/select.h>
+#include <sys/time.h>
+
+int tep_pg_poll_notification(int h, int timeout_ms) {
+    PGconn *c = tep_pg_conn_for(h);
+    if (c == NULL) return -1;
+
+    /* Fast path: check for already-pending notification before
+     * doing any I/O. PQconsumeInput drains the kernel buffer if
+     * anything is sitting there. */
+    if (PQconsumeInput(c) == 0) return -1;
+    PGnotify *n = PQnotifies(c);
+
+    /* If nothing pending, wait on the socket for up to timeout_ms. */
+    if (n == NULL) {
+        int fd = PQsocket(c);
+        if (fd < 0) return -1;
+        fd_set rs;
+        FD_ZERO(&rs);
+        FD_SET(fd, &rs);
+        struct timeval tv;
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+        int sel = select(fd + 1, &rs, NULL, NULL, &tv);
+        if (sel < 0) return -1;
+        if (sel == 0) return 0;
+        if (PQconsumeInput(c) == 0) return -1;
+        n = PQnotifies(c);
+        if (n == NULL) return 0;
+    }
+
+    /* Copy out into static buffers + free the libpq struct. */
+    if (n->relname) {
+        size_t nlen = strlen(n->relname);
+        if (nlen >= sizeof(tep_pg_notify_channel_buf)) {
+            nlen = sizeof(tep_pg_notify_channel_buf) - 1;
+        }
+        memcpy(tep_pg_notify_channel_buf, n->relname, nlen);
+        tep_pg_notify_channel_buf[nlen] = '\0';
+    } else {
+        tep_pg_notify_channel_buf[0] = '\0';
+    }
+    if (n->extra) {
+        size_t plen = strlen(n->extra);
+        if (plen >= sizeof(tep_pg_notify_payload_buf)) {
+            plen = sizeof(tep_pg_notify_payload_buf) - 1;
+        }
+        memcpy(tep_pg_notify_payload_buf, n->extra, plen);
+        tep_pg_notify_payload_buf[plen] = '\0';
+    } else {
+        tep_pg_notify_payload_buf[0] = '\0';
+    }
+    PQfreemem(n);
+    return 1;
+}
+
+const char *tep_pg_notify_channel(void) {
+    return tep_pg_notify_channel_buf;
+}
+
+const char *tep_pg_notify_payload(void) {
+    return tep_pg_notify_payload_buf;
+}
+
 /* --- Version --- */
 
 const char *tep_pg_libpq_version(void) {

--- a/sig/tep/broadcast.rbs
+++ b/sig/tep/broadcast.rbs
@@ -27,5 +27,29 @@ module Tep
 
     # Drop every subscription. Returns the count dropped.
     def self.clear: () -> Integer
+
+    # ---- PG backend (cross-worker pub/sub) ----
+
+    # Open a dedicated PG connection, issue LISTEN <channel>, and
+    # flip publish() into PG-NOTIFY-aware mode. `channel` must be
+    # a safe SQL identifier. Returns 0 on success, -1 on failure.
+    def self.enable_pg_backend: (String conninfo, String channel) -> Integer
+
+    # Close the LISTEN connection + revert publish() to local-only.
+    def self.disable_pg_backend: () -> Integer
+
+    # Block up to timeout_ms for one notification on the PG
+    # channel; dispatch to local subscribers. Returns 1 on
+    # delivery, 0 on timeout, -1 on connection error.
+    def self.poll_pg_once: (Integer timeout_ms) -> Integer
+
+    # Wire format helpers (length-prefixed "<topic_len>:<topic><payload>").
+    def self.encode_wire: (String topic, String payload) -> String
+    def self.deliver_wire_local: (String wire) -> Integer
+
+    # Same fan-out as publish but skips the PG NOTIFY step.
+    # Used internally when delivering a cross-worker message that
+    # came in via PG.
+    def self.publish_local_only: (String topic, String payload) -> Integer
   end
 end

--- a/test/test_broadcast_pg.rb
+++ b/test/test_broadcast_pg.rb
@@ -1,0 +1,135 @@
+require_relative "helper"
+
+# Tep::Broadcast PG backend: cross-worker pub/sub via
+# LISTEN/NOTIFY. Gated on PG_TEST_URL like test_pg.rb.
+#
+#   PG_TEST_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+#     ruby test/test_broadcast_pg.rb
+#
+# Test strategy: configure the backend at on_start, then exercise
+# publish() + poll_pg_once() within a single tep app instance. PG's
+# LISTEN/NOTIFY delivers a worker's own NOTIFYs back to it (the
+# "LISTEN sees own publishes" property), so a single-process app
+# can validate the full wire round-trip without needing to spin up
+# a second worker.
+class TestBroadcastPg < TepTest
+  PG_URL = ENV["PG_TEST_URL"]
+  CHANNEL = "tep_broadcast_test_#{$$}"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    PG_URL  = "#{PG_URL}"
+    CHANNEL = "#{CHANNEL}"
+
+    on_start do
+      Tep::Broadcast.enable_pg_backend(PG_URL, CHANNEL)
+    end
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    get '/reset' do
+      Tep::Broadcast.clear.to_s
+    end
+
+    get '/subscribe' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Broadcast.subscribe(topic, fd).to_s
+    end
+
+    get '/publish' do
+      topic   = params[:topic]
+      payload = params[:payload]
+      Tep::Broadcast.publish(topic, payload).to_s
+    end
+
+    get '/poll' do
+      timeout = params[:timeout].to_i
+      Tep::Broadcast.poll_pg_once(timeout).to_s
+    end
+
+    get '/encode_wire' do
+      topic   = params[:topic]
+      payload = params[:payload]
+      Tep::Broadcast.encode_wire(topic, payload)
+    end
+
+    get '/decode_wire' do
+      wire = params[:wire]
+      Tep::Broadcast.deliver_wire_local(wire).to_s
+    end
+  RB
+
+  def setup
+    if PG_URL.nil? || PG_URL.empty?
+      skip "PG_TEST_URL not set (e.g. PG_TEST_URL=postgresql:///postgres). " \
+           "See test/test_pg.rb header for the docker recipe."
+    end
+    super
+    get("/reset")
+  end
+
+  # ---- Wire format round-trip (no PG, no NOTIFY -- pure encoding) ----
+
+  def test_encode_wire_length_prefixed
+    res = get("/encode_wire?topic=room:lobby&payload=hello")
+    # "10:room:lobbyhello" -- 10 chars in topic "room:lobby" then payload "hello"
+    assert_equal "10:room:lobbyhello", res.body
+  end
+
+  def test_encode_wire_empty_payload
+    res = get("/encode_wire?topic=t&payload=")
+    assert_equal "1:t", res.body
+  end
+
+  def test_decode_wire_delivers_to_local_subs
+    # Subscribe a fake fd to a topic, then decode-and-deliver a
+    # wire-format payload as if it had come in via PG NOTIFY.
+    get("/subscribe?topic=room:lobby&fd=-1")
+    res = get("/decode_wire?wire=10:room:lobbyhello")
+    # Matched 1 local subscriber.
+    assert_equal "1", res.body
+  end
+
+  def test_decode_wire_unsubscribed_topic_zero
+    res = get("/decode_wire?wire=4:nope")
+    assert_equal "0", res.body
+  end
+
+  # ---- End-to-end PG NOTIFY round trip ----
+
+  def test_publish_then_poll_round_trips_via_pg
+    # Publish a message -- NOTIFY's PG.
+    get("/publish?topic=pg_round_trip&payload=ping")
+    # Poll for the NOTIFY (we sent it; LISTEN sees own publishes).
+    res = get("/poll?timeout=2000")
+    assert_equal "1", res.body
+  end
+
+  def test_poll_returns_zero_on_timeout
+    # With no preceding publish + no other publisher on the channel,
+    # poll should time out cleanly.
+    res = get("/poll?timeout=100")
+    assert_equal "0", res.body
+  end
+
+  def test_publish_with_local_sub_also_matches_local
+    # Local fan-out still works alongside PG NOTIFY. Subscribe a
+    # local fake fd, publish -- match count reflects the local sub.
+    get("/subscribe?topic=mixed_topic&fd=-1")
+    res = get("/publish?topic=mixed_topic&payload=hi")
+    assert_equal "1", res.body
+  end
+
+  def test_publish_with_no_local_sub_matches_zero_but_still_notifies
+    # No local subs -- match count is 0, but publish still ran the
+    # PG NOTIFY (subsequent poll confirms).
+    res = get("/publish?topic=remote_only&payload=hi")
+    assert_equal "0", res.body
+    poll_res = get("/poll?timeout=2000")
+    assert_equal "1", poll_res.body
+  end
+end


### PR DESCRIPTION
Builds on #23's in-process broker. Adds a Postgres-backed backend so a publish from worker A reaches subscribers on worker B via PG `NOTIFY` — the cross-worker piece that makes pub/sub actually useful under prefork.

## Public surface

```ruby
# Boot in each worker:
Tep::Broadcast.enable_pg_backend(ENV["PG_URL"], "tep_broadcast")

# Publish (existing API; now also NOTIFY's PG):
Tep::Broadcast.publish("room:lobby", "hello")
# → writes to local subscribed fds AND issues
#   NOTIFY tep_broadcast, '<wire-encoded message>'

# Receive cross-worker broadcasts: app drives the poll cadence.
# Typically: background fiber under Tep::Server::Scheduled loops
# `Tep::Broadcast.poll_pg_once(100)` ms-by-ms. Apps can also drive
# from request handlers, periodic timers, etc.
Tep::Broadcast.poll_pg_once(100)   # returns 1=delivered, 0=timeout, -1=err

Tep::Broadcast.disable_pg_backend  # UNLISTEN + close conn
```

## Why not a built-in listener fiber

Scheduled is still gated on matz/spinel#641. Once that lands and Scheduled is reliable under burst, the framework can ship an automatic listener fiber that gets installed alongside `enable_pg_backend`. Apps that want auto-listening today can write a single-line background fiber themselves under their own server.

## What's added

**C primitives** (`lib/tep/tep_pg.c`):
- `tep_pg_listen(h, channel)` / `tep_pg_unlisten(h, channel)`
- `tep_pg_notify(h, channel, payload)` — PQescapeLiteral on payload
- `tep_pg_poll_notification(h, timeout_ms)` — select() + PQconsumeInput + PQnotifies
- `tep_pg_notify_channel()` / `tep_pg_notify_payload()` — static-buffer getters

**Ruby wrappers** on `PG::Connection`: `#listen` / `#unlisten` / `#notify` / `#poll_notification` / `#last_notify_channel` / `#last_notify_payload`.

**`Tep::Broadcast`** gains `enable_pg_backend` / `disable_pg_backend` / `poll_pg_once` / `encode_wire` / `deliver_wire_local` / `publish_local_only`. `publish` is unchanged in public shape but now NOTIFY's PG when the backend is enabled.

## Wire format

Length-prefixed: `"<topic_byte_length>:<topic><payload>"` — sidesteps escape concerns for topics and payloads with arbitrary chars (commas, colons, embedded quotes, newlines all round-trip).

```
encode_wire("room:lobby", "hello") → "10:room:lobbyhello"
```

PG's NOTIFY payload max is 8000 bytes by default — payloads + topic length must fit. Larger payloads need a separate path (durable outbox table, future chunk).

## Spinel gotcha solved

Earlier draft assigned `@broadcast_pg_conn = PG::Connection.new("")` in `Tep::App#initialize`. That **segfaulted at module load** because `PG::Connection.new` reads `Tep::APP.sched_current` to pick sync vs async path — but `Tep::APP` itself is being constructed during that initialize call, so there's no `APP` to read from yet. Moved the seed assignment to a top-level setter call (`APP.set_broadcast_pg_conn(PG::Connection.new(""))`) in `lib/tep.rb` after `APP` exists.

This is a real spinel-side question worth filing — `Tep::App#initialize` running before `APP` exists is structurally normal; the crash on reading `APP.sched_current` from within it isn't great UX. Will file separately.

## Validation

- `test/test_broadcast_pg.rb`: 8 new tests, gated on `PG_TEST_URL`. Cover wire-format round-trip (no PG needed for those), publish→poll round trip via PG NOTIFY, timeout behavior, mixed local+PG publish, NOTIFY-without-local-sub still propagates cross-worker.
- Full suite without `PG_TEST_URL`: **316 / 599 green / 0 failures / 0 errors / 47 skips**. 8 new skips from `test_broadcast_pg` (since `PG_TEST_URL` isn't set in this env) plus the existing 39 upstream-blocked skips from #22. No new regressions.

## Battery 2 progress

| Chunk | Status |
|---|---|
| 2.1 In-process core | shipped |
| **2.2 PG LISTEN/NOTIFY backend** | **this PR** |
| 2.3 WS bridge | next |
| 2.4 Authz callback | small, drops in any time |