### PR TITLE
refactor: factor body-drain + form/multipart parse into Tep::Request#consume_body

### DIFF
--- a/lib/tep/request.rb
+++ b/lib/tep/request.rb
@@ -108,5 +108,35 @@ module Tep
     def ssl?
       scheme == "https"
     end
+
+    # Pull any remaining body bytes from `client_fd` up to the
+    # advertised Content-Length, then merge form / multipart fields
+    # into @params. Called once per request by both the prefork and
+    # scheduled servers right after Parser.parse populates the
+    # request headers + the body bytes already in the recv buffer.
+    #
+    # No-op on bodyless requests. Form parsing handles
+    # `application/x-www-form-urlencoded`; multipart handles
+    # `multipart/form-data` (text fields only; file uploads skipped).
+    # Other content types leave @raw_body intact for handlers that
+    # want to consume it directly.
+    def consume_body(client_fd)
+      cl = content_length
+      already = @raw_body.length
+      if cl > already
+        rest = Sock.sphttp_drain_body(client_fd, cl - already)
+        @raw_body = @raw_body + rest
+      end
+      if form?
+        Url.parse_query(@raw_body).each do |k, v|
+          @params[k] = v
+        end
+      elsif multipart?
+        Tep::Multipart.parse(@raw_body, @req_headers["content-type"]).each do |k, v|
+          @params[k] = v
+        end
+      end
+      0
+    end
   end
 end

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -90,21 +90,7 @@ module Tep
           break
         end
 
-        cl = req.content_length
-        already = req.raw_body.length
-        if cl > already
-          rest = Sock.sphttp_drain_body(client, cl - already)
-          req.raw_body = req.raw_body + rest
-        end
-        if req.form?
-          Url.parse_query(req.raw_body).each do |k, v|
-            req.params[k] = v
-          end
-        elsif req.multipart?
-          Tep::Multipart.parse(req.raw_body, req.req_headers["content-type"]).each do |k, v|
-            req.params[k] = v
-          end
-        end
+        req.consume_body(client)
 
         res = Response.new
         @app.dispatch(req, res)

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -141,21 +141,7 @@ module Tep
             break
           end
 
-          cl = req.content_length
-          already = req.raw_body.length
-          if cl > already
-            rest = Sock.sphttp_drain_body(client, cl - already)
-            req.raw_body = req.raw_body + rest
-          end
-          if req.form?
-            Url.parse_query(req.raw_body).each do |k, v|
-              req.params[k] = v
-            end
-          elsif req.multipart?
-            Tep::Multipart.parse(req.raw_body, req.req_headers["content-type"]).each do |k, v|
-              req.params[k] = v
-            end
-          end
+          req.consume_body(client)
 
           res = Response.new
           Tep::APP.dispatch(req, res)


### PR DESCRIPTION
Code-smell sweep 1/7. Both servers carried an identical 15-line block (content-length drain + form? / multipart? branch); the multipart PR (#41) had to touch both. Now lives as `Tep::Request#consume_body(client_fd)`, called from both server entry points.

Behavior unchanged: 364/0/49 green on full `make test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)