### PR TITLE
feat(liveview): topic + broadcast_render binding (Battery 4, chunk 4.2)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -302,6 +302,8 @@ module Tep
   _tep_seed_live_view.render
   _tep_seed_live_view.handle_event("", "", _tep_seed_live_view_req)
   _tep_seed_live_view.dispatch_event_json("{}", _tep_seed_live_view_req)
+  _tep_seed_live_view.topic
+  _tep_seed_live_view.broadcast_render
   Tep::LiveView.render_page("", "")
 
   # SQLite type-seeding. Each method below pins a parameter type

--- a/lib/tep/live_view.rb
+++ b/lib/tep/live_view.rb
@@ -85,6 +85,35 @@ module Tep
       0
     end
 
+    # Topic this view is bound to for broadcast fan-out. Default
+    # is the empty string -- subclasses override to return a
+    # stable id (e.g. "room:" + @id.to_s). When non-empty, the
+    # broadcast_render helper publishes re-renders here so every
+    # subscribed WS sees the new HTML.
+    def topic
+      ""
+    end
+
+    # Re-render + publish the result to self.topic via
+    # Tep::Broadcast. Apps call this from handle_event after
+    # mutating state; subscribed WSes -- including the originating
+    # client -- receive the new HTML and the client-side bootstrap
+    # outerHTML-swaps it into the DOM.
+    #
+    # Returns the local-match count from Tep::Broadcast.publish
+    # (number of WSes that received the re-render on this worker).
+    # 0 here is ambiguous between "no topic configured" (skip) and
+    # "topic configured but no subscribers" -- the empty-topic path
+    # short-circuits without calling publish, so callers that
+    # want to distinguish can check `topic.length == 0` themselves.
+    def broadcast_render
+      t = topic
+      if t.length == 0
+        return 0
+      end
+      Tep::Broadcast.publish(t, render)
+    end
+
     # Imeth bridge from the WS-side JSON wire format to the
     # subclass's `handle_event`. Apps call this from their
     # on_message block:

--- a/sig/tep/live_view.rbs
+++ b/sig/tep/live_view.rbs
@@ -16,6 +16,14 @@ module Tep
     # Subclasses override to mutate state on client events.
     def handle_event: (String event, String payload, Tep::Request req) -> Integer
 
+    # Topic this view binds to for broadcast fan-out. Default "";
+    # subclasses override to return a stable id.
+    def topic: () -> String
+
+    # Publish self.render to self.topic via Tep::Broadcast.
+    # No-op when topic is empty.
+    def broadcast_render: () -> Integer
+
     # Parse JSON-encoded {event, payload} from the client + call
     # handle_event. Imeth so subclass dispatch goes through the
     # typed slot.

--- a/test/test_live_view.rb
+++ b/test/test_live_view.rb
@@ -90,6 +90,48 @@ class TestLiveView < TepTest
       # shell -- subclasses are expected to override.
       Tep::LiveView.new.render
     end
+
+    # ---- chunk 4.2: broadcast binding ----
+
+    # A view bound to a topic. Setting the topic via a class
+    # constant rather than a per-instance ivar so the test
+    # endpoint doesn't need to thread state across calls.
+    class RoomView < Tep::LiveView
+      def topic
+        "room:lobby"
+      end
+      def render
+        "<div id='tep-live-root'>room:lobby</div>"
+      end
+    end
+
+    # Default base class topic.
+    get '/base_topic' do
+      Tep::LiveView.new.topic
+    end
+
+    # Subclass with overridden topic.
+    get '/room_topic' do
+      RoomView.new.topic
+    end
+
+    # broadcast_render on a topic-less view is a no-op (returns 0).
+    get '/broadcast_noop_topicless' do
+      Tep::LiveView.new.broadcast_render.to_s
+    end
+
+    # broadcast_render with a topic + an existing subscriber.
+    get '/broadcast_render_match_count' do
+      # Subscribe a fake fd to room:lobby so broadcast_render has
+      # someone to match.
+      Tep::Broadcast.clear
+      Tep::Broadcast.subscribe("room:lobby", -1)
+      v = RoomView.new
+      "topic=" + v.topic +
+        "|subs=" + Tep::Broadcast.subscribers_for("room:lobby").to_s +
+        "|direct_publish=" + Tep::Broadcast.publish("room:lobby", "x").to_s +
+        "|broadcast_render=" + v.broadcast_render.to_s
+    end
   RB
 
   def test_initial_render_default_count
@@ -135,5 +177,33 @@ class TestLiveView < TepTest
   def test_base_class_render_is_empty_shell
     res = get("/base_class_render").body
     assert_equal "<div id='tep-live-root'></div>", res
+  end
+
+  # ---- chunk 4.2: broadcast binding ----
+
+  def test_base_class_topic_is_empty
+    assert_equal "", get("/base_topic").body
+  end
+
+  def test_subclass_topic_override
+    assert_equal "room:lobby", get("/room_topic").body
+  end
+
+  def test_broadcast_render_noop_when_topicless
+    # broadcast_render on a view with no topic is a no-op
+    # (subscribers can't bind to "" topics).
+    assert_equal "0", get("/broadcast_noop_topicless").body
+  end
+
+  def test_broadcast_render_publishes_to_topic
+    # Pre-subscribe a fake fd to room:lobby. broadcast_render
+    # should publish + match the subscriber.
+    res = get("/broadcast_render_match_count").body
+    # res shape:
+    #   topic=room:lobby|subs=1|direct_publish=1|broadcast_render=1
+    assert_match(/topic=room:lobby/, res)
+    assert_match(/subs=1/, res)
+    assert_match(/direct_publish=1/, res)
+    assert_match(/broadcast_render=1/, res)
   end
 end


### PR DESCRIPTION
Adds the topic-binding primitives that connect `Tep::LiveView` to `Tep::Broadcast`. Apps now write live state fan-out in one line.

## Public surface delta

```ruby
view.topic              # subclasses override; default ""
view.broadcast_render   # publish self.render to self.topic
```

Typical handler shape after this chunk:

```ruby
class ChatView < Tep::LiveView
  def topic; "room:lobby"; end
  def render; "<div id='tep-live-root'>" + @msg + "</div>"; end
  def handle_event(event, payload, req)
    if event == "send"
      @msg = payload
      broadcast_render   # → Tep::Broadcast.publish(topic, render)
    end
    0
  end
end

websocket "/chat_live" do |ws|
  v = ChatView.new
  on_open do |evt|
    Tep::Broadcast.subscribe_ws(v.topic, ws.fd)
    ws.text(v.render)
  end
  on_message do |evt|
    v.dispatch_event_json(evt.data, req)
    # broadcast_render inside handle_event already sent the
    # new HTML to every subscribed WS (including this one).
  end
  on_close do |evt|
    Tep::Broadcast.unsubscribe_fd(ws.fd)
  end
end
```

## What's NOT in this chunk

- **Server-side `handle_broadcast(msg)` intercept.** The design doc's full shape (a background fiber per WS that re-renders on broadcast receipt) needs `Tep::Server::Scheduled` reliable under sustained load — gated on matz/spinel#641. Until then, broadcasts go **directly to clients as already-rendered HTML**; the publisher (handle_event) is responsible for rendering once per state change.
- **`Tep.live "/path", view` auto-route helper.** Apps wire two routes manually. Auto-wire lands when we have a way to bridge the closure / runtime-class issue without translator changes.

## `broadcast_render` return value

Returns the publish match count (number of WSes that received the re-render on this worker). Lets handlers log "n viewers updated" if they want. `0` is ambiguous between "no topic configured" and "topic with no subscribers"; the empty-topic path short-circuits before `publish`, so callers can disambiguate via `topic.length == 0` if needed.

## Validation

- `test/test_live_view.rb`: **11 runs / 29 assertions / 0 failures** (was 7 / 18 in #29). New tests cover default `topic == ""`, subclass topic override, `broadcast_render` no-op when topicless, `broadcast_render` publishes to topic + matches a pre-subscribed fd.
- Full suite: **360 / 686 green / 0 failures / 0 errors / 53 skips**. One transient failure on the first attempt in `TestAuthSessionCookie` (a known intermittent flake seen across prior runs); passes on re-run. Not introduced by this chunk.

## Battery 4 progress

| Chunk | Status |
|---|---|
| 4.1 Base + render_page bootstrap | shipped |
| **4.2 topic + broadcast_render** | **this PR** |
| 4.3 Presence diff binding | next |
| 4.4 Morphdom client | deferred |