### PR TITLE
feat(request): parse multipart/form-data text fields into req.params

### DIFF
--- a/examples/agentic_chat/app.rb
+++ b/examples/agentic_chat/app.rb
@@ -246,12 +246,7 @@ def agentic_chat_js
   "function tepSend(ev){" +
     "ev.preventDefault();" +
     "var f = ev.target;" +
-    "var body = new URLSearchParams(new FormData(f)).toString();" +
-    "fetch(f.action, {" +
-      "method:f.method," +
-      "headers:{'Content-Type':'application/x-www-form-urlencoded'}," +
-      "body:body" +
-    "});" +
+    "fetch(f.action, {method:f.method, body:new FormData(f)});" +
     "var inp = f.querySelector('input[name=body]');" +
     "if (inp) inp.value='';" +
     "return false;" +

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -18,6 +18,7 @@
 
 require_relative "tep/version"
 require_relative "tep/url"
+require_relative "tep/multipart"
 require_relative "tep/net"
 require_relative "tep/agent_delegation"
 require_relative "tep/identity"
@@ -204,6 +205,12 @@ module Tep
   _tep_seed_res.streamer.pump(_tep_seed_stream)
   _tep_seed_stream.write("")   # pin the parameter type to :str
   Tep.h("")                    # pin Tep.h(s)'s param to :str
+  # Multipart parser: pin all param types so the server-side
+  # branches that call Tep::Multipart.parse have proper signatures
+  # even when no user app exercises multipart on its own.
+  Tep::Multipart.parse("", "")
+  Tep::Multipart.extract_boundary("")
+  Tep::Multipart.extract_field_name("")
   _tep_seed_res.start_websocket("", Tep::WebSocket::Driver.new(0))
 
   # AuthOAuth2 type-seeding. Every public cmeth needs at least one

--- a/lib/tep/multipart.rb
+++ b/lib/tep/multipart.rb
@@ -1,0 +1,98 @@
+# Tep::Multipart -- text-field parsing for multipart/form-data bodies.
+#
+# Browser forms submitted via `new FormData(form)` (or any form
+# carrying file inputs) use `Content-Type: multipart/form-data`
+# instead of urlencoded. tep's request layer treats those bodies
+# as String fields here. File-upload parts (any part with a
+# `filename=` header) are skipped in v1 -- the field's bytes
+# don't land in `req.params`. Supporting file uploads needs a
+# different surface (likely `req.files`) plus an NUL-safe byte
+# array, both follow-ups.
+#
+# Public API mirrors Url.parse_query: pass the raw body + the
+# request's Content-Type header value; get back a string-keyed
+# string-valued hash, ready to merge into `req.params`.
+module Tep
+  module Multipart
+    # Parse `body` against the boundary embedded in `content_type`.
+    # Returns an empty hash when the boundary can't be extracted
+    # (defensive: caller already checked `req.multipart?`).
+    def self.parse(body, content_type)
+      h = Tep.str_hash
+      bnd = Tep::Multipart.extract_boundary(content_type)
+      if bnd.length == 0
+        return h
+      end
+      delim = "--" + bnd
+      parts = body.split(delim)
+      i = 1   # parts[0] is the prologue before the first delimiter
+      while i < parts.length
+        part = parts[i]
+        # Terminator: a part that starts with "--" is the closing
+        # boundary "--<bnd>--<crlf>"; nothing meaningful after it.
+        if part.length >= 2 && part[0, 2] == "--"
+          return h
+        end
+        # Strip the CRLF that follows every interior delimiter.
+        if part.length >= 2 && part[0, 2] == "\r\n"
+          part = part[2, part.length - 2]
+        end
+        # Strip the CRLF that precedes the next delimiter (every
+        # interior part ends with \r\n before the next "--<bnd>").
+        if part.length >= 2 && part[part.length - 2, 2] == "\r\n"
+          part = part[0, part.length - 2]
+        end
+        sep = Tep.str_find(part, "\r\n\r\n", 0)
+        if sep >= 0
+          headers = part[0, sep]
+          value   = part[sep + 4, part.length - sep - 4]
+          name = Tep::Multipart.extract_field_name(headers)
+          has_filename = Tep.str_find(headers, "filename=", 0) >= 0
+          if name.length > 0 && !has_filename
+            h[name] = value
+          end
+        end
+        i += 1
+      end
+      h
+    end
+
+    # Extract `boundary=...` from a Content-Type value. Handles
+    # quoted (`boundary="x"`) and unquoted (`boundary=x;` or
+    # `boundary=x` at end of string).
+    def self.extract_boundary(content_type)
+      at = Tep.str_find(content_type, "boundary=", 0)
+      if at < 0
+        return ""
+      end
+      rest = content_type[at + 9, content_type.length - at - 9]
+      if rest.length > 0 && rest[0, 1] == "\""
+        end_q = Tep.str_find(rest, "\"", 1)
+        if end_q < 0
+          return ""
+        end
+        return rest[1, end_q - 1]
+      end
+      semi = Tep.str_find(rest, ";", 0)
+      if semi >= 0
+        return rest[0, semi]
+      end
+      rest
+    end
+
+    # Extract the `name="..."` value from a part's headers blob.
+    # Returns "" when no name found.
+    def self.extract_field_name(headers)
+      at = Tep.str_find(headers, "name=\"", 0)
+      if at < 0
+        return ""
+      end
+      start = at + 6
+      end_q = Tep.str_find(headers, "\"", start)
+      if end_q < 0
+        return ""
+      end
+      headers[start, end_q - start]
+    end
+  end
+end

--- a/lib/tep/request.rb
+++ b/lib/tep/request.rb
@@ -73,6 +73,14 @@ module Tep
       @req_headers["content-type"].downcase.start_with?("application/x-www-form-urlencoded")
     end
 
+    # True when the request body is a multipart/form-data submission
+    # (browsers use this for any form built via `new FormData(...)`
+    # or carrying file inputs). Tep::Multipart.parse handles the
+    # text fields; file-upload parts are skipped in v1.
+    def multipart?
+      @req_headers["content-type"].downcase.start_with?("multipart/form-data")
+    end
+
     # ---- Rack::Request-style accessors (reads only, no .ip yet) ----
     # These are convenience getters over headers we already parse;
     # `.ip` would need a sphttp_accept_with_peer C helper before it

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -100,6 +100,10 @@ module Tep
           Url.parse_query(req.raw_body).each do |k, v|
             req.params[k] = v
           end
+        elsif req.multipart?
+          Tep::Multipart.parse(req.raw_body, req.req_headers["content-type"]).each do |k, v|
+            req.params[k] = v
+          end
         end
 
         res = Response.new

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -151,6 +151,10 @@ module Tep
             Url.parse_query(req.raw_body).each do |k, v|
               req.params[k] = v
             end
+          elsif req.multipart?
+            Tep::Multipart.parse(req.raw_body, req.req_headers["content-type"]).each do |k, v|
+              req.params[k] = v
+            end
           end
 
           res = Response.new

--- a/sig/tep/multipart.rbs
+++ b/sig/tep/multipart.rbs
@@ -1,0 +1,18 @@
+# Multipart/form-data text-field parser. File-upload parts (any part
+# carrying `filename=`) are skipped in v1; supporting them requires
+# `req.files` + NUL-safe byte storage.
+module Tep
+  module Multipart
+    # Returns a string-keyed string-valued hash of text fields.
+    # Empty when the boundary can't be extracted or the body is empty.
+    def self.parse: (String body, String content_type) -> Hash[String, String]
+
+    # Extract `boundary=...` value from a Content-Type header.
+    # Returns "" when no boundary param is present.
+    def self.extract_boundary: (String content_type) -> String
+
+    # Extract `name="..."` from a single part's headers blob.
+    # Returns "" when no name found.
+    def self.extract_field_name: (String headers) -> String
+  end
+end

--- a/sig/tep/request.rbs
+++ b/sig/tep/request.rbs
@@ -50,6 +50,7 @@ module Tep
     def keep_alive?: () -> bool
     def content_length: () -> Integer
     def form?: () -> bool
+    def multipart?: () -> bool
     def scheme: () -> String
     def ssl?: () -> bool
   end

--- a/test/test_params.rb
+++ b/test/test_params.rb
@@ -19,6 +19,10 @@ class TestParams < TepTest
       "" + params[:name] + "=" + params[:age]
     end
 
+    post '/multipart' do
+      "" + params[:name] + "=" + params[:age]
+    end
+
     get '/encoded/:name' do
       "" + params[:name]
     end
@@ -51,6 +55,25 @@ class TestParams < TepTest
   def test_form_body
     res = post("/form", "name=alice&age=30",
                "Content-Type" => "application/x-www-form-urlencoded")
+    assert_equal "alice=30", res.body
+  end
+
+  def test_multipart_body
+    # Browsers send multipart/form-data for any form using FormData
+    # or carrying a file input. The text fields land in req.params;
+    # file-upload parts are skipped in v1.
+    bnd  = "----TepTestBoundary"
+    body = "--#{bnd}\r\n" \
+           "Content-Disposition: form-data; name=\"name\"\r\n" \
+           "\r\n" \
+           "alice\r\n" \
+           "--#{bnd}\r\n" \
+           "Content-Disposition: form-data; name=\"age\"\r\n" \
+           "\r\n" \
+           "30\r\n" \
+           "--#{bnd}--\r\n"
+    res = post("/multipart", body,
+               "Content-Type" => "multipart/form-data; boundary=#{bnd}")
     assert_equal "alice=30", res.body
   end
 


### PR DESCRIPTION
## Summary

Browsers submit forms built via `new FormData(form)` (or carrying any file input) as `multipart/form-data` instead of urlencoded. tep's request layer silently dropped these bodies — `req.params['body']` came back empty. The demo's `tepSend` JS in #40 worked around this by manually URL-encoding; this PR makes the natural `FormData` path Just Work.

New surface:

```ruby
req.multipart?                                # bool
Tep::Multipart.parse(body, content_type)       # -> Hash[String,String]
```

Both `Tep::Server` and `Tep::Server::Scheduled` branch on `multipart?` after `form?` and merge the result into `req.params`. File-upload parts (any part carrying `filename=`) are skipped in v1; supporting them needs a separate `req.files` surface + NUL-safe byte storage.

Restores `fetch(f.action, {body: new FormData(f)})` in the agentic_chat demo, undoing the URL-encode workaround from #40.

## Test plan

- [x] `test/test_params.rb#test_multipart_body` green (browser-shape boundary + `Content-Disposition`).
- [x] `make test` green (364 runs, 0 failures, 49 pre-existing skips).
- [x] Smoke-tested the demo end-to-end with a curl-built multipart POST: message lands in chat log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)