### PR TITLE
chore: nil-narrow Session#load_from rindex post matz/spinel#645

### DIFF
--- a/lib/tep/session.rb
+++ b/lib/tep/session.rb
@@ -42,7 +42,7 @@ module Tep
         return false
       end
       dot = cookie_value.rindex(".")
-      if dot < 0
+      if dot.nil?
         return false
       end
       payload = cookie_value[0, dot]


### PR DESCRIPTION
## Summary

`String#rindex(str)` now returns `int?` upstream
([matz/spinel#645](https://github.com/matz/spinel/issues/645),
spinel fe91c01) and flow-narrows through a `.nil?` guard. The old
`if dot < 0` was the pre-narrowing workaround; with the fix
landed, the idiomatic `.nil?` is correct and reads cleaner.

Behavior unchanged — the only path that mattered was "no dot in
cookie value," handled before via `-1` sentinel and now via `nil`.

## Test plan

- [x] `ruby test/test_sessions.rb` green (4 runs).
- [x] `ruby test/test_auth_session_cookie.rb` green across 3 random seeds (12 runs each).
- [x] Build / runtime check via single-route repro (`v.rindex(".")` + `dot.nil?` + slice).
- [ ] Full `make test` — one flake in `test_human_caps_round_trip` during a parallel-suite run; passes cleanly standalone. Pre-existing parallelism flake, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)