### PR TITLE
chore(ci): unskip what's now passing post spinel #641, #642, #643

### DIFF
--- a/test/test_parallel.rb
+++ b/test/test_parallel.rb
@@ -4,15 +4,6 @@ require_relative "helper"
 # Worker against a small input list and checks both the
 # result-collecting and fire-and-forget shapes.
 class TestParallel < TepTest
-  # Upstream-blocked on matz/spinel#643: File.write inside
-  # Tep::Parallel#spawn_one passes a poly-typed (sp_RbVal) value
-  # to the :str FFI arg without unboxing, gcc rejects the cast.
-  # Reproduces on clean main against current spinel master. Drop
-  # this skip when #643 closes.
-  def setup
-    skip "blocked on matz/spinel#643 (:str FFI arg poly-unbox missing)"
-    super
-  end
 
   app_source <<~RB
     require 'sinatra'

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -9,14 +9,15 @@ require_relative "helper"
 #     (sphttp_connect) to make the listener readable, the scheduler's
 #     next tick picks up the readiness and resumes the fiber.
 class TestScheduler < TepTest
-  # Upstream-blocked on matz/spinel#641: Tep::Server::Scheduled
-  # segfaults under any non-trivial concurrent workload due to the
-  # post-#636 per-fiber GC root save/restore not walking
-  # sp_fiber_root's saved region. PR up at matz/spinel#641 (this
-  # side authored + bisected + patched); waiting on merge. Drop
-  # this skip when #641 closes.
+  # Upstream still has issues: matz/spinel#641 (per-fiber GC root)
+  # is now merged, but the prefork handler in /cooperate still
+  # SIGSEGVs on the Tep::Scheduler.clear + spawn_fiber +
+  # run_until_empty path. Likely a separate spinel issue worth
+  # filing once we have a smaller standalone repro; for now the
+  # class stays skipped so the suite's signal stays useful.
   def setup
-    skip "blocked on matz/spinel#641 (Tep::Server::Scheduled GC-root regression)"
+    skip "blocked on a separate spinel issue (#641 merged but " \
+         "Tep::Scheduler primitives still SIGSEGV in prefork handlers)"
     super
   end
 

--- a/test/test_server_scheduled.rb
+++ b/test/test_server_scheduled.rb
@@ -37,11 +37,6 @@ class TestServerScheduled < TepTest
   end
 
   def test_post_body_through_scheduler
-    # The POST-body path through Tep::Server::Scheduled trips a
-    # fiber + GC root interaction matz/spinel#641 covers (the GET
-    # variants in this class don't exercise the same draining
-    # sequence). Drop this skip when #641 closes.
-    skip "blocked on matz/spinel#641 (Tep::Server::Scheduled POST-body interaction)"
     res = post("/upper", "hello world")
     assert_equal "200", res.code
     assert_equal "HELLO WORLD", res.body


### PR DESCRIPTION
Spinel master shipped three relevant fixes in the last 24h:

| Commit | Issue | Effect |
|---|---|---|
| `c0d9c37` | #641 (our PR) | Per-fiber GC root walk — `Tep::Server::Scheduled` GC regression closed |
| `37649bd` | #642 | Warn on missing required positional arg |
| `4783559` | #643 | `File.write` unboxes poly path/data args |

Together they unskip:

- **`TestParallel`** (all 3 tests) — #643 closed.
- **`TestServerScheduled#test_post_body_through_scheduler`** — #641 closed.

`TestScheduler` stays skipped: the `/cooperate` route still SIGSEGVs on the `Tep::Scheduler.clear + spawn_fiber + run_until_empty` path inside a prefork handler. The crash is specific to prefork-handler-spawning-fibers (Scheduled server's own WS tests are green), so it's a separate spinel issue from #641. Worth filing once I have a smaller standalone repro; for now this class stays skipped with an updated comment.

## Test suite delta

| | Before | After |
|---|---|---|
| runs | 363 | 363 |
| assertions | 689 | 699 |
| failures | 0 | 0 |
| errors | 0 | 0 |
| skips | 53 | 49 |

10 more assertions actually run; 4 tests un-skipped. CI signal is now broader against current spinel master.

## Confirmed-still-open on spinel master `423aea5`

- **#645** (String#rindex Optional<Int> doesn't narrow through ternary) — [confirming comment posted](https://github.com/matz/spinel/issues/645).
- **#646** (constant-during-init segfault) — [confirming comment posted](https://github.com/matz/spinel/issues/646); workaround in tep documented.
- Newly filed **OriPekelman/tep#34** — `Tep::Json.get_str` from inside `websocket on_message` widens `evt.data` to poly + breaks build. Affects the agentic chat demo's WS upgrade path.