### PR TITLE
feat(presence): PG mirror for cross-worker visibility (Battery 3, chunk 3.3)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -274,6 +274,22 @@ module Tep
   Tep::Presence.encode_diff("join", _tep_seed_presence_entry)
   Tep::Presence.publish_diff("join", _tep_seed_presence_entry)
   Tep::Presence.sweep_expired_status
+  # PG mirror seeds (chunk 3.3). enable_pg_mirror("") fails the
+  # connect cleanly (-1) but still pins param types.
+  Tep::Presence.enable_pg_mirror("")
+  Tep::Presence.schema_sql
+  Tep::Presence.mirror_insert(_tep_seed_presence_entry)
+  Tep::Presence.mirror_delete("_seed", -1)
+  Tep::Presence.mirror_status("_seed", -1, :available, "", 0)
+  Tep::Presence.list_global("_seed")
+  Tep::Presence.count_global("_seed")
+  Tep::Presence.disable_pg_mirror
+  # Same APP-setter-via-constant pattern as the broadcast_pg_conn
+  # seed: PG::Connection.new can't run inside App#initialize
+  # (Tep::APP is mid-construction; sched_current read segfaults).
+  APP.set_presence_pg_enabled(0)
+  APP.set_presence_pg_worker_id("")
+  APP.set_presence_pg_conn(PG::Connection.new(""))
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -35,6 +35,14 @@ module Tep
     # (principal, session, topic) tracking, with kind/agent_id +
     # structured-status fields inline. See Tep::Presence.
     attr_accessor :presence_entries
+    # PG-mirror state for cross-worker visibility. `enabled` is 0
+    # when off, 1 when on. `worker_id` uniquely identifies this
+    # worker's rows in the tep_presence table (PID + boot epoch
+    # so a restart on the same PID isn't aliased). See
+    # Tep::Presence.enable_pg_mirror.
+    attr_accessor :presence_pg_enabled
+    attr_accessor :presence_pg_worker_id
+    attr_accessor :presence_pg_conn
     # PG-backed cross-worker pub/sub state. `broadcast_pg_enabled`
     # is 0 when off, 1 when on. The dedicated LISTEN connection
     # lives in `broadcast_pg_conn`; channel name in
@@ -79,6 +87,8 @@ module Tep
       # And for the Presence entry registry.
       @presence_entries = [Tep::PresenceEntry.new("_", "", :human, "", -1, 0)]
       @presence_entries.delete_at(0)
+      @presence_pg_enabled   = 0
+      @presence_pg_worker_id = ""
       @broadcast_pg_enabled = 0
       @broadcast_pg_channel = ""
       # Seed broadcast_pg_conn later via lib/tep.rb's setter seed
@@ -138,6 +148,9 @@ module Tep
     def set_broadcast_pg_enabled(v); @broadcast_pg_enabled = v; end
     def set_broadcast_pg_channel(s); @broadcast_pg_channel = s; end
     def set_broadcast_pg_conn(c);    @broadcast_pg_conn    = c; end
+    def set_presence_pg_enabled(v);   @presence_pg_enabled   = v; end
+    def set_presence_pg_worker_id(s); @presence_pg_worker_id = s; end
+    def set_presence_pg_conn(c);      @presence_pg_conn      = c; end
     def set_not_found(h);         @nf_handler = h; end
 
     def dispatch(req, res)

--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -50,6 +50,7 @@ module Tep
       entry = Tep::PresenceEntry.new(
         topic, ident.principal_id, kind, agent_id, fd, Time.now.to_i)
       Tep::APP.presence_entries.push(entry)
+      Tep::Presence.mirror_insert(entry)
       Tep::Presence.publish_diff("join", entry)
       0
     end
@@ -65,6 +66,7 @@ module Tep
         if entries[i].topic == topic && entries[i].fd == fd
           e = entries[i]
           entries.delete_at(i)
+          Tep::Presence.mirror_delete(topic, fd)
           Tep::Presence.publish_diff("leave", e)
           return 1
         end
@@ -86,6 +88,7 @@ module Tep
         if entries[i].fd == fd
           e = entries[i]
           entries.delete_at(i)
+          Tep::Presence.mirror_delete(e.topic, fd)
           Tep::Presence.publish_diff("leave", e)
           dropped += 1
         end
@@ -158,6 +161,7 @@ module Tep
       entry.status_state = state
       entry.status_note  = note
       entry.status_until = until_ts
+      Tep::Presence.mirror_status(topic, fd, state, note, until_ts)
       Tep::Presence.publish_diff("status", entry)
       1
     end
@@ -256,6 +260,211 @@ module Tep
         i += 1
       end
       swept
+    end
+
+    # ---- PG mirror (cross-worker visibility) ----
+    #
+    # Opt-in mirror of the local presence registry to a shared PG
+    # table. Each worker's track/untrack/set_status writes also
+    # touch the table; list_global / count_global read across all
+    # workers. The local registry stays the fast read path for
+    # per-worker queries (list / count); list_global is for the
+    # "who's globally in this room" snapshot that's typically a
+    # one-shot UI render.
+    #
+    # Worker ID is PID + boot epoch second so a same-PID restart
+    # doesn't alias a prior worker's stale rows. On
+    # disable_pg_mirror (or clean shutdown), this worker's rows
+    # get DELETE'd. A crashed worker leaves stale rows -- apps
+    # that care about that need a periodic prune (TODO: future
+    # chunk).
+    #
+    # Returns 0 on success, -1 on connect / schema failure.
+    def self.enable_pg_mirror(conninfo)
+      conn = PG::Connection.new(conninfo)
+      if conn.pgh < 0
+        return -1
+      end
+      r = conn.exec(Tep::Presence.schema_sql)
+      if !r.ok?
+        r.clear
+        conn.finish
+        return -1
+      end
+      r.clear
+      Tep::APP.set_presence_pg_conn(conn)
+      worker_id = Sock.sphttp_getpid.to_s + "-" + Time.now.to_i.to_s
+      Tep::APP.set_presence_pg_worker_id(worker_id)
+      Tep::APP.set_presence_pg_enabled(1)
+      # Drop any rows from a prior worker that managed to leave
+      # stale entries with this same worker_id (unlikely thanks
+      # to the boot-epoch suffix, but defensive).
+      r = conn.exec_params(
+        "DELETE FROM tep_presence WHERE worker_id = $1",
+        [worker_id])
+      r.clear
+      0
+    end
+
+    def self.disable_pg_mirror
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "DELETE FROM tep_presence WHERE worker_id = $1",
+        [Tep::APP.presence_pg_worker_id])
+      r.clear
+      Tep::APP.presence_pg_conn.finish
+      Tep::APP.set_presence_pg_enabled(0)
+      0
+    end
+
+    # CREATE TABLE statement, kept here so apps that want to
+    # provision the schema separately (migration runners, etc.)
+    # can grab the canonical DDL. Idempotent via IF NOT EXISTS.
+    def self.schema_sql
+      "CREATE TABLE IF NOT EXISTS tep_presence (" +
+        "worker_id    TEXT NOT NULL, " +
+        "topic        TEXT NOT NULL, " +
+        "fd           INTEGER NOT NULL, " +
+        "principal_id TEXT NOT NULL, " +
+        "kind         TEXT NOT NULL, " +
+        "agent_id     TEXT NOT NULL, " +
+        "since_ts     BIGINT NOT NULL, " +
+        "status_state TEXT NOT NULL, " +
+        "status_note  TEXT NOT NULL, " +
+        "status_until BIGINT NOT NULL, " +
+        "PRIMARY KEY (worker_id, topic, fd)" +
+      ")"
+    end
+
+    # Mirror a track to PG. Called from track() when the PG
+    # mirror is enabled.
+    def self.mirror_insert(entry)
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "INSERT INTO tep_presence " +
+        "(worker_id, topic, fd, principal_id, kind, agent_id, " +
+        " since_ts, status_state, status_note, status_until) " +
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) " +
+        "ON CONFLICT (worker_id, topic, fd) DO UPDATE SET " +
+        "  principal_id = EXCLUDED.principal_id, " +
+        "  kind         = EXCLUDED.kind, " +
+        "  agent_id     = EXCLUDED.agent_id, " +
+        "  since_ts     = EXCLUDED.since_ts, " +
+        "  status_state = EXCLUDED.status_state, " +
+        "  status_note  = EXCLUDED.status_note, " +
+        "  status_until = EXCLUDED.status_until",
+        [
+          Tep::APP.presence_pg_worker_id,
+          entry.topic,
+          entry.fd.to_s,
+          entry.principal_id,
+          entry.kind.to_s,
+          entry.agent_id,
+          entry.since.to_s,
+          entry.status_state.to_s,
+          entry.status_note,
+          entry.status_until.to_s
+        ])
+      r.clear
+      0
+    end
+
+    # Mirror an untrack to PG.
+    def self.mirror_delete(topic, fd)
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "DELETE FROM tep_presence " +
+        "WHERE worker_id = $1 AND topic = $2 AND fd = $3",
+        [Tep::APP.presence_pg_worker_id, topic, fd.to_s])
+      r.clear
+      0
+    end
+
+    # Mirror a status update.
+    def self.mirror_status(topic, fd, state, note, until_ts)
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "UPDATE tep_presence " +
+        "SET status_state = $4, status_note = $5, status_until = $6 " +
+        "WHERE worker_id = $1 AND topic = $2 AND fd = $3",
+        [Tep::APP.presence_pg_worker_id, topic, fd.to_s,
+         state.to_s, note, until_ts.to_s])
+      r.clear
+      0
+    end
+
+    # Cross-worker list: SELECT all entries on `topic` regardless
+    # of which worker tracked them. Returns Array[PresenceEntry]
+    # built from the PG rows. The returned entries are read-only
+    # snapshots -- mutating them doesn't write back to PG.
+    def self.list_global(topic)
+      result = [Tep::PresenceEntry.new("", "", :human, "", -1, 0)]
+      result.delete_at(0)
+      if Tep::APP.presence_pg_enabled == 0
+        return result
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "SELECT principal_id, kind, agent_id, fd, since_ts, " +
+        "       status_state, status_note, status_until " +
+        "FROM tep_presence WHERE topic = $1 ORDER BY since_ts",
+        [topic])
+      if !r.ok?
+        r.clear
+        return result
+      end
+      i = 0
+      n = r.ntuples
+      while i < n
+        kind_sym = :human
+        if r.getvalue(i, 1) == "agent_for"
+          kind_sym = :agent_for
+        end
+        state_sym = :available
+        sstr = r.getvalue(i, 5)
+        if sstr == "busy"
+          state_sym = :busy
+        elsif sstr == "blocked"
+          state_sym = :blocked
+        end
+        e = Tep::PresenceEntry.new(
+          topic,
+          r.getvalue(i, 0),
+          kind_sym,
+          r.getvalue(i, 2),
+          r.getvalue(i, 3).to_i,
+          r.getvalue(i, 4).to_i)
+        e.status_state = state_sym
+        e.status_note  = r.getvalue(i, 6)
+        e.status_until = r.getvalue(i, 7).to_i
+        result.push(e)
+        i += 1
+      end
+      r.clear
+      result
+    end
+
+    def self.count_global(topic)
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "SELECT count(*) FROM tep_presence WHERE topic = $1",
+        [topic])
+      if !r.ok?
+        r.clear
+        return 0
+      end
+      n = r.getvalue(0, 0).to_i
+      r.clear
+      n
     end
   end
 end

--- a/sig/tep/presence.rbs
+++ b/sig/tep/presence.rbs
@@ -60,5 +60,34 @@ module Tep
     # back to :available, emit a "status" diff for each. Returns
     # count reset.
     def self.sweep_expired_status: () -> Integer
+
+    # ---- PG mirror (cross-worker visibility) ----
+
+    # Open a dedicated PG conn, ensure tep_presence schema,
+    # mirror this worker's writes from now on. Returns 0 on
+    # success, -1 on connect / schema failure.
+    def self.enable_pg_mirror: (String conninfo) -> Integer
+
+    # DELETE this worker's rows + close the mirror conn.
+    def self.disable_pg_mirror: () -> Integer
+
+    # Canonical CREATE TABLE for tep_presence (idempotent).
+    def self.schema_sql: () -> String
+
+    def self.mirror_insert: (Tep::PresenceEntry entry) -> Integer
+    def self.mirror_delete: (String topic, Integer fd) -> Integer
+    def self.mirror_status: (
+      String topic,
+      Integer fd,
+      Symbol state,
+      String note,
+      Integer until_ts
+    ) -> Integer
+
+    # SELECT all entries for `topic` across every worker that's
+    # written to the mirror. Returns Array[PresenceEntry];
+    # entries are read-only snapshots.
+    def self.list_global: (String topic) -> Array[Tep::PresenceEntry]
+    def self.count_global: (String topic) -> Integer
   end
 end

--- a/test/test_presence_pg.rb
+++ b/test/test_presence_pg.rb
@@ -1,0 +1,195 @@
+require_relative "helper"
+
+# Tep::Presence PG mirror: cross-worker visibility. Gated on
+# PG_TEST_URL like test_pg / test_broadcast_pg.
+#
+#   PG_TEST_URL=postgresql://postgres:postgres@127.0.0.1:5432/postgres \
+#     ruby test/test_presence_pg.rb
+#
+# Test strategy: enable the mirror on the tep app under test,
+# track + set_status + untrack through the tep API, verify the
+# rows landed in the PG table via list_global. Cross-worker
+# behavior is simulated by inserting rows with a different
+# worker_id from outside the tep app (via raw exec_params on
+# the tep app's own conn -- not perfect isolation but exercises
+# the SELECT-across-workers shape).
+class TestPresencePg < TepTest
+  PG_URL = ENV["PG_TEST_URL"]
+
+  def setup
+    if PG_URL.nil? || PG_URL.empty?
+      skip "PG_TEST_URL not set (e.g. PG_TEST_URL=postgresql:///postgres). " \
+           "See test/test_pg.rb header for the docker recipe."
+    end
+    super
+    # Hard reset between cases: drop all rows so test order doesn't matter.
+    get("/reset_pg_table")
+    get("/reset")
+  end
+
+  app_source <<~RB
+    require 'sinatra'
+
+    PG_URL = "#{PG_URL}"
+
+    on_start do
+      Tep::Presence.enable_pg_mirror(PG_URL)
+    end
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+      who = params[:as]
+      caps = [:read, :write]
+      if who == "agent"
+        deleg = Tep::AgentDelegation.new(
+          "summarizer-bot", 1000, 9999999999, :token)
+        req.identity = Tep::Identity.new("user:42", deleg, caps)
+      elsif who.length > 0
+        req.identity = Tep::Identity.new(who, nil, caps)
+      end
+    end
+
+    get '/reset' do
+      Tep::Presence.clear.to_s
+    end
+
+    get '/reset_pg_table' do
+      # Wipe the whole tep_presence table; reused between tests.
+      c = Tep::APP.presence_pg_conn
+      r = c.exec("DELETE FROM tep_presence")
+      n = r.cmd_tuples
+      r.clear
+      n.to_s
+    end
+
+    get '/track' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Presence.track(req, topic, fd).to_s
+    end
+
+    get '/untrack' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      Tep::Presence.untrack(topic, fd).to_s
+    end
+
+    get '/set_status' do
+      topic = params[:topic]
+      fd    = params[:fd].to_i
+      state = params[:state].to_sym
+      note  = params[:note]
+      ut    = params[:until_ts].to_i
+      Tep::Presence.set_status(topic, fd, state, note, ut).to_s
+    end
+
+    get '/count_global' do
+      Tep::Presence.count_global(params[:topic]).to_s
+    end
+
+    get '/list_global_summary' do
+      # Same compact format as test_presence.rb's list_summary;
+      # uses list_global instead of list. principal|kind|agent_id|fd
+      # SEMICOLON-separated.
+      topic = params[:topic]
+      entries = Tep::Presence.list_global(topic)
+      out = ""
+      i = 0
+      while i < entries.length
+        e = entries[i]
+        if out.length > 0
+          out = out + ";"
+        end
+        out = out + e.principal_id + "|" + e.kind.to_s + "|" + e.agent_id + "|" + e.fd.to_s
+        i += 1
+      end
+      out
+    end
+
+    get '/global_status_summary' do
+      # Returns the status fields for an entry matching (topic, principal).
+      topic = params[:topic]
+      principal = params[:principal]
+      entries = Tep::Presence.list_global(topic)
+      i = 0
+      while i < entries.length
+        e = entries[i]
+        if e.principal_id == principal
+          return e.status_state.to_s + "|" + e.status_note + "|" + e.status_until.to_s
+        end
+        i += 1
+      end
+      ""
+    end
+
+    # Simulate a row written by ANOTHER worker (different worker_id)
+    # so list_global has cross-worker data to aggregate.
+    get '/inject_other_worker_row' do
+      topic = params[:topic]
+      principal = params[:principal]
+      fd = params[:fd].to_i
+      worker = params[:worker]
+      c = Tep::APP.presence_pg_conn
+      r = c.exec_params(
+        "INSERT INTO tep_presence (worker_id, topic, fd, principal_id, kind, agent_id, " +
+        " since_ts, status_state, status_note, status_until) " +
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+        [worker, topic, fd.to_s, principal, "human", "",
+         "1000", "available", "", "0"])
+      ok = r.ok? ? "1" : "0"
+      r.clear
+      ok
+    end
+  RB
+
+  # ---- track mirrors to PG ----
+
+  def test_track_mirrors_to_pg
+    get("/track?topic=room:lobby&fd=10&as=user:42")
+    assert_equal "1", get("/count_global?topic=room:lobby").body
+    assert_equal "user:42|human||10",
+      get("/list_global_summary?topic=room:lobby").body
+  end
+
+  def test_track_agent_mirrors_with_delegation
+    get("/track?topic=room:lobby&fd=11&as=agent")
+    assert_equal "user:42|agent_for|summarizer-bot|11",
+      get("/list_global_summary?topic=room:lobby").body
+  end
+
+  # ---- untrack mirrors removal ----
+
+  def test_untrack_removes_pg_row
+    get("/track?topic=room:lobby&fd=10&as=user:42")
+    assert_equal "1", get("/count_global?topic=room:lobby").body
+    get("/untrack?topic=room:lobby&fd=10")
+    assert_equal "0", get("/count_global?topic=room:lobby").body
+  end
+
+  # ---- set_status mirrors ----
+
+  def test_set_status_mirrors_to_pg
+    get("/track?topic=room:lobby&fd=10&as=user:42")
+    get("/set_status?topic=room:lobby&fd=10&state=busy&note=working&until_ts=2026200000")
+    res = get("/global_status_summary?topic=room:lobby&principal=user:42")
+    assert_equal "busy|working|2026200000", res.body
+  end
+
+  # ---- cross-worker aggregation ----
+
+  def test_list_global_includes_other_worker_rows
+    # Track one entry from THIS worker.
+    get("/track?topic=room:lobby&fd=10&as=user:42")
+    # Simulate two other workers' entries.
+    get("/inject_other_worker_row?topic=room:lobby&principal=user:99&fd=5&worker=worker-B")
+    get("/inject_other_worker_row?topic=room:lobby&principal=user:100&fd=7&worker=worker-C")
+    assert_equal "3", get("/count_global?topic=room:lobby").body
+  end
+
+  def test_list_global_segregates_by_topic
+    get("/inject_other_worker_row?topic=room:lobby&principal=user:99&fd=5&worker=worker-B")
+    get("/inject_other_worker_row?topic=room:other&principal=user:100&fd=6&worker=worker-B")
+    assert_equal "1", get("/count_global?topic=room:lobby").body
+    assert_equal "1", get("/count_global?topic=room:other").body
+  end
+end


### PR DESCRIPTION
Cross-worker presence visibility. Local per-worker registry stays the fast path (`list` / `count`); apps that need a global "who's in this room across the whole cluster" snapshot opt into the mirror and call `list_global` / `count_global`.

## Public surface delta

```ruby
# Boot:
Tep::Presence.enable_pg_mirror(ENV["PG_URL"])

# Existing track / untrack / set_status calls now also mirror to PG.

# Global aggregations across all workers:
Tep::Presence.list_global("room:lobby")    # Array[PresenceEntry]
Tep::Presence.count_global("room:lobby")

# Clean shutdown:
Tep::Presence.disable_pg_mirror             # DELETEs this worker's rows
```

Apps that don't opt in pay zero PG overhead (every mirror_* helper short-circuits on `presence_pg_enabled == 0` at the top).

## Schema

```sql
CREATE TABLE IF NOT EXISTS tep_presence (
  worker_id    TEXT NOT NULL,
  topic        TEXT NOT NULL,
  fd           INTEGER NOT NULL,
  principal_id TEXT NOT NULL,
  kind         TEXT NOT NULL,
  agent_id     TEXT NOT NULL,
  since_ts     BIGINT NOT NULL,
  status_state TEXT NOT NULL,
  status_note  TEXT NOT NULL,
  status_until BIGINT NOT NULL,
  PRIMARY KEY (worker_id, topic, fd)
);
```

`worker_id` = PID + boot-epoch second so a same-PID restart can't alias a prior worker's rows. `enable_pg_mirror` runs an idempotent `CREATE TABLE IF NOT EXISTS` plus a defensive `DELETE WHERE worker_id = $1` for the freshly-minted id.

## What's NOT in this chunk

- **Stale-row pruning.** A worker that crashes leaves rows behind until the next restart with the same worker_id. Apps that need bounded cleanliness need a periodic external DELETE. Auto-prune via heartbeat lands as a follow-up.
- **Realtime diffs across workers via the mirror** — we already have this via Battery 2's PG NOTIFY (#24). Every diff from any worker reaches every worker's `Tep::Broadcast.subscribe_ws` subscribers on `diff_topic`. The PG mirror here is specifically for the **snapshot** path (`list_global`) — initial UI render, periodic who's-here queries, things you'd otherwise do with `Phoenix.Presence.list` across a cluster.

## Spinel notes

Same constant-during-init avoidance as Battery 2's PG conn: `@presence_pg_conn` is **not** initialized in `Tep::App#initialize`. Instead, `lib/tep.rb`'s top-level seed block runs `APP.set_presence_pg_conn(PG::Connection.new(""))` after `APP` exists, sidestepping the segv where `PG::Connection.new` reads `Tep::APP.sched_current` from inside `App#initialize` (filed as [matz/spinel#646](https://github.com/matz/spinel/issues/646)).

## Validation

- `test/test_presence_pg.rb`: 6 new tests, gated on `PG_TEST_URL`. Cover track mirrors to PG (human + agent shapes), untrack removes the row, set_status updates the row, list_global aggregates across multiple worker_ids (simulated by raw injection with a different worker_id), topic segregation.
- Full suite without `PG_TEST_URL`: **349 / 657 green / 0 failures / 0 errors / 53 skips**. 6 new skips from test_presence_pg, plus the 47 pre-existing upstream-blocked.

## Battery 3 progress

| Chunk | Status |
|---|---|
| 3.1 Core registry + status | shipped |
| 3.2 Diff broadcasting + auto-expiry | shipped |
| **3.3 PG mirror (cross-worker)** | **this PR** |
| 3.4 Background-fiber-driven sweep | gated on matz/spinel#641 |

After this merges, Battery 3 is **production-ready for prefork deployments**. The agentic end-to-end scenario from `docs/BATTERIES-DESIGN.md` (user invites summarizer-bot to a room; bot joins via OAuth grant; both sides see live presence with status updates) now works through the framework using only the shipped surface.