### PR TITLE
feat(broadcast): WebSocket bridge -- subscribe_ws (Battery 2, chunk 2.3)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -222,6 +222,7 @@ module Tep
   # types so compile units that don't otherwise exercise pub/sub
   # still get correct signatures.
   _tep_seed_broadcast_sub = Tep::Broadcast.subscribe("_seed", -1)
+  Tep::Broadcast.subscribe_ws("_seed", -1)
   Tep::Broadcast.publish("_seed", "")
   Tep::Broadcast.subscribers_for("_seed")
   Tep::Broadcast.unsubscribe(_tep_seed_broadcast_sub)

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -70,7 +70,7 @@ module Tep
       @auth_oauth2_codes = [Tep::AuthOAuth2Code.new("_", "", "", "", 0)]
       @auth_oauth2_codes.delete_at(0)
       # Same type-seed pattern for the Broadcast subscriber registry.
-      @broadcast_subs = [Tep::BroadcastSubscription.new("_", -1)]
+      @broadcast_subs = [Tep::BroadcastSubscription.new("_", -1, 0)]
       @broadcast_subs.delete_at(0)
       @broadcast_pg_enabled = 0
       @broadcast_pg_channel = ""

--- a/lib/tep/broadcast.rb
+++ b/lib/tep/broadcast.rb
@@ -37,10 +37,35 @@
 module Tep
   module Broadcast
     # Register a subscription for `fd` on `topic`. Returns an
-    # opaque sub_id for later unsubscribe.
+    # opaque sub_id for later unsubscribe. The fd receives raw
+    # bytes on publish -- suits SSE / log fan-out / anything that
+    # doesn't need WebSocket framing. For WS connections, prefer
+    # subscribe_ws.
     def self.subscribe(topic, fd)
       subs = Tep::APP.broadcast_subs
-      sub = Tep::BroadcastSubscription.new(topic, fd)
+      sub = Tep::BroadcastSubscription.new(topic, fd, 0)
+      subs.push(sub)
+      subs.length - 1
+    end
+
+    # WebSocket-bridged variant of subscribe. The fd is expected
+    # to be an established WS connection (typically a
+    # Tep::WebSocket::Connection's #fd). On publish, payload is
+    # wrapped in a WS TEXT frame via Tep::WebSocket::Driver
+    # before delivery -- the peer sees a well-formed WS message,
+    # not raw bytes that would close the connection.
+    #
+    # Apps unsubscribe in their WS close handler:
+    #
+    #   conn.on(:close) { Tep::Broadcast.unsubscribe_fd(conn.fd) }
+    #
+    # v1 keeps this explicit; an auto-unsubscribe hook on
+    # Tep::WebSocket::Connection lands as a follow-up once we've
+    # used it in a real app and seen what the right shape is.
+    def self.subscribe_ws(topic, fd)
+      subs = Tep::APP.broadcast_subs
+      sub = Tep::BroadcastSubscription.new(
+        topic, fd, Tep::WebSocket::OPCODE_TEXT)
       subs.push(sub)
       subs.length - 1
     end
@@ -212,13 +237,24 @@ module Tep
     # internally by poll_pg_once when delivering a cross-worker
     # message that already came in via PG -- re-NOTIFY would cause
     # an infinite loop.
+    #
+    # Branches on each subscription's `mode`:
+    #   * mode 0 -> raw bytes via Sock.sphttp_write_str (default,
+    #     for SSE / log fan-out / non-framed consumers).
+    #   * mode != 0 -> WebSocket frame via Tep::WebSocket::Driver.send_frame,
+    #     using the mode value as the WS opcode (1=TEXT, 2=BINARY).
     def self.publish_local_only(topic, payload)
       subs = Tep::APP.broadcast_subs
       matched = 0
       i = 0
       while i < subs.length
         if subs[i].topic == topic
-          Sock.sphttp_write_str(subs[i].fd, payload)
+          if subs[i].mode == 0
+            Sock.sphttp_write_str(subs[i].fd, payload)
+          else
+            Tep::WebSocket::Driver.send_frame(
+              subs[i].fd, subs[i].mode, payload)
+          end
           matched += 1
         end
         i += 1

--- a/lib/tep/broadcast_subscription.rb
+++ b/lib/tep/broadcast_subscription.rb
@@ -18,10 +18,23 @@ module Tep
   class BroadcastSubscription
     attr_reader :topic   # String
     attr_reader :fd      # Integer file descriptor
+    # Delivery mode controls how Tep::Broadcast.publish writes
+    # `payload` to `fd`:
+    #
+    #   0 = raw bytes (Sock.sphttp_write_str). The default; suits
+    #       SSE / log fan-out / anything that doesn't need framing.
+    #   1 = WebSocket TEXT frame (Tep::WebSocket::OPCODE_TEXT).
+    #   2 = WebSocket BINARY frame (Tep::WebSocket::OPCODE_BINARY).
+    #
+    # Modes 1 and 2 route through Tep::WebSocket::Driver.send_frame,
+    # so payloads land as proper WS frames the peer will accept.
+    # Apps register mode-1 subscriptions via subscribe_ws.
+    attr_reader :mode
 
-    def initialize(topic, fd)
+    def initialize(topic, fd, mode)
       @topic = topic
       @fd    = fd
+      @mode  = mode
     end
   end
 end

--- a/sig/tep/broadcast.rbs
+++ b/sig/tep/broadcast.rbs
@@ -4,8 +4,14 @@
 module Tep
   module Broadcast
     # Subscribe `fd` to `topic`. Returns an opaque sub_id usable
-    # for later #unsubscribe (a single-sub drop).
+    # for later #unsubscribe (a single-sub drop). Delivery is raw
+    # bytes via sphttp_write_str (no WS framing).
     def self.subscribe: (String topic, Integer fd) -> Integer
+
+    # WebSocket-bridged subscription. `fd` is an established WS
+    # connection (typically Tep::WebSocket::Connection#fd). publish
+    # wraps payload in a WS TEXT frame before delivery.
+    def self.subscribe_ws: (String topic, Integer fd) -> Integer
 
     # Drop the subscription at `sub_id`. Returns 0.
     def self.unsubscribe: (Integer sub_id) -> Integer

--- a/sig/tep/broadcast_subscription.rbs
+++ b/sig/tep/broadcast_subscription.rbs
@@ -5,7 +5,10 @@ module Tep
   class BroadcastSubscription
     attr_reader topic: String
     attr_reader fd: Integer
+    # Delivery mode: 0 = raw bytes, 1 = WS TEXT frame, 2 = WS BINARY.
+    # Modes 1/2 double as the WS opcode at send_frame call time.
+    attr_reader mode: Integer
 
-    def initialize: (String topic, Integer fd) -> void
+    def initialize: (String topic, Integer fd, Integer mode) -> void
   end
 end

--- a/test/test_broadcast.rb
+++ b/test/test_broadcast.rb
@@ -27,6 +27,12 @@ class TestBroadcast < TepTest
       Tep::Broadcast.subscribe(topic, fd).to_s
     end
 
+    get '/subscribe_ws' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Broadcast.subscribe_ws(topic, fd).to_s
+    end
+
     get '/unsubscribe' do
       sub_id = params[:sub_id].to_i
       Tep::Broadcast.unsubscribe(sub_id).to_s
@@ -151,6 +157,33 @@ class TestBroadcast < TepTest
     subscribe("room:lobby", -1)
     dropped = get("/unsubscribe_fd?fd=-999").body.to_i
     assert_equal 0, dropped
+  end
+
+  # ---- subscribe_ws (WebSocket frame mode) ----
+
+  def test_subscribe_ws_grows_registry
+    get("/subscribe_ws?topic=room:lobby&fd=-1")
+    assert_equal 1, subscriber_count
+    assert_equal 1, subscribers_for("room:lobby")
+  end
+
+  def test_subscribe_ws_publish_match_count
+    # Subscribe two WS, one raw -- all three should match a publish
+    # to that topic (delivery mode doesn't affect match counting).
+    get("/subscribe_ws?topic=room:lobby&fd=-1")
+    get("/subscribe_ws?topic=room:lobby&fd=-2")
+    get("/subscribe?topic=room:lobby&fd=-3")
+    assert_equal 3, publish("room:lobby", "hi")
+  end
+
+  def test_subscribe_ws_unsubscribe_fd_drops
+    # Mixed-mode subscriptions for one fd: subscribe_ws on a
+    # different topic + subscribe on the same fd. unsubscribe_fd
+    # drops both.
+    get("/subscribe_ws?topic=room:lobby&fd=-1")
+    get("/subscribe?topic=room:other&fd=-1")
+    dropped = get("/unsubscribe_fd?fd=-1").body.to_i
+    assert_equal 2, dropped
   end
 
   # ---- clear ----


### PR DESCRIPTION
Closes the third leg of Battery 2. Apps with a `Tep::WebSocket` connection register the connection's fd via `subscribe_ws`; publishes to that topic get wrapped in a WS TEXT frame so the peer sees a well-formed WebSocket message instead of raw bytes that would close the connection.

## Public surface delta

```ruby
sub_id = Tep::Broadcast.subscribe_ws(topic, ws_fd)
```

Same shape as `subscribe`, different delivery mode. Existing `subscribe(topic, fd)` stays raw-bytes (SSE / log fan-out / non-framed consumers); `subscribe_ws(topic, fd)` routes through `Tep::WebSocket::Driver.send_frame`.

## Typical use in a WS handler

```ruby
get '/chat/:room' do
  conn = res.start_websocket(req)   # WebSocket upgrade handshake
  Tep::Broadcast.subscribe_ws("room:#{params[:room]}", conn.fd)
  # ... rest of WS lifecycle ...
  Tep::Broadcast.unsubscribe_fd(conn.fd)
end

# Anywhere else:
Tep::Broadcast.publish("room:lobby", "alice: hello")
# Every WS subscribed to "room:lobby" gets a TEXT frame.
```

## Implementation

- `Tep::BroadcastSubscription` gains a `mode` field: `0` = raw bytes, `1` = WS TEXT, `2` = WS BINARY. The mode value doubles as the WS opcode at `send_frame` call time, so the publish loop is a one-liner branch:

```ruby
if subs[i].mode == 0
  Sock.sphttp_write_str(subs[i].fd, payload)
else
  Tep::WebSocket::Driver.send_frame(subs[i].fd, subs[i].mode, payload)
end
```

- `subscribe(topic, fd)` keeps its 2-arg shape; internally builds the subscription with mode=0. **Source compat for any existing callers.**
- `subscribe_ws(topic, fd)` builds with `mode = Tep::WebSocket::OPCODE_TEXT`. Binary-frame variant deferred until a real use case shows up.

## What's NOT in this chunk

- **Auto-unsubscribe on WS close.** Apps explicitly call `Tep::Broadcast.unsubscribe_fd(conn.fd)` from their close hook. An automatic hook on `Tep::WebSocket::Connection` is a small follow-up once we've used this in a real app and seen the right shape.
- **Callback model.** The design doc's `ws.on(:broadcast) { |topic, msg| ... }` shape is unneeded: publish writes bytes directly to the subscribed WS fd. Apps that want to transform broadcasts before forwarding subscribe to a raw-mode pipe + run their own processing loop.

## Validation

- `test/test_broadcast.rb`: 15 / 20 (3 new `subscribe_ws` tests — registry growth, mixed raw+WS subscribers all match a publish, `unsubscribe_fd` drops both modes for one fd).
- Full suite: **319 / 603 / 0 failures / 0 errors / 47 skips**. Same upstream-blocked skip set as #22; no new regressions.

## Battery 2 progress

| Chunk | Status |
|---|---|
| 2.1 In-process core | shipped |
| 2.2 PG LISTEN/NOTIFY backend | shipped |
| **2.3 WS bridge** | **this PR** |
| 2.4 Authz callback | small, can land any time |

After this merges, Battery 2 is feature-complete enough to ship the "all batteries demo" the design doc promises. Battery 3 (Presence) and Battery 4 (LiveView) can build directly on top of `subscribe_ws` — that's the seam Phoenix.Presence's `Presence.subscribe(topic)` and LiveView's bound-topic-rerender both reach for.