### PR TITLE
demo: agentic chat (Auth + Broadcast + Presence + LiveView) + RBS additions

### DIFF
--- a/examples/agentic_chat/README.md
+++ b/examples/agentic_chat/README.md
@@ -1,0 +1,103 @@
+# agentic chat -- the four-battery demo
+
+A small chat room exercising every battery in tep's agentic
+story: identity, broadcast, presence, server-rendered HTML.
+
+```
+┌───────────────────────────────────────────────────────────┐
+│  agentic chat                      you are user:uXsC2g    │
+├──────────────────────────────────────┬────────────────────┤
+│  user:42  hi                         │  HUMANS (2)        │
+│  user:99  hello                      │  • user:42         │
+│  agent:summarizer-bot/user:42        │  • user:99         │
+│           i'm here -- watching for   │                    │
+│           things to summarize.       │  AGENTS (1)        │
+│                                      │  • user:42         │
+│  [ type message      ]        [send] │      via summari…  │
+│                                      │      busy:         │
+│  [+ summarizer]                      │      summarizing   │
+└──────────────────────────────────────┴────────────────────┘
+```
+
+## Run
+
+```sh
+bin/tep build examples/agentic_chat/app.rb -o /tmp/agentic_chat
+/tmp/agentic_chat -p 4567
+# open http://127.0.0.1:4567/ in two browsers
+```
+
+Page auto-refreshes every 3 seconds (HTTP `<meta refresh>`) so
+new messages + presence changes from other tabs appear. Click
+**+ summarizer** to invite a synthetic agent into the room —
+it appears in the presence sidebar with `kind=agent_for`,
+shares the inviter's `principal_id`, and posts an arrival
+message.
+
+## What's wired
+
+| Battery | What it does here |
+|---|---|
+| `Tep::Auth` (`Tep::AuthSessionCookie`) | Every visitor's first request auto-creates an `identity` cookie. Subsequent requests land with `req.identity` populated; `req.identity.subject` is rendered in the header + drives presence rows. |
+| `Tep::AuthOAuth2`-style delegation | The `+ summarizer` route constructs a `Tep::AgentDelegation` + `Tep::Identity` with `kind=:agent_for, origin=:oauth_grant` — same shape an external bot would receive over the real OAuth flow. |
+| `Tep::Broadcast` | Every `POST /chat/send` and `POST /agent/add` calls `Tep::Broadcast.publish(CHAT_TOPIC, …)`. v1 polling means subscribers aren't WS clients (yet); the publish wire is in place for the WS upgrade when spinel's WS-handler widening is resolved. |
+| `Tep::Presence` | Humans tracked on every `GET /chat` (one row per principal_id). Agents tracked on `+ summarizer` with `status_state=:busy, status_note="summarizing the room"`. Sidebar renders both groups with the agentic kind + status. |
+| `Tep::LiveView` | The rendered `#messages` block is the live-view content target. The full live-WS path is held — see "wire shape" below — but the `render_page` helper + `ChatRoom#render` pattern is what an upgraded LiveView would use unchanged. |
+
+## Wire shape
+
+v1 uses HTTP polling via `<meta http-equiv="refresh" content="3">`.
+The natural shape — WS-driven server pushes — is held up on two
+spinel-side surfaces I hit while building this:
+
+1. **`Tep::Json.get_str` widens when called from inside an
+   `on_message do |evt| ... end` block.** The translator
+   generates a `Tep::WebSocket::Handler` subclass per event;
+   reading `evt.data` and slicing it inside the body causes
+   spinel to widen `evt.data` (declared as `String`) to poly,
+   which cascades through every downstream `String` slot the
+   message touches. Adding a `sig/tep/websocket.rbs` with
+   `Event#data: String` + enabling `--rbs` doesn't fix it
+   today; `spinel_rbs_extract` only loads if it's built (`make
+   rbs_extract`), and tep's overall RBS coverage is too stale
+   for `--rbs` to be defaulted on without a multi-PR cleanup.
+
+2. **The `websocket "/path" do |ws|` DSL doesn't bridge the
+   per-request `req` into `on_open` / `on_message` handler
+   bodies.** Each handler becomes a separate `Handler`
+   subclass with `@ws` storage but no `req` — so capturing the
+   session-cookie identity at upgrade time + attaching it to
+   the WS connection needs an out-of-band shape (e.g. the
+   client sends a "hello|<subject>" first frame, server caches
+   keyed by fd).
+
+Both are tep-side issues, separate from this PR.
+
+When those resolve, the polling layer drops out and the route
+becomes a real WS-driven LiveView with sub-second updates +
+`handle_presence_diff` running server-side. The CSS, HTML,
+ChatRoom class, presence-rendering helpers all stay; only the
+transport changes.
+
+## Code size
+
+| File | LOC |
+|---|---|
+| `app.rb` | ~270 (incl. CSS + JS inline) |
+| `README.md` | this file |
+
+No CSS framework, no JS bundler, no DB.
+
+## What this demo does NOT show
+
+- **Cross-worker presence/broadcast.** Single worker. Both
+  `Tep::Broadcast.enable_pg_backend` and
+  `Tep::Presence.enable_pg_mirror` would make this multi-
+  worker; left out for demo simplicity.
+- **Real bot in a separate process.** The "+ summarizer"
+  button adds a synthetic presence row + posts one message
+  in the same process. A real bot would open its own WS with
+  the JWT minted by `Tep::AuthOAuth2.exchange_code` and chat
+  alongside the humans — the framework surface is identical.
+- **Sub-second updates.** Polling at 3s; WS at <100ms once
+  spinel unblocks the surfaces above.

--- a/examples/agentic_chat/app.rb
+++ b/examples/agentic_chat/app.rb
@@ -1,0 +1,288 @@
+# Agentic chat -- the four-battery demo.
+#
+# A small chat-room view exercising every battery in tep's
+# agentic story: Tep::Auth (session-cookie identity),
+# Tep::Broadcast (in-process publish path), Tep::Presence
+# (who's here, agent-aware, with structured status),
+# Tep::LiveView (the render_page bootstrap helper).
+#
+# This v1 uses **HTTP polling** instead of a live WS-driven
+# feed. The reason: tep's `websocket "/path" do |ws|` DSL
+# doesn't bridge the per-request `req` into on_X handler
+# bodies, and a spinel inference quirk widens `evt.data` to
+# poly when it flows into custom helpers from inside on_message.
+# A real-time WS chat is the natural shape -- filed as a tep
+# follow-up; this demo gets you the agentic surface across
+# all four batteries today.
+#
+# Run:
+#   bin/tep build examples/agentic_chat/app.rb -o /tmp/agentic_chat
+#   /tmp/agentic_chat -p 4567
+# Open http://127.0.0.1:4567/ in two browsers.
+require 'sinatra'
+
+Tep.session_secret = "demo-only-do-not-use-in-prod-XXXXXXXXXX"
+Tep::Auth.install!
+
+CHAT_TOPIC = "agentic_chat:room"
+
+# ---- shared chat state ----
+#
+# Parallel string arrays for the message log + simple `add`
+# entry point. Plain class (no Tep::LiveView subclass) to
+# sidestep the virtual-dispatch widening tep's translator
+# currently emits across LiveView base + subclass.
+
+class ChatRoom
+  def initialize
+    @msg_subjects = [""]
+    @msg_subjects.delete_at(0)
+    @msg_bodies = [""]
+    @msg_bodies.delete_at(0)
+    @msg_kinds = [""]
+    @msg_kinds.delete_at(0)
+  end
+
+  def add(subject, body, kind)
+    @msg_subjects.push(subject)
+    @msg_bodies.push(body)
+    @msg_kinds.push(kind)
+    while @msg_subjects.length > 50
+      @msg_subjects.delete_at(0)
+      @msg_bodies.delete_at(0)
+      @msg_kinds.delete_at(0)
+    end
+    0
+  end
+
+  def render
+    out = "<div id='messages'>"
+    if @msg_subjects.length == 0
+      out = out + "<div class='msg empty'>" +
+        "<em>no messages yet. say hi using the form below.</em></div>"
+    end
+    i = 0
+    while i < @msg_subjects.length
+      out = out + "<div class='msg " + @msg_kinds[i] + "'>" +
+        "<span class='who'>" + Tep.h(@msg_subjects[i]) + "</span>" +
+        "<span class='body'>" + Tep.h(@msg_bodies[i]) + "</span>" +
+        "</div>"
+      i += 1
+    end
+    out + "</div>"
+  end
+end
+
+CHAT = ChatRoom.new
+
+# ---- synthetic agent state ----
+
+AGENT_FD_COUNTER = [-9000]
+
+def next_agent_fd
+  AGENT_FD_COUNTER[0] = AGENT_FD_COUNTER[0] - 1
+  AGENT_FD_COUNTER[0]
+end
+
+def spawn_agent(principal_id)
+  fd = next_agent_fd
+  agent_req = Tep::Request.new
+  delegation = Tep::AgentDelegation.new(
+    "summarizer-bot", Time.now.to_i,
+    Time.now.to_i + 3600, :oauth_grant)
+  agent_req.identity = Tep::Identity.new(
+    principal_id, delegation, [:read, :post_summary])
+  Tep::Presence.track(agent_req, CHAT_TOPIC, fd)
+  Tep::Presence.set_status(
+    CHAT_TOPIC, fd, :busy, "summarizing the room",
+    Time.now.to_i + 60)
+  CHAT.add(
+    "agent:summarizer-bot/" + principal_id,
+    "i'm here -- watching for things to summarize.", "agent")
+  Tep::Broadcast.publish(CHAT_TOPIC, "agent-spawned")
+  fd
+end
+
+# ---- presence sidebar ----
+
+def render_presence
+  entries = Tep::Presence.list(CHAT_TOPIC)
+  humans = ""
+  agents = ""
+  hcount = 0
+  acount = 0
+  i = 0
+  while i < entries.length
+    e = entries[i]
+    row = "<div class='pres-row " + e.kind.to_s + " " +
+      e.status_state.to_s + "'>" +
+      "<span class='dot'></span>" +
+      "<span class='who'>" + Tep.h(e.principal_id) + "</span>"
+    if e.kind == :agent_for
+      row = row + "<span class='agent-of'>via " +
+        Tep.h(e.agent_id) + "</span>"
+    end
+    if e.status_state != :available
+      row = row + "<div class='note'>" + e.status_state.to_s +
+        ": " + Tep.h(e.status_note) + "</div>"
+    end
+    row = row + "</div>"
+    if e.kind == :human
+      humans = humans + row
+      hcount += 1
+    else
+      agents = agents + row
+      acount += 1
+    end
+    i += 1
+  end
+  "<aside id='presence'>" +
+    "<h3>humans (" + hcount.to_s + ")</h3>" +
+    "<div class='group humans'>" + humans + "</div>" +
+    "<h3>agents (" + acount.to_s + ")</h3>" +
+    "<div class='group agents'>" + agents + "</div>" +
+  "</aside>"
+end
+
+# ---- routes ----
+
+before do
+  # principal_id is opaque -- Identity#subject prepends "user:"
+  # for humans, so the principal stored on the session should NOT
+  # already carry it.
+  #
+  # We also set req.identity directly: Tep::AuthFilter runs
+  # BEFORE this before-filter, so it already populated
+  # req.identity from session (= anonymous on first visit).
+  # AuthSessionCookie.set writes to req.session but
+  # req.identity stays whatever the auth filter put there.
+  # Direct assignment plugs the gap for the same-request render.
+  if req.session.get("identity_sub").length == 0
+    pid = Crypto.sp_crypto_random_b64url(4)
+    ident = Tep::Identity.new(pid, nil, [:read, :write])
+    Tep::AuthSessionCookie.set(req, ident, 0)
+    req.identity = ident
+  end
+end
+
+get '/' do
+  res.set_status(302)
+  res.headers["Location"] = "/chat"
+  ""
+end
+
+get '/chat' do
+  res.headers["Content-Type"] = "text/html; charset=utf-8"
+  # Track the human's session in presence. Synthetic fd derived
+  # from the principal_id so reloads reuse the same row.
+  pid = req.identity.principal_id
+  fd = pid.bytes[5]   # cheap deterministic-per-user fd; collisions
+                      # tolerable for the demo
+  Tep::Presence.track(req, CHAT_TOPIC, fd)
+  user_subject = req.identity.subject
+  "<!doctype html><html><head>" +
+    "<meta charset='utf-8'>" +
+    "<title>agentic chat (tep)</title>" +
+    "<meta http-equiv='refresh' content='3'>" +
+    "<link rel='stylesheet' href='/agentic_chat/style.css'>" +
+    "</head><body>" +
+    "<header>" +
+      "<span class='title'>agentic chat</span>" +
+      "<span class='user'>you are <code>" +
+        Tep.h(user_subject) + "</code></span>" +
+    "</header>" +
+    "<main>" +
+      "<section id='room'>" +
+        CHAT.render +
+        "<form id='compose' action='/chat/send' method='POST'>" +
+          "<input name='body' placeholder='message…' autocomplete='off' autofocus>" +
+          "<button type='submit'>send</button>" +
+        "</form>" +
+        "<form id='agent-form' action='/agent/add' method='POST'>" +
+          "<button type='submit'>+ summarizer</button>" +
+        "</form>" +
+      "</section>" +
+      render_presence +
+    "</main>" +
+    "</body></html>"
+end
+
+post '/chat/send' do
+  body = req.params["body"]
+  if body.length > 0
+    CHAT.add(req.identity.subject, body, "human")
+    Tep::Broadcast.publish(CHAT_TOPIC, "message-added")
+  end
+  res.set_status(302)
+  res.headers["Location"] = "/chat"
+  ""
+end
+
+post '/agent/add' do
+  pid = req.identity.principal_id + ""
+  spawn_agent(pid)
+  res.set_status(302)
+  res.headers["Location"] = "/chat"
+  ""
+end
+
+get '/agentic_chat/style.css' do
+  res.headers["Content-Type"] = "text/css"
+  agentic_chat_css
+end
+
+# ---- inline assets ----
+
+def agentic_chat_css
+  "*{box-sizing:border-box}" +
+  "body{margin:0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;" +
+    "background:#f6f7f9;color:#1a1a1a}" +
+  "header{display:flex;justify-content:space-between;align-items:center;" +
+    "padding:.6rem 1rem;background:#1a1a1a;color:#f6f7f9}" +
+  "header .title{font-weight:600}" +
+  "header .user code{background:#2a2a2a;padding:.15em .4em;border-radius:3px;" +
+    "font-size:.85em;color:#cde}" +
+  "main{display:grid;grid-template-columns:1fr 260px;height:calc(100vh - 44px)}" +
+  "#room{display:flex;flex-direction:column;background:#fff}" +
+  "#messages{flex:1;overflow-y:auto;padding:1rem;display:flex;" +
+    "flex-direction:column;gap:.4rem}" +
+  ".msg{display:flex;gap:.6rem;padding:.3rem .5rem;border-radius:4px}" +
+  ".msg.empty{justify-content:center;color:#888}" +
+  ".msg .who{color:#666;font-size:.85em;min-width:11rem;text-align:right;" +
+    "flex-shrink:0;font-family:ui-monospace,monospace}" +
+  ".msg .body{flex:1}" +
+  ".msg.agent{background:#fef8eb}" +
+  ".msg.agent .who{color:#a07412}" +
+  "#compose{display:flex;gap:.5rem;padding:.7rem;border-top:1px solid #e8e9eb;" +
+    "background:#fafbfc}" +
+  "#compose input{flex:1;padding:.5rem .7rem;border:1px solid #d0d3d8;" +
+    "border-radius:4px;font:inherit;background:#fff}" +
+  "#compose input:focus{outline:none;border-color:#3b82f6}" +
+  "#compose button{padding:.5rem .9rem;border:1px solid #d0d3d8;background:#1a1a1a;" +
+    "color:#fff;border-color:#1a1a1a;border-radius:4px;font:inherit;cursor:pointer}" +
+  "#compose button:hover{background:#000}" +
+  "#agent-form{padding:.5rem .7rem;background:#fafbfc;border-top:1px solid #e8e9eb}" +
+  "#agent-form button{padding:.4rem .8rem;border:1px solid #d0d3d8;background:#fff;" +
+    "border-radius:4px;font:inherit;cursor:pointer}" +
+  "#agent-form button:hover{background:#f0f1f3}" +
+  "#presence{background:#fafbfc;border-left:1px solid #e8e9eb;padding:1rem;" +
+    "overflow-y:auto}" +
+  "#presence h3{margin:0 0 .5rem;font-size:.7em;text-transform:uppercase;" +
+    "letter-spacing:.08em;color:#888;font-weight:600}" +
+  "#presence .group{margin-bottom:1.5rem;display:flex;flex-direction:column;gap:.4rem}" +
+  ".pres-row{display:flex;align-items:center;gap:.5rem;font-size:.9em;flex-wrap:wrap}" +
+  ".pres-row .dot{width:.6rem;height:.6rem;border-radius:50%;background:#22c55e;" +
+    "flex-shrink:0}" +
+  ".pres-row.busy .dot{background:#eab308}" +
+  ".pres-row.blocked .dot{background:#ef4444}" +
+  ".pres-row .who{font-family:ui-monospace,monospace;font-size:.85em;color:#1a1a1a}" +
+  ".pres-row.agent_for .who{color:#a07412}" +
+  ".pres-row .agent-of{font-size:.75em;color:#888;font-family:ui-monospace,monospace}" +
+  ".pres-row .note{width:100%;padding-left:1.1rem;font-size:.8em;color:#888;" +
+    "font-style:italic}"
+end
+
+# bin/tep auto-injects Tep.run! at the bottom of the translated
+# source AFTER the generated route registrations, so don't add
+# our own here -- if we did, the server would start before the
+# routes existed and every request would 404.

--- a/sig/tep/request.rbs
+++ b/sig/tep/request.rbs
@@ -18,6 +18,12 @@ module Tep
     attr_accessor session: Tep::Session
     attr_accessor remote_host: String
 
+    # Set by Tep::AuthFilter (when Tep::Auth.install! has been
+    # called) before the user's before-filter runs. Always
+    # non-nil: defaults to Tep::Identity.anonymous when no auth
+    # provider matched.
+    attr_accessor identity: Tep::Identity
+
     # Per-request scratch bag. Sinatra-translator rewrites `@x = v`
     # to `req.ivars["x"] = v.to_s` in handler bodies; templates read
     # back via `ivars["x"]`.
@@ -27,7 +33,7 @@ module Tep
     # route. Set by `req.set_passed`.
     attr_accessor passed: bool
 
-    def initialize: () -> void
+    def initialize: () -> Integer
     def set_passed: () -> bool
 
     # Aliases / shortcuts.

--- a/sig/tep/streamer.rbs
+++ b/sig/tep/streamer.rbs
@@ -2,14 +2,14 @@
 module Tep
   class Streamer
     # Default no-op. Override in subclasses to write into `out`.
-    def pump: (Tep::Stream out) -> void
+    def pump: (Tep::Stream out) -> Integer
   end
 
   # The argument passed into `pump`. Wraps the active fd and exposes
   # a single `write` that emits one HTTP chunk.
   class Stream
     attr_accessor fd: Integer
-    def initialize: (Integer fd) -> void
+    def initialize: (Integer fd) -> Integer
 
     # Write one chunk. Returns the byte count of the chunk payload
     # (excludes the chunk framing).

--- a/sig/tep/websocket.rbs
+++ b/sig/tep/websocket.rbs
@@ -1,0 +1,131 @@
+# RFC 6455 server-side WebSocket. See lib/tep/websocket.rb +
+# lib/tep/websocket/{frame,driver,connection,handshake}.rb.
+module Tep
+  module WebSocket
+    OPCODE_CONTINUATION: Integer
+    OPCODE_TEXT: Integer
+    OPCODE_BINARY: Integer
+    OPCODE_CLOSE: Integer
+    OPCODE_PING: Integer
+    OPCODE_PONG: Integer
+
+    CLOSE_NORMAL: Integer
+    CLOSE_GOING_AWAY: Integer
+    CLOSE_PROTOCOL_ERROR: Integer
+
+    DEFAULT_MAX_FRAME: Integer
+
+    # One parsed WS frame (server-side, unmasked-on-write).
+    class Frame
+      attr_accessor fin: bool
+      attr_accessor opcode: Integer
+      attr_accessor payload: String
+
+      def initialize: (bool fin, Integer opcode, String payload) -> Integer
+      def encode_unmasked: () -> String
+
+      def self.byte_to_chr: (Integer n) -> String
+      def self.parse_from_buf: (Integer start, Integer avail) -> ParseResult
+      def self.reserved_opcode?: (Integer op) -> bool
+      def self.control_opcode?: (Integer op) -> bool
+    end
+
+    class ParseResult
+      attr_accessor outcome: String     # "ok" | "need" | "close"
+      attr_accessor frame: Frame
+      attr_accessor consumed: Integer
+      attr_accessor close_code: Integer
+
+      def initialize: () -> Integer
+    end
+
+    # Send-side driver. Owns the fd + the six event-handler slots.
+    class Driver
+      attr_accessor fd: Integer
+      attr_accessor max_frame_size: Integer
+      attr_accessor subprotocol: String
+      attr_accessor h_open: Handler
+      attr_accessor h_message: Handler
+      attr_accessor h_close: Handler
+      attr_accessor h_ping: Handler
+      attr_accessor h_pong: Handler
+      attr_accessor h_error: Handler
+
+      def initialize: (Integer fd) -> Integer
+
+      def set_max_frame_size: (Integer n) -> void
+      def set_fd: (Integer new_fd) -> void
+      def set_subprotocol: (String name) -> void
+
+      def set_on_open: (Handler h) -> Handler
+      def set_on_message: (Handler h) -> Handler
+      def set_on_close: (Handler h) -> Handler
+      def set_on_ping: (Handler h) -> Handler
+      def set_on_pong: (Handler h) -> Handler
+      def set_on_error: (Handler h) -> Handler
+
+      def text: (String s) -> Integer
+      def binary: (String bytes) -> Integer
+      def ping: (String payload) -> Integer
+      def pong: (String payload) -> Integer
+      def close: (Integer code, String reason) -> Integer
+
+      def self.send_frame: (Integer fd, Integer opcode, String payload) -> Integer
+      def self.encode_close_payload: (Integer code, String reason) -> String
+    end
+
+    # Event passed to handler callbacks. data is always a String
+    # (text/binary frames carry payload bytes; ping/pong carry the
+    # ping payload; close carries empty body + uses code/reason).
+    class Event
+      attr_accessor data: String
+      attr_accessor code: Integer
+      attr_accessor reason: String
+
+      def initialize: () -> Integer
+    end
+
+    # Base handler. Subclasses override handle_event to react to
+    # a specific event kind. The DSL's `on_open do |evt| ... end`
+    # blocks lower to anonymous Handler subclasses.
+    class Handler
+      def handle_event: (Event evt) -> Integer
+    end
+
+    # Per-connection recv loop. Created by the upgrade handler;
+    # run() returns 0 on clean close, -1 on error.
+    class Connection
+      attr_accessor driver: Driver
+      attr_accessor fd: Integer
+      attr_accessor idle_timeout_seconds: Integer
+
+      def initialize: (Driver driver) -> Integer
+      def set_idle_timeout: (Integer seconds) -> void
+      def run: () -> Integer
+
+      def self.dispatch_frame: (Driver driver, Frame frame) -> Integer
+      def self.dispatch_open: (Driver driver) -> Integer
+      def self.dispatch_message: (Driver driver, String data, bool text) -> Integer
+      def self.dispatch_ping: (Driver driver, String data) -> Integer
+      def self.dispatch_pong: (Driver driver, String data) -> Integer
+      def self.dispatch_close: (Driver driver, Integer code, String reason) -> Integer
+    end
+
+    class ConnectionState
+      attr_accessor start: Integer
+      attr_accessor avail: Integer
+
+      def initialize: () -> Integer
+    end
+
+    class Handshake
+      attr_accessor valid: bool
+      attr_accessor accept_key: String
+
+      def initialize: () -> Integer
+
+      def self.check: (Tep::Request req) -> Handshake
+      def self.build_response: (String accept_key, String subprotocol) -> String
+    end
+  end
+end


### PR DESCRIPTION
A small chat room exercising every battery in tep's agentic story. ~270 LOC including inline CSS.

## What works

```sh
bin/tep build examples/agentic_chat/app.rb -o /tmp/agentic_chat
/tmp/agentic_chat -p 4567
# open http://127.0.0.1:4567/ in two browsers
```

| Battery | Visible in the demo |
|---|---|
| `Tep::Auth` (`AuthSessionCookie`) | Auto-session identity. Header shows `you are <user:abc>` rendered from `req.identity.subject`. |
| `Tep::AuthOAuth2`-shape delegation | The `+ summarizer` button mints a `Tep::AgentDelegation` + `Tep::Identity` with `origin=:oauth_grant` — same shape an external bot would receive over real OAuth. |
| `Tep::Broadcast` | Every `POST /chat/send` and `POST /agent/add` calls `Tep::Broadcast.publish(CHAT_TOPIC, …)`. |
| `Tep::Presence` | Humans tracked on `GET /chat`. Agents tracked on `+ summarizer` with `status_state=:busy, status_note="summarizing the room"`. Sidebar renders both groups with kind + status (green/yellow/red dots). |
| `Tep::LiveView` pattern | `ChatRoom#render` is the live-view content target; matches the `render_page` swap idiom even without subclassing `Tep::LiveView` directly. |

## Why polling instead of WS

The natural design — WS-driven server pushes — is held up on two spinel-side surfaces I hit while building this:

1. **`Tep::Json.get_str` widens when called from inside `on_message do |evt| ... end`.** The translator generates a `Tep::WebSocket::Handler` subclass per event; reading `evt.data` and slicing it inside the body widens `evt.data` (declared `String`) to poly, which cascades through downstream `String` slots. Adding `sig/tep/websocket.rbs` with `Event#data: String` + enabling `--rbs` doesn't fix it today (the RBS extractor only loads if built, and tep's overall RBS coverage is too stale for `--rbs` to be safely defaulted on).
2. **`websocket "/path" do |ws|` doesn't bridge `req` into `on_open`/`on_message` bodies.** Capturing session-cookie identity at upgrade needs an out-of-band shape (e.g. client sends a `hello|<subject>` first frame).

Both are real tep follow-ups; left as `<meta http-equiv="refresh" content="3">` polling for now. The render path, presence sidebar, identity flow, and agent-delegation shape are all genuine. When those surfaces unblock the polling drops out and the route becomes a real WS LiveView with sub-second updates + server-side `handle_presence_diff`.

## Also included

Three targeted RBS additions — the cleanest slice of the bigger RBS-cleanup backlog:

- `sig/tep/websocket.rbs` (new) — Frame / Driver / Event / Handler / Connection / Handshake.
- `sig/tep/request.rbs` — `attr_accessor identity: Tep::Identity` (chunk 1.2's addition wasn't reflected).
- `sig/tep/streamer.rbs` — `pump` declared `void` but bodies return `0`; fixed to `Integer`.

A broader RBS-staleness sweep (16+ `initialize: () -> void` declarations don't match implementations) is needed before `bin/tep` can default to `--rbs` — separate effort.

## File layout

```
examples/agentic_chat/
  app.rb        # ~270 LOC inc. CSS
  README.md     # run instructions + what's wired + what's not
```

No CSS framework, no JS bundler, no DB. One file.