### PR TITLE
fix(agentic_chat): URL-encode form body so req.params parses it

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 A Sinatra-flavoured web framework that compiles to a native binary
 via [Spinel][spinel].
 
+> **Current release:** [v0.7.0](https://github.com/OriPekelman/tep/releases/tag/v0.7.0)
+> — the four-battery release (Auth, Broadcast, Presence, LiveView).
+> Pre-alpha; API still in motion.
+
 > **Pre-alpha.** Tep exists primarily to exercise Spinel against
 > real-world Ruby code. The framework happens to be useful too —
 > it's a fast, single-binary HTTP server with the Sinatra DSL most

--- a/examples/agentic_chat/app.rb
+++ b/examples/agentic_chat/app.rb
@@ -246,7 +246,12 @@ def agentic_chat_js
   "function tepSend(ev){" +
     "ev.preventDefault();" +
     "var f = ev.target;" +
-    "fetch(f.action, {method:f.method, body:new FormData(f)});" +
+    "var body = new URLSearchParams(new FormData(f)).toString();" +
+    "fetch(f.action, {" +
+      "method:f.method," +
+      "headers:{'Content-Type':'application/x-www-form-urlencoded'}," +
+      "body:body" +
+    "});" +
     "var inp = f.querySelector('input[name=body]');" +
     "if (inp) inp.value='';" +
     "return false;" +


### PR DESCRIPTION
## Summary

Live-tested the v0.7.0 demo over Tailscale; the **+ summarizer**
button worked but typing a chat message did nothing. Root cause:
tep's request parser only handles
`application/x-www-form-urlencoded`, while the demo's JS submitted
forms via `new FormData(f)` (multipart). `req.params['body']` came
back empty, so `/chat/send` silently no-op'd.

Fix: wrap `FormData` in `URLSearchParams` and set the content-type
explicitly. Agent-spawn was unaffected because its form has no
body fields.

Also surfaces the v0.7.0 release in the top-of-README callout.

## Test plan

- [x] Reproduced in two browser tabs over Tailscale: messages now
      land in both tabs in <100ms.
- [x] Agent spawn still works.
- [ ] Consider follow-up: add multipart parsing to `Tep::Request`
      so the natural `new FormData()` path Just Works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)