### PR TITLE
feat(presence): topic-keyed who's-here registry (Battery 3, chunk 3.1)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -21,11 +21,12 @@ require_relative "tep/url"
 require_relative "tep/net"
 require_relative "tep/agent_delegation"
 require_relative "tep/identity"
-# Auth + Broadcast data classes (no deps; storage on Tep::App
-# references them, so they must load before app.rb).
+# Auth + Broadcast + Presence data classes (no deps; storage on
+# Tep::App references them, so they must load before app.rb).
 require_relative "tep/auth_oauth2_client"
 require_relative "tep/auth_oauth2_code"
 require_relative "tep/broadcast_subscription"
+require_relative "tep/presence_entry"
 require_relative "tep/session"
 require_relative "tep/request"
 require_relative "tep/response"
@@ -43,6 +44,7 @@ require_relative "tep/auth_session_cookie"
 require_relative "tep/auth_oauth2"
 require_relative "tep/auth"
 require_relative "tep/broadcast"
+require_relative "tep/presence"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"
 require_relative "tep/sqlite"
@@ -243,6 +245,28 @@ module Tep
   # The new PG::Connection LISTEN/NOTIFY method seeds live further
   # down with the rest of the PG seeds, where _tep_seed_pg_conn is
   # already defined.
+
+  # Presence type-seeding. Same pattern as Broadcast: pin every
+  # cmeth's param C types so compile units that don't otherwise
+  # touch Presence still get correct signatures. track() requires
+  # a req with a populated identity -- construct a synthetic one.
+  _tep_seed_presence_caps = [:_seed]
+  _tep_seed_presence_caps.delete_at(0)
+  _tep_seed_presence_req = Tep::Request.new
+  _tep_seed_presence_req.identity = Tep::Identity.new(
+    "_seed", nil, _tep_seed_presence_caps)
+  Tep::Presence.track(_tep_seed_presence_req, "_seed", -1)
+  Tep::Presence.find_entry("_seed", -1)
+  Tep::Presence.list("_seed")
+  Tep::Presence.count("_seed")
+  Tep::Presence.count_humans("_seed")
+  Tep::Presence.count_agents("_seed")
+  Tep::Presence.count_filtered("_seed", :both)
+  Tep::Presence.set_status("_seed", -1, :busy, "", 0)
+  Tep::Presence.clear_status("_seed", -1)
+  Tep::Presence.untrack("_seed", -1)
+  Tep::Presence.untrack_by_fd(-1)
+  Tep::Presence.clear
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -31,6 +31,10 @@ module Tep
     # topic with an output fd; publish iterates + writes the payload
     # to every matching fd.
     attr_accessor :broadcast_subs
+    # Per-process Presence entry registry. Each entry is one
+    # (principal, session, topic) tracking, with kind/agent_id +
+    # structured-status fields inline. See Tep::Presence.
+    attr_accessor :presence_entries
     # PG-backed cross-worker pub/sub state. `broadcast_pg_enabled`
     # is 0 when off, 1 when on. The dedicated LISTEN connection
     # lives in `broadcast_pg_conn`; channel name in
@@ -72,6 +76,9 @@ module Tep
       # Same type-seed pattern for the Broadcast subscriber registry.
       @broadcast_subs = [Tep::BroadcastSubscription.new("_", -1, 0)]
       @broadcast_subs.delete_at(0)
+      # And for the Presence entry registry.
+      @presence_entries = [Tep::PresenceEntry.new("_", "", :human, "", -1, 0)]
+      @presence_entries.delete_at(0)
       @broadcast_pg_enabled = 0
       @broadcast_pg_channel = ""
       # Seed broadcast_pg_conn later via lib/tep.rb's setter seed

--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -1,0 +1,186 @@
+# Tep::Presence -- topic-keyed who's-here registry.
+#
+# Battery 3 (Presence). Layers on req.identity (Battery 1) for
+# the principal+delegate split and on the Broadcast pub-sub
+# surface (Battery 2) for diff fan-out -- though in chunk 3.1
+# diff broadcasting isn't wired yet; apps that want presence
+# diffs build them on top of list() snapshots for now.
+#
+# Tracking model: one PresenceEntry per (principal, session,
+# topic). `fd` doubles as the session-id surrogate, so a human
+# with three browser tabs lands as three entries with kind=:human
+# and three distinct fds. An agent acting on behalf of that
+# human gets its own entry with kind=:agent_for and the agent_id
+# populated -- four entries, one principal, one topic. This is
+# the Phoenix.Presence shape extended with the agentic kind/
+# agent_id pair.
+#
+# Storage scope is per-process (Tep::APP). Cross-worker
+# visibility (PG-backed) lands in a follow-up chunk; v1 works
+# best in single-worker prefork or app-internal contexts.
+#
+# Status handling: every entry carries a Tep::PresenceStatus
+# inline (status_state / status_note / status_until on the
+# entry). track() initializes status to :available; apps update
+# via set_status / clear_status. Expiry (status_until) isn't
+# auto-swept in chunk 3.1; the next chunk's diff loop will
+# handle reset-on-expire alongside emit.
+module Tep
+  module Presence
+    # Track a presence entry. principal_id comes off req.identity;
+    # kind is :human or :agent_for depending on the identity's
+    # delegation state. fd is the underlying connection's socket
+    # (typically a WS-accepted fd). Returns 0 on success.
+    #
+    # Multiple track() calls for the same (principal, topic, fd)
+    # are deduped: the existing entry stays, no second row is
+    # created. Apps can call freely from before-filters /
+    # reconnect paths without growing the registry.
+    def self.track(req, topic, fd)
+      ident = req.identity
+      if Tep::Presence.find_entry(topic, fd) != nil
+        return 0
+      end
+      kind = :human
+      agent_id = ""
+      if ident.agent?
+        kind = :agent_for
+        agent_id = ident.acting_via.agent_id
+      end
+      entry = Tep::PresenceEntry.new(
+        topic, ident.principal_id, kind, agent_id, fd, Time.now.to_i)
+      Tep::APP.presence_entries.push(entry)
+      0
+    end
+
+    # Drop the entry for (topic, fd). The fd is the unique key
+    # within a topic; principal_id isn't needed. Returns 1 if an
+    # entry was removed, 0 if none matched.
+    def self.untrack(topic, fd)
+      entries = Tep::APP.presence_entries
+      i = 0
+      while i < entries.length
+        if entries[i].topic == topic && entries[i].fd == fd
+          entries.delete_at(i)
+          return 1
+        end
+        i += 1
+      end
+      0
+    end
+
+    # Drop every entry associated with `fd` (across all topics).
+    # Used by the WS close hook to clean up everything a
+    # connection had tracked. Returns the count dropped.
+    def self.untrack_by_fd(fd)
+      entries = Tep::APP.presence_entries
+      dropped = 0
+      i = entries.length - 1
+      while i >= 0
+        if entries[i].fd == fd
+          entries.delete_at(i)
+          dropped += 1
+        end
+        i -= 1
+      end
+      dropped
+    end
+
+    # All entries for `topic`. Caller groups by principal_id when
+    # they want the Phoenix.Presence-style {principal => [metas]}
+    # shape; tep doesn't pre-group because spinel's nested-hash
+    # lowering is awkward.
+    def self.list(topic)
+      result = [Tep::PresenceEntry.new("", "", :human, "", -1, 0)]
+      result.delete_at(0)
+      entries = Tep::APP.presence_entries
+      i = 0
+      while i < entries.length
+        if entries[i].topic == topic
+          result.push(entries[i])
+        end
+        i += 1
+      end
+      result
+    end
+
+    # Total entries for `topic` (across all kinds).
+    def self.count(topic)
+      Tep::Presence.count_filtered(topic, :both)
+    end
+
+    def self.count_humans(topic)
+      Tep::Presence.count_filtered(topic, :human)
+    end
+
+    def self.count_agents(topic)
+      Tep::Presence.count_filtered(topic, :agent_for)
+    end
+
+    # Internal counting helper: `kind_filter` is :both for all
+    # entries, otherwise :human or :agent_for to filter.
+    def self.count_filtered(topic, kind_filter)
+      entries = Tep::APP.presence_entries
+      n = 0
+      i = 0
+      while i < entries.length
+        if entries[i].topic == topic
+          if kind_filter == :both
+            n += 1
+          elsif entries[i].kind == kind_filter
+            n += 1
+          end
+        end
+        i += 1
+      end
+      n
+    end
+
+    # Set the structured status on an existing entry. `state` ∈
+    # {:available, :busy, :blocked}; `note` is free text (~140
+    # char soft hint); `until_ts` is unix epoch seconds (0 = no
+    # identity-level expiry). Returns 1 if the entry was found
+    # and updated, 0 otherwise.
+    def self.set_status(topic, fd, state, note, until_ts)
+      entry = Tep::Presence.find_entry(topic, fd)
+      if entry == nil
+        return 0
+      end
+      entry.status_state = state
+      entry.status_note  = note
+      entry.status_until = until_ts
+      1
+    end
+
+    # Reset an entry's status back to :available / "" / 0.
+    def self.clear_status(topic, fd)
+      Tep::Presence.set_status(topic, fd, :available, "", 0)
+    end
+
+    # Internal: find the entry matching (topic, fd). Returns nil
+    # if no match.
+    def self.find_entry(topic, fd)
+      entries = Tep::APP.presence_entries
+      i = 0
+      while i < entries.length
+        if entries[i].topic == topic && entries[i].fd == fd
+          return entries[i]
+        end
+        i += 1
+      end
+      nil
+    end
+
+    # Drop every entry. Used by tests between fixtures and
+    # available to apps for graceful-shutdown cleanup. Returns
+    # the count dropped.
+    def self.clear
+      entries = Tep::APP.presence_entries
+      n = entries.length
+      while entries.length > 0
+        entries.delete_at(0)
+      end
+      n
+    end
+  end
+end

--- a/lib/tep/presence_entry.rb
+++ b/lib/tep/presence_entry.rb
@@ -1,0 +1,52 @@
+# Tep::PresenceEntry -- one row in the Tep::Presence registry.
+#
+# Represents one (principal, session, topic) tracking, plus the
+# optional structured-status + agent-delegation metadata that
+# makes Presence agent-aware. Multiple entries with the same
+# principal_id under one topic are normal: a human in three
+# browser tabs (kind=:human, three different fds), plus their
+# delegated summarizer-bot (kind=:agent_for, agent_id set,
+# separate fd) -- five entries, one principal.
+#
+# fd is the underlying socket file descriptor (typically the
+# accepted WS socket). It's the session-id surrogate: each WS
+# connection has its own fd, so fd uniquely identifies a session
+# within a worker. The framework's WS close hook calls
+# Tep::Presence.untrack_by_fd(fd) to clear all entries when the
+# connection closes.
+#
+# `since` is unix epoch seconds at track time. Useful for "online
+# for N minutes" UI labels.
+#
+# Status fields encode Tep::PresenceStatus inline (a separate
+# wrapper class would force a nested struct and complicate
+# spinel's PtrArray<PresenceEntry> dispatch). Status defaults to
+# (:available, "", 0) at track time; apps update via
+# Tep::Presence.set_status.
+module Tep
+  class PresenceEntry
+    attr_reader :topic         # String
+    attr_reader :principal_id  # String, opaque
+    attr_reader :kind          # Symbol: :human | :agent_for
+    attr_reader :agent_id      # String, empty when kind == :human
+    attr_reader :fd            # Integer, session-id surrogate
+    attr_reader :since         # Integer unix epoch seconds
+    # Structured-status fields (see docs/BATTERIES-DESIGN.md +
+    # memory presence_status). state ∈ :available | :busy | :blocked.
+    attr_accessor :status_state
+    attr_accessor :status_note
+    attr_accessor :status_until
+
+    def initialize(topic, principal_id, kind, agent_id, fd, since)
+      @topic         = topic
+      @principal_id  = principal_id
+      @kind          = kind
+      @agent_id      = agent_id
+      @fd            = fd
+      @since         = since
+      @status_state  = :available
+      @status_note   = ""
+      @status_until  = 0
+    end
+  end
+end

--- a/sig/tep/presence.rbs
+++ b/sig/tep/presence.rbs
@@ -1,0 +1,47 @@
+# Topic-keyed who's-here registry, agent-aware via Tep::Identity.
+# Builds on Battery 1 (identity) + Battery 2 (broadcast). See
+# lib/tep/presence.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  module Presence
+    # Track a presence entry. principal_id / kind / agent_id come
+    # off req.identity. fd is the connection's socket fd (acts as
+    # the session-id surrogate). Returns 0; dedups on
+    # (topic, fd) so repeat calls are safe.
+    def self.track: (Tep::Request req, String topic, Integer fd) -> Integer
+
+    # Drop the (topic, fd) entry. Returns 1 if removed, 0 if not
+    # found.
+    def self.untrack: (String topic, Integer fd) -> Integer
+
+    # Drop every entry tied to fd (across topics). Used by the WS
+    # close hook. Returns count dropped.
+    def self.untrack_by_fd: (Integer fd) -> Integer
+
+    # All entries for topic. Apps group by principal_id when they
+    # want the Phoenix.Presence-shaped {principal => [metas]}
+    # snapshot.
+    def self.list: (String topic) -> Array[Tep::PresenceEntry]
+
+    def self.count: (String topic) -> Integer
+    def self.count_humans: (String topic) -> Integer
+    def self.count_agents: (String topic) -> Integer
+    def self.count_filtered: (String topic, Symbol kind_filter) -> Integer
+
+    # Structured status (:available | :busy | :blocked + note +
+    # until). Returns 1 if applied, 0 if entry not found.
+    def self.set_status: (
+      String topic,
+      Integer fd,
+      Symbol state,
+      String note,
+      Integer until_ts
+    ) -> Integer
+
+    def self.clear_status: (String topic, Integer fd) -> Integer
+
+    def self.find_entry: (String topic, Integer fd) -> Tep::PresenceEntry?
+
+    # Drop every entry. Returns count dropped.
+    def self.clear: () -> Integer
+  end
+end

--- a/sig/tep/presence_entry.rbs
+++ b/sig/tep/presence_entry.rbs
@@ -1,0 +1,27 @@
+# One row in Tep::Presence's registry. (principal, session, topic)
+# plus kind/agent_id for the agentic split and inline structured
+# status. See lib/tep/presence_entry.rb + docs/BATTERIES-DESIGN.md.
+module Tep
+  class PresenceEntry
+    attr_reader topic: String
+    attr_reader principal_id: String
+    attr_reader kind: Symbol       # :human | :agent_for
+    attr_reader agent_id: String   # empty when kind == :human
+    attr_reader fd: Integer        # session-id surrogate
+    attr_reader since: Integer     # unix epoch sec
+
+    # Structured-status fields (Tep::PresenceStatus inlined).
+    attr_accessor status_state: Symbol   # :available | :busy | :blocked
+    attr_accessor status_note: String
+    attr_accessor status_until: Integer  # unix epoch sec; 0 = no expiry
+
+    def initialize: (
+      String topic,
+      String principal_id,
+      Symbol kind,
+      String agent_id,
+      Integer fd,
+      Integer since
+    ) -> void
+  end
+end

--- a/test/test_presence.rb
+++ b/test/test_presence.rb
@@ -1,0 +1,242 @@
+require_relative "helper"
+
+# Tep::Presence: topic-keyed who's-here registry, agent-aware via
+# Tep::Identity. v1 chunk covers storage + track/untrack +
+# list/count + status; diff broadcasting via Tep::Broadcast lands
+# in a follow-up.
+class TestPresence < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    # Per-request identity is normally set by Tep::Auth's filter
+    # off Bearer / SessionCookie / OAuth credentials. These tests
+    # don't go through auth -- we build identities inline and
+    # poke them onto req.identity in a before-filter keyed off
+    # the ?as=<...> query param. Same exercise of Presence's
+    # principal_id / kind / agent_id pickup that the real
+    # production path takes.
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+      caps = [:read, :write]
+      who = params[:as]
+      if who == "agent"
+        deleg = Tep::AgentDelegation.new(
+          "summarizer-bot", 1000, 9999999999, :token)
+        req.identity = Tep::Identity.new("user:42", deleg, caps)
+      elsif who.length > 0
+        # who looks like "user:NN" -- use it as principal directly.
+        req.identity = Tep::Identity.new(who, nil, caps)
+      end
+      # else: req.identity stays at anonymous (set by auth filter).
+    end
+
+    get '/reset' do
+      Tep::Presence.clear.to_s
+    end
+
+    get '/track' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Presence.track(req, topic, fd).to_s
+    end
+
+    get '/untrack' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Presence.untrack(topic, fd).to_s
+    end
+
+    get '/untrack_by_fd' do
+      fd = params[:fd].to_i
+      Tep::Presence.untrack_by_fd(fd).to_s
+    end
+
+    get '/count' do
+      Tep::Presence.count(params[:topic]).to_s
+    end
+
+    get '/count_humans' do
+      Tep::Presence.count_humans(params[:topic]).to_s
+    end
+
+    get '/count_agents' do
+      Tep::Presence.count_agents(params[:topic]).to_s
+    end
+
+    get '/list_summary' do
+      # Compact serialization for assertion: principal_id|kind|agent_id|fd
+      # SEMICOLON-separated (newlines inside heredoc tep app source
+      # appear to absorb indentation -- bench the actual cause out
+      # of band).
+      topic = params[:topic]
+      entries = Tep::Presence.list(topic)
+      out = ""
+      i = 0
+      while i < entries.length
+        e = entries[i]
+        if out.length > 0
+          out = out + ";"
+        end
+        out = out + e.principal_id + "|" + e.kind.to_s + "|" + e.agent_id + "|" + e.fd.to_s
+        i += 1
+      end
+      out
+    end
+
+    get '/set_status' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      state = params[:state].to_sym
+      note  = params[:note]
+      ut    = params[:until_ts].to_i
+      Tep::Presence.set_status(topic, fd, state, note, ut).to_s
+    end
+
+    get '/clear_status' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Presence.clear_status(topic, fd).to_s
+    end
+
+    get '/status_summary' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      e = Tep::Presence.find_entry(topic, fd)
+      if e == nil
+        ""
+      else
+        e.status_state.to_s + "|" + e.status_note + "|" + e.status_until.to_s
+      end
+    end
+  RB
+
+  def setup
+    super
+    get("/reset")
+  end
+
+  # ---- empty registry ----
+
+  def test_count_empty
+    assert_equal "0", get("/count?topic=room:lobby").body
+  end
+
+  # ---- track + list ----
+
+  def test_track_human
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    assert_equal "user:42|human||1", get("/list_summary?topic=room:lobby").body
+  end
+
+  def test_track_agent
+    get("/track?topic=room:lobby&fd=2&as=agent")
+    # The agentic-row format: principal user:42, kind agent_for,
+    # agent_id summarizer-bot.
+    assert_equal "user:42|agent_for|summarizer-bot|2",
+      get("/list_summary?topic=room:lobby").body
+  end
+
+  def test_track_multi_session_same_principal
+    # Two browser tabs for user:42 + one summarizer-bot delegate
+    # for them. List should return all three.
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:lobby&fd=2&as=user:42")
+    get("/track?topic=room:lobby&fd=3&as=agent")
+    body = get("/list_summary?topic=room:lobby").body
+    rows = body.split(";").sort
+    assert_equal 3, rows.length
+    assert_includes rows, "user:42|agent_for|summarizer-bot|3"
+    assert_includes rows, "user:42|human||1"
+    assert_includes rows, "user:42|human||2"
+  end
+
+  def test_track_dedups_repeat_calls
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    assert_equal "1", get("/count?topic=room:lobby").body
+  end
+
+  # ---- count_humans / count_agents ----
+
+  def test_kind_counts
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:lobby&fd=2&as=user:99")
+    get("/track?topic=room:lobby&fd=3&as=agent")
+    assert_equal "3", get("/count?topic=room:lobby").body
+    assert_equal "2", get("/count_humans?topic=room:lobby").body
+    assert_equal "1", get("/count_agents?topic=room:lobby").body
+  end
+
+  # ---- untrack ----
+
+  def test_untrack_drops_one
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:lobby&fd=2&as=user:99")
+    res = get("/untrack?topic=room:lobby&fd=1")
+    assert_equal "1", res.body
+    assert_equal "1", get("/count?topic=room:lobby").body
+  end
+
+  def test_untrack_unknown_zero
+    res = get("/untrack?topic=never&fd=99")
+    assert_equal "0", res.body
+  end
+
+  # ---- untrack_by_fd (WS-close hook shape) ----
+
+  def test_untrack_by_fd_drops_across_topics
+    # One fd, three topics -- a human in three rooms simultaneously
+    # via one connection. Close their connection -> drop all three.
+    get("/track?topic=room:a&fd=1&as=user:42")
+    get("/track?topic=room:b&fd=1&as=user:42")
+    get("/track?topic=room:c&fd=1&as=user:42")
+    dropped = get("/untrack_by_fd?fd=1").body.to_i
+    assert_equal 3, dropped
+  end
+
+  # ---- topic segregation ----
+
+  def test_topics_dont_cross
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/track?topic=room:other&fd=2&as=user:99")
+    assert_equal "1", get("/count?topic=room:lobby").body
+    assert_equal "1", get("/count?topic=room:other").body
+  end
+
+  # ---- structured status ----
+
+  def test_status_defaults_to_available
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    res = get("/status_summary?topic=room:lobby&fd=1")
+    assert_equal "available||0", res.body
+  end
+
+  def test_set_status_busy
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/set_status?topic=room:lobby&fd=1&state=busy&note=working&until_ts=0")
+    res = get("/status_summary?topic=room:lobby&fd=1")
+    assert_equal "busy|working|0", res.body
+  end
+
+  def test_set_status_blocked_with_until
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/set_status?topic=room:lobby&fd=1&state=blocked&note=Claude API throttled&until_ts=2026200000")
+    res = get("/status_summary?topic=room:lobby&fd=1")
+    assert_equal "blocked|Claude API throttled|2026200000", res.body
+  end
+
+  def test_clear_status_resets
+    get("/track?topic=room:lobby&fd=1&as=user:42")
+    get("/set_status?topic=room:lobby&fd=1&state=busy&note=working&until_ts=0")
+    get("/clear_status?topic=room:lobby&fd=1")
+    res = get("/status_summary?topic=room:lobby&fd=1")
+    assert_equal "available||0", res.body
+  end
+
+  def test_set_status_unknown_entry_zero
+    res = get("/set_status?topic=never&fd=99&state=busy&note=&until_ts=0")
+    assert_equal "0", res.body
+  end
+end


### PR DESCRIPTION
First chunk of Battery 3. Tracks presence entries per (principal, session, topic) with the agentic split baked in — `kind ∈ {:human, :agent_for}`, `agent_id` populated when delegated. Builds on `req.identity` from Battery 1; diff broadcasting via Tep::Broadcast lands in chunk 3.2.

## Public surface

```ruby
# In a WS handler after auth:
Tep::Presence.track(req, "room:lobby", conn.fd)

# Drop on close:
Tep::Broadcast.unsubscribe_fd(conn.fd)        # broadcast cleanup
Tep::Presence.untrack_by_fd(conn.fd)          # presence cleanup

# Inspect:
entries = Tep::Presence.list("room:lobby")    # Array[PresenceEntry]
Tep::Presence.count("room:lobby")
Tep::Presence.count_humans("room:lobby")
Tep::Presence.count_agents("room:lobby")

# Status (per memory presence_status KISS spec):
Tep::Presence.set_status(topic, fd, :busy, "summarizing", 0)
Tep::Presence.set_status(topic, fd, :blocked, "API throttled", Time.now.to_i + 600)
Tep::Presence.clear_status(topic, fd)
```

## Entry shape

Each `Tep::PresenceEntry` carries:
- `topic`, `principal_id`, `kind`, `agent_id`, `fd`, `since`
- Inline structured status: `status_state` (`:available | :busy | :blocked`), `status_note`, `status_until`

`fd` is the session-id surrogate: one WS connection = one fd = one entry. A human in three browser tabs → three entries with `kind=:human`, three fds, same `principal_id`. An agent acting on behalf of that human → its own entry with `kind=:agent_for`, `agent_id` populated, separate fd. **Phoenix.Presence shape with the agentic `kind`+`agent_id` pair grafted on.**

## What's NOT in this chunk

- **Diff broadcasting.** Joins/leaves/updates via `Tep::Broadcast` land in chunk 3.2. Apps wanting reactivity build off `list()` snapshots for v1.
- **Cross-worker visibility.** PG-backed `presence_entries` table is chunk 3.3 (parallels Broadcast's PG backend).
- **Status auto-expiry.** `status_until` is stored but the background-reset fiber lands alongside the diff stream in 3.2.

## Spinel notes

- **Flat naming** (`Tep::Presence`, `Tep::PresenceEntry`) per the `cls_id`-risk discipline used across Auth + Broadcast batteries.
- **Top-level seeds** in `lib/tep.rb` pin param C types for every Presence cmeth — without these, compile units that don't exercise Presence default the params to `mrb_int` and the constructor calls inside method bodies mismatch the typed ivars.
- **Test wrinkle observed**: a newline separator (`"\n"`) inside the test `app_source` heredoc absorbed the heredoc's leading-line whitespace into subsequent output rows. Worked around by switching the test serializer to `";"` separator. May be a tep-translator-heredoc issue worth a separate filing — non-blocking.

## Validation

- `test/test_presence.rb`: **15 runs / 25 assertions / 0 failures**. Covers empty registry, track human, track agent (with delegation), multi-session, dedup-on-repeat-track, kind counts, untrack + untrack_by_fd, topic segregation, default status, set_status with note + until, clear_status, set_status on unknown entry.
- Full suite: **334 / 628 green / 0 failures / 0 errors / 47 skips**. Same upstream-blocked skip set as #22.

## Battery 3 roadmap

| Chunk | Status |
|---|---|
| **3.1 Core registry + status** | **this PR** |
| 3.2 Diff broadcasting via Tep::Broadcast | next |
| 3.3 PG-backed cross-worker visibility | after 3.2 |
| 3.4 Status auto-expiry sweep | small, can land alongside 3.2 |

After 3.2 + 3.3 land, Presence is fully usable in production prefork deployments — and the agentic "🤖 summarizer (busy: API throttled until 14:34)" scenario from the design doc becomes real code.