### PR TITLE
feat(liveview): Tep::LiveView base + render_page bootstrap (Battery 4, chunk 4.1)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -45,6 +45,7 @@ require_relative "tep/auth_oauth2"
 require_relative "tep/auth"
 require_relative "tep/broadcast"
 require_relative "tep/presence"
+require_relative "tep/live_view"
 require_relative "tep/server"
 require_relative "tep/server_scheduled"
 require_relative "tep/sqlite"
@@ -290,6 +291,18 @@ module Tep
   APP.set_presence_pg_enabled(0)
   APP.set_presence_pg_worker_id("")
   APP.set_presence_pg_conn(PG::Connection.new(""))
+
+  # LiveView type-seeding (chunk 4.1). The render_page + dispatch_event
+  # cmeths get pinned via top-level calls; the base-class mount /
+  # render / handle_event imeths are pinned via a single noop
+  # instance call so subclass dispatch widens cleanly.
+  _tep_seed_live_view = Tep::LiveView.new
+  _tep_seed_live_view_req = Tep::Request.new
+  _tep_seed_live_view.mount(_tep_seed_live_view_req)
+  _tep_seed_live_view.render
+  _tep_seed_live_view.handle_event("", "", _tep_seed_live_view_req)
+  _tep_seed_live_view.dispatch_event_json("{}", _tep_seed_live_view_req)
+  Tep::LiveView.render_page("", "")
 
   # SQLite type-seeding. Each method below pins a parameter type
   # (or pulls the FFI return into use) so spinel emits the correct

--- a/lib/tep/live_view.rb
+++ b/lib/tep/live_view.rb
@@ -1,0 +1,144 @@
+# Tep::LiveView -- Phoenix.LiveView-shape server-rendered stateful
+# UI over WebSocket. Battery 4 in docs/BATTERIES-DESIGN.md.
+#
+# v1 (chunk 4.1) ships the bones: the base class apps subclass + a
+# pair of cmeths (render_page / dispatch_event) for the manual
+# wiring path. Auto-wiring (Tep.live "/path", CounterView), the
+# handle_broadcast hook, and presence-diff bindings land in 4.2 /
+# 4.3 -- they need either translator changes or the Scheduled
+# server to be reliable upstream (matz/spinel#641).
+#
+# Usage (chunk 4.1):
+#
+#   class CounterView < Tep::LiveView
+#     def initialize
+#       super
+#       @count = 0
+#     end
+#
+#     def render
+#       "<div id='tep-live-root'>Count: " + @count.to_s + "</div>"
+#     end
+#
+#     def handle_event(event, payload, req)
+#       if event == "inc"
+#         @count += 1
+#       end
+#       0
+#     end
+#   end
+#
+#   # Initial HTML: GET serves the rendered view wrapped in a
+#   # bootstrap shell that opens a WS to /counter_live + applies
+#   # incoming HTML to the #tep-live-root element.
+#   get "/counter" do
+#     v = CounterView.new
+#     v.mount(req)
+#     Tep::LiveView.render_page(v.render, "/counter_live")
+#   end
+#
+#   # WS handler -- per-connection view instance, event dispatch,
+#   # re-render + send on every event.
+#   websocket "/counter_live" do |ws|
+#     v = CounterView.new
+#     on_open do |evt|
+#       v.mount_via_ws
+#       ws.text(v.render)
+#     end
+#     on_message do |evt|
+#       Tep::LiveView.dispatch_event(v, evt.data, req)
+#       ws.text(v.render)
+#     end
+#   end
+#
+# Why the manual wiring shape: tep's bin/tep translator lowers the
+# `websocket` DSL into a generated route + per-event handler
+# subclasses, and the user-supplied block bodies are subject to
+# spinel's closure-capture limits. Wrapping the LiveView in the
+# block is the spinel-friendly path; auto-wire helpers can lean on
+# the translator in 4.2.
+module Tep
+  class LiveView
+    def initialize
+      0
+    end
+
+    # Called when the view boots -- once on the initial HTTP GET,
+    # once on WS open. Subclasses override to seed @ivars from
+    # req.params / req.identity / etc.
+    def mount(req)
+      0
+    end
+
+    # Render the view's current state to HTML. Subclasses override.
+    # Wrap your real content in an element with `id="tep-live-root"`
+    # so the client-side bootstrap can swap the innerHTML cleanly.
+    def render
+      "<div id='tep-live-root'></div>"
+    end
+
+    # Receive an event from the client. `event` and `payload` are
+    # strings (the client-side JS sends them as JSON). Subclasses
+    # mutate @ivars based on the event; the caller re-renders +
+    # sends the new HTML.
+    def handle_event(event, payload, req)
+      0
+    end
+
+    # Imeth bridge from the WS-side JSON wire format to the
+    # subclass's `handle_event`. Apps call this from their
+    # on_message block:
+    #
+    #   on_message do |evt|
+    #     v.dispatch_event_json(evt.data, req)
+    #     ws.text(v.render)
+    #   end
+    #
+    # Why an imeth and not a cmeth: spinel widens cmeth params
+    # to poly (sp_RbVal) when the cmeth has callers across
+    # multiple LiveView subclasses, but doesn't auto-box concrete
+    # subclass pointers into the poly slot at the call site. An
+    # imeth on the base class dispatches through the typed slot
+    # of the subclass instance and avoids the box.
+    def dispatch_event_json(json_msg, req)
+      event   = Tep::Json.get_str(json_msg, "event")
+      payload = Tep::Json.get_str(json_msg, "payload")
+      handle_event(event, payload, req)
+      0
+    end
+
+    # ---- helpers (cmeths so apps reach for them without a view
+    #      instance in scope) ----
+
+    # Wrap `content_html` in a full HTML page with the client-side
+    # bootstrap. The JS:
+    #
+    #   1. Opens a WS to `ws_path`.
+    #   2. On each incoming text frame: parses as HTML and assigns
+    #      to #tep-live-root's innerHTML.
+    #   3. Intercepts clicks on anything with [data-event] and
+    #      sends `{"event": <name>, "payload": <data-payload or "">}`
+    #      over the WS.
+    #
+    # That's all the client-side surface for v1. No morphdom, no
+    # form-data shipping, no key bindings -- "click + re-render"
+    # is enough to demonstrate the pattern. Future chunks can swap
+    # in morphdom for diff-on-client.
+    def self.render_page(content_html, ws_path)
+      "<!doctype html>\n<html><head><meta charset='utf-8'></head><body>\n" +
+        content_html + "\n" +
+        "<script>(function(){\n" +
+        "var ws=new WebSocket((location.protocol==='https:'?'wss://':'ws://')+location.host+'" + ws_path + "');\n" +
+        "ws.onmessage=function(e){var r=document.getElementById('tep-live-root');if(r){r.outerHTML=e.data;}};\n" +
+        "document.addEventListener('click',function(e){\n" +
+        "  var t=e.target;while(t&&!t.dataset.event){t=t.parentElement;}\n" +
+        "  if(!t)return;\n" +
+        "  e.preventDefault();\n" +
+        "  ws.send(JSON.stringify({event:t.dataset.event,payload:t.dataset.payload||''}));\n" +
+        "});\n" +
+        "})();</script>\n" +
+        "</body></html>\n"
+    end
+
+  end
+end

--- a/sig/tep/live_view.rbs
+++ b/sig/tep/live_view.rbs
@@ -1,0 +1,29 @@
+# Phoenix.LiveView-shape server-rendered stateful UI over
+# WebSocket. v1 chunk 4.1 ships the base class + render_page +
+# dispatch_event helpers. See lib/tep/live_view.rb +
+# docs/BATTERIES-DESIGN.md.
+module Tep
+  class LiveView
+    def initialize: () -> void
+
+    # Subclasses override to seed @ivars from the request.
+    def mount: (Tep::Request req) -> Integer
+
+    # Subclasses override to render the current state as HTML.
+    # Wrap real content in an element with id="tep-live-root".
+    def render: () -> String
+
+    # Subclasses override to mutate state on client events.
+    def handle_event: (String event, String payload, Tep::Request req) -> Integer
+
+    # Parse JSON-encoded {event, payload} from the client + call
+    # handle_event. Imeth so subclass dispatch goes through the
+    # typed slot.
+    def dispatch_event_json: (String json_msg, Tep::Request req) -> Integer
+
+    # Wrap content in a full HTML page with the client-side
+    # bootstrap (WS connect + innerHTML swap + click->event
+    # dispatch).
+    def self.render_page: (String content_html, String ws_path) -> String
+  end
+end

--- a/test/test_live_view.rb
+++ b/test/test_live_view.rb
@@ -1,0 +1,139 @@
+require_relative "helper"
+
+# Tep::LiveView base class + helpers (Battery 4 chunk 4.1).
+# v1 ships the manual-wiring path: a base class apps subclass +
+# the render_page / dispatch_event cmeths. Auto-wiring lands in
+# 4.2; these tests cover the building blocks.
+class TestLiveView < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    # A counter view: state is an integer; "inc" increments,
+    # "dec" decrements, "reset" zeroes.
+    class CounterView < Tep::LiveView
+      attr_accessor :count
+      def initialize
+        super
+        @count = 0
+      end
+      def mount(req)
+        # Pull a seed value from the request's params if present;
+        # otherwise leave at 0.
+        seed = req.params["seed"]
+        if seed.length > 0
+          @count = seed.to_i
+        end
+        0
+      end
+      def render
+        "<div id='tep-live-root'>Count: " + @count.to_s + "</div>"
+      end
+      def handle_event(event, payload, req)
+        if event == "inc"
+          @count += 1
+        elsif event == "dec"
+          @count -= 1
+        elsif event == "reset"
+          @count = 0
+        end
+        0
+      end
+    end
+
+    # Per-request scratchpad: the test app boots once, but we
+    # need a fresh view per request so tests don't pollute each
+    # other. The handler routes below construct a view, run the
+    # operation, return the result; no cross-request state.
+
+    before do
+      res.headers["Content-Type"] = "text/plain"
+    end
+
+    get '/initial_render' do
+      v = CounterView.new
+      v.mount(req)
+      v.render
+    end
+
+    get '/render_page' do
+      Tep::LiveView.render_page("<p>hi</p>", "/_live")
+    end
+
+    get '/event_inc' do
+      v = CounterView.new
+      v.mount(req)
+      v.dispatch_event_json("{\\"event\\":\\"inc\\",\\"payload\\":\\"\\"}", req)
+      v.render
+    end
+
+    get '/event_chain' do
+      # Multiple events through the same view to verify state
+      # carries forward.
+      v = CounterView.new
+      v.mount(req)
+      v.dispatch_event_json("{\\"event\\":\\"inc\\",\\"payload\\":\\"\\"}", req)
+      v.dispatch_event_json("{\\"event\\":\\"inc\\",\\"payload\\":\\"\\"}", req)
+      v.dispatch_event_json("{\\"event\\":\\"inc\\",\\"payload\\":\\"\\"}", req)
+      v.dispatch_event_json("{\\"event\\":\\"dec\\",\\"payload\\":\\"\\"}", req)
+      v.render
+    end
+
+    get '/event_unknown' do
+      v = CounterView.new
+      v.mount(req)
+      v.dispatch_event_json("{\\"event\\":\\"never\\",\\"payload\\":\\"\\"}", req)
+      v.render
+    end
+
+    get '/base_class_render' do
+      # The Tep::LiveView base class's default render is a noop
+      # shell -- subclasses are expected to override.
+      Tep::LiveView.new.render
+    end
+  RB
+
+  def test_initial_render_default_count
+    res = get("/initial_render")
+    assert_equal "<div id='tep-live-root'>Count: 0</div>", res.body
+  end
+
+  def test_mount_picks_seed_from_params
+    res = get("/initial_render?seed=42")
+    assert_equal "<div id='tep-live-root'>Count: 42</div>", res.body
+  end
+
+  def test_render_page_wraps_content_and_includes_bootstrap
+    res = get("/render_page").body
+    assert_includes res, "<!doctype html>"
+    assert_includes res, "<p>hi</p>"
+    # The bootstrap script connects to the supplied WS path.
+    assert_includes res, "new WebSocket"
+    assert_includes res, "/_live"
+    # Click->event dispatch wire shape (uses t.dataset.event on the
+    # client side).
+    assert_includes res, "dataset.event"
+    # innerHTML/outerHTML swap on incoming frame.
+    assert_includes res, "outerHTML"
+  end
+
+  def test_dispatch_event_inc
+    res = get("/event_inc").body
+    assert_equal "<div id='tep-live-root'>Count: 1</div>", res
+  end
+
+  def test_dispatch_event_chain_preserves_state_across_events
+    # 3 inc + 1 dec = 2
+    res = get("/event_chain").body
+    assert_equal "<div id='tep-live-root'>Count: 2</div>", res
+  end
+
+  def test_dispatch_event_unknown_event_is_noop
+    res = get("/event_unknown").body
+    assert_equal "<div id='tep-live-root'>Count: 0</div>", res
+  end
+
+  def test_base_class_render_is_empty_shell
+    res = get("/base_class_render").body
+    assert_equal "<div id='tep-live-root'></div>", res
+  end
+end


### PR DESCRIPTION
First chunk of Battery 4. Ships the bones: a base class apps subclass + a `render_page` cmeth that wraps content in an HTML page with the client-side bootstrap (WS connect + innerHTML swap on receive + click→event dispatch). Apps wire routes manually via the existing `websocket` DSL in this chunk; auto-wiring helpers land in 4.2.

## Usage

```ruby
class CounterView < Tep::LiveView
  def initialize
    super
    @count = 0
  end

  def mount(req)
    seed = req.params["seed"]
    if seed.length > 0
      @count = seed.to_i
    end
    0
  end

  def render
    "<div id='tep-live-root'>Count: " + @count.to_s + "</div>"
  end

  def handle_event(event, payload, req)
    if event == "inc"
      @count += 1
    end
    0
  end
end

# Initial HTTP GET: render once + ship the bootstrap shell.
get "/counter" do
  v = CounterView.new
  v.mount(req)
  Tep::LiveView.render_page(v.render, "/counter_live")
end

# WS endpoint: per-connection view, event dispatch loop.
websocket "/counter_live" do |ws|
  v = CounterView.new
  on_open do |evt|
    ws.text(v.render)
  end
  on_message do |evt|
    v.dispatch_event_json(evt.data, req)
    ws.text(v.render)
  end
end
```

## Client-side bootstrap

~10 lines of inline JS:
1. Opens a WS to the supplied path on page load.
2. Each incoming text frame replaces `#tep-live-root`'s `outerHTML` with the new server HTML.
3. Clicks on any `[data-event]` element send `{"event": <name>, "payload": <data-payload>}` over the WS.

**No morphdom, no form submission, no key bindings.** "Click + re-render" is the v1 shape; morphdom can land later.

## Spinel constraint navigated

`dispatch_event_json` is an **imeth** on `Tep::LiveView`, not a cmeth. A cmeth taking `view` as a param widens it to `sp_RbVal` across multiple LiveView subclasses, and spinel doesn't auto-box concrete subclass pointers into the poly slot at the call site. The imeth dispatches through the subclass instance's typed slot, sidestepping the boxing entirely. Worth filing against spinel if it bites in other places — for this chunk, the imeth shape is the right shape regardless (better OO ergonomics).

## What's NOT in this chunk

- **`Tep.live "/path", CounterView` auto-wiring.** Apps wire two routes manually for now. Auto-wire needs translator changes or a pattern that side-steps closure capture across the `websocket "/path" do |ws|` block.
- **`handle_broadcast(msg)` callback** — auto-subscribe to a topic + re-render on receive. Lands in 4.2.
- **`handle_presence_diff(diff)` callback** — auto-subscribe to a `presence:<topic>` channel. Lands in 4.3.
- **Diff-on-client via morphdom** — v1 ships full innerHTML/outerHTML swap.

## Validation

- `test/test_live_view.rb`: **7 runs / 18 assertions / 0 failures**. Covers initial render with default state, mount picking seed from params, render_page wrapping content + bootstrap script, dispatch_event single + chain + unknown event, base-class render is empty shell.
- Full suite: **356 / 675 green / 0 failures / 0 errors / 53 skips**. Same upstream-blocked skip set as #22.

## Battery 4 roadmap

| Chunk | Status |
|---|---|
| **4.1 Base class + render_page bootstrap** | **this PR** |
| 4.2 `handle_broadcast` auto-binding + Tep.live helper | next |
| 4.3 `handle_presence_diff` auto-binding | after 4.2 |
| 4.4 Optional morphdom client | when wire size starts to matter |

After 4.2 lands the agentic end-to-end flow from `docs/BATTERIES-DESIGN.md` will be wireable — a chat-room LiveView whose `handle_broadcast` fires on new messages + whose `handle_presence_diff` fires on agents joining / leaving / blocked-by-API.