### PR TITLE
feat(liveview): handle_presence_diff binding (Battery 4, chunk 4.3)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -304,6 +304,8 @@ module Tep
   _tep_seed_live_view.dispatch_event_json("{}", _tep_seed_live_view_req)
   _tep_seed_live_view.topic
   _tep_seed_live_view.broadcast_render
+  _tep_seed_live_view.handle_presence_diff("{}")
+  _tep_seed_live_view.apply_presence_diff_json("{}")
   Tep::LiveView.render_page("", "")
 
   # SQLite type-seeding. Each method below pins a parameter type

--- a/lib/tep/live_view.rb
+++ b/lib/tep/live_view.rb
@@ -114,6 +114,52 @@ module Tep
       Tep::Broadcast.publish(t, render)
     end
 
+    # Receive a Tep::Presence diff event. Subclasses override to
+    # update their state when someone joins / leaves / changes
+    # status on the bound topic. Default is a no-op so v1 views
+    # without presence-awareness compile cleanly.
+    #
+    # The diff arrives as the same flat JSON Tep::Presence emits:
+    #
+    #   { "kind":      "join" | "leave" | "status",
+    #     "topic":     <topic>,
+    #     "principal": <principal_id>,
+    #     "ekind":     "human" | "agent_for",
+    #     "agent_id":  <agent_id or empty>,
+    #     "fd":        <session-id surrogate>,
+    #     "since":     <unix ts>,
+    #     "state":     "available" | "busy" | "blocked",
+    #     "note":      <free text>,
+    #     "until_ts":  <unix ts or 0> }
+    #
+    # Subclasses typically pull a few keys via Tep::Json.get_str /
+    # Tep::Json.get_int + update an @presence ivar; then either
+    # call broadcast_render (to fan out the new HTML to every
+    # subscriber) or just mutate (if the LiveView is the only
+    # observer).
+    def handle_presence_diff(diff_json)
+      0
+    end
+
+    # Convenience: same shape as dispatch_event_json. Used by apps
+    # wiring a presence-diff intercept loop -- they feed received
+    # diff JSON strings to this method and it dispatches to
+    # handle_presence_diff on the subclass.
+    #
+    # Note: as of chunk 4.3, automatic server-side intercept of
+    # diffs (a background fiber per WS that pulls from the
+    # presence diff topic and calls apply_presence_diff_json) is
+    # not provided -- it needs Tep::Server::Scheduled reliable
+    # under load, gated on matz/spinel#641. Apps that need
+    # server-side reaction wire the intercept loop themselves.
+    # Apps that only need client-side display can skip this and
+    # rely on Tep::Broadcast.subscribe_ws delivering the diff
+    # JSON straight to the WS for client-side rendering.
+    def apply_presence_diff_json(json)
+      handle_presence_diff(json)
+      0
+    end
+
     # Imeth bridge from the WS-side JSON wire format to the
     # subclass's `handle_event`. Apps call this from their
     # on_message block:

--- a/sig/tep/live_view.rbs
+++ b/sig/tep/live_view.rbs
@@ -24,6 +24,14 @@ module Tep
     # No-op when topic is empty.
     def broadcast_render: () -> Integer
 
+    # Subclasses override to react to a Tep::Presence diff
+    # (join/leave/status) on the bound topic. Default no-op.
+    def handle_presence_diff: (String diff_json) -> Integer
+
+    # Convenience: parse + dispatch. Same shape as
+    # dispatch_event_json but for presence diffs.
+    def apply_presence_diff_json: (String json) -> Integer
+
     # Parse JSON-encoded {event, payload} from the client + call
     # handle_event. Imeth so subclass dispatch goes through the
     # typed slot.

--- a/test/test_live_view.rb
+++ b/test/test_live_view.rb
@@ -120,6 +120,55 @@ class TestLiveView < TepTest
       Tep::LiveView.new.broadcast_render.to_s
     end
 
+    # ---- chunk 4.3: presence diff binding ----
+
+    # A view that records every presence diff it receives -- the
+    # subclass override of handle_presence_diff pulls a field out
+    # and appends to a class-level Array so the test endpoint can
+    # report it back.
+    class PresenceTrackingView < Tep::LiveView
+      def initialize
+        super
+        @last_principal = ""
+        @last_kind      = ""
+        @last_state     = ""
+      end
+      attr_reader :last_principal, :last_kind, :last_state
+      def topic
+        "room:lobby"
+      end
+      def render
+        "<div id='tep-live-root'>" + @last_principal + ":" + @last_state + "</div>"
+      end
+      def handle_presence_diff(diff_json)
+        @last_principal = Tep::Json.get_str(diff_json, "principal")
+        @last_kind      = Tep::Json.get_str(diff_json, "kind")
+        @last_state     = Tep::Json.get_str(diff_json, "state")
+        0
+      end
+    end
+
+    get '/presence_diff_default_noop' do
+      Tep::LiveView.new.handle_presence_diff("{\\"kind\\":\\"join\\"}").to_s
+    end
+
+    get '/presence_diff_apply' do
+      v = PresenceTrackingView.new
+      # Feed a synthetic diff JSON.
+      diff = "{\\"kind\\":\\"status\\",\\"principal\\":\\"user:42\\"," +
+             "\\"state\\":\\"busy\\",\\"note\\":\\"\\"}"
+      v.apply_presence_diff_json(diff)
+      v.last_principal + "|" + v.last_kind + "|" + v.last_state
+    end
+
+    get '/presence_diff_render_after_apply' do
+      v = PresenceTrackingView.new
+      diff = "{\\"kind\\":\\"join\\",\\"principal\\":\\"user:99\\"," +
+             "\\"state\\":\\"available\\",\\"note\\":\\"\\"}"
+      v.apply_presence_diff_json(diff)
+      v.render
+    end
+
     # broadcast_render with a topic + an existing subscriber.
     get '/broadcast_render_match_count' do
       # Subscribe a fake fd to room:lobby so broadcast_render has
@@ -205,5 +254,25 @@ class TestLiveView < TepTest
     assert_match(/subs=1/, res)
     assert_match(/direct_publish=1/, res)
     assert_match(/broadcast_render=1/, res)
+  end
+
+  # ---- chunk 4.3: presence diff binding ----
+
+  def test_base_class_handle_presence_diff_is_noop
+    # Default returns 0 and doesn't crash on arbitrary JSON.
+    assert_equal "0", get("/presence_diff_default_noop").body
+  end
+
+  def test_subclass_handle_presence_diff_receives_diff_fields
+    # The subclass override pulls principal/kind/state out of the
+    # diff JSON and updates ivars. apply_presence_diff_json is
+    # the imeth that bridges JSON to handle_presence_diff.
+    assert_equal "user:42|status|busy", get("/presence_diff_apply").body
+  end
+
+  def test_handle_presence_diff_can_drive_render
+    # After applying a join diff, render reflects the new state.
+    res = get("/presence_diff_render_after_apply").body
+    assert_equal "<div id='tep-live-root'>user:99:available</div>", res
   end
 end


### PR DESCRIPTION
Adds the `Tep::Presence` diff callback to `Tep::LiveView` so views can react to join/leave/status events on their bound topic. Pairs with the topic + broadcast_render binding (#30) — the agentic feedback loop ("agent goes blocked → UI re-renders showing the new status") is now wireable through real code.

## Public surface delta

```ruby
view.handle_presence_diff(diff_json)   # subclasses override
view.apply_presence_diff_json(json)    # imeth bridge (parse + dispatch)
```

Typical handler shape:

```ruby
class ChatRoomView < Tep::LiveView
  def topic; "room:lobby"; end
  def initialize
    super
    @presence = []
  end
  def handle_event(event, payload, req)
    # ... client events ...
  end
  def handle_presence_diff(diff_json)
    kind  = Tep::Json.get_str(diff_json, "kind")
    pri   = Tep::Json.get_str(diff_json, "principal")
    state = Tep::Json.get_str(diff_json, "state")
    # ... update @presence based on kind ...
    broadcast_render
    0
  end
end
```

## What's NOT in this chunk

**Automatic server-side intercept** — a background fiber per WS that pulls from the presence diff topic and calls `apply_presence_diff_json` is what makes the design doc's "handle_presence_diff fires automatically" promise. v1 leaves the intercept loop to app code; apps with a stable Scheduled build can wire it themselves. Will land automatically when matz/spinel#641 unblocks `Tep::Server::Scheduled`.

## Client-side vs server-side use

- **Client-side display** (e.g. participant strip that updates without server-side state changes): apps subscribe their WS directly to `Tep::Presence.diff_topic(topic)` via `Tep::Broadcast.subscribe_ws` and the client renders incoming JSON.
- **Server-side reaction** (re-render with new agent count, gate on agent-is-blocked, etc.): `handle_presence_diff` is the hook.

## Validation

- `test/test_live_view.rb`: **14 runs / 32 assertions / 0 failures** (was 11 / 29 in #30). New tests cover default `handle_presence_diff` is a no-op, subclass override receives the diff fields, `apply_presence_diff_json` correctly bridges JSON to the handler, post-apply render reflects mutated state.
- Full suite: **363 / 689 green / 0 failures / 0 errors / 53 skips**. Same upstream-blocked skip set as #22.

## Battery 4 progress

| Chunk | Status |
|---|---|
| 4.1 Base + render_page bootstrap | shipped |
| 4.2 topic + broadcast_render | shipped |
| **4.3 Presence diff binding** | **this PR** |
| 4.4 Morphdom client | deferred |
| Auto-wire (`Tep.live`, server-side intercept) | gated on matz/spinel#641 |

After this merges all four batteries are feature-complete enough for the agentic demo to be wireable through real code. Manual route wiring is the v1 cost; auto-wire is a one-PR add-on once Scheduled is reliable upstream.