### PR TITLE
chore: refresh stale spinel-issue comments post-#641 wave

### DIFF
--- a/lib/tep/live_view.rb
+++ b/lib/tep/live_view.rb
@@ -1,12 +1,12 @@
 # Tep::LiveView -- Phoenix.LiveView-shape server-rendered stateful
 # UI over WebSocket. Battery 4 in docs/BATTERIES-DESIGN.md.
 #
-# v1 (chunk 4.1) ships the bones: the base class apps subclass + a
-# pair of cmeths (render_page / dispatch_event) for the manual
-# wiring path. Auto-wiring (Tep.live "/path", CounterView), the
-# handle_broadcast hook, and presence-diff bindings land in 4.2 /
-# 4.3 -- they need either translator changes or the Scheduled
-# server to be reliable upstream (matz/spinel#641).
+# Ships the base class apps subclass + a pair of cmeths
+# (render_page / dispatch_event) for the manual wiring path, the
+# topic + broadcast_render binding, and the handle_presence_diff
+# hook. Auto-wiring (Tep.live "/path", CounterView) is the open
+# follow-up -- needs translator support to lower a per-view
+# Handler subclass.
 #
 # Usage (chunk 4.1):
 #
@@ -146,11 +146,11 @@ module Tep
     # diff JSON strings to this method and it dispatches to
     # handle_presence_diff on the subclass.
     #
-    # Note: as of chunk 4.3, automatic server-side intercept of
-    # diffs (a background fiber per WS that pulls from the
-    # presence diff topic and calls apply_presence_diff_json) is
-    # not provided -- it needs Tep::Server::Scheduled reliable
-    # under load, gated on matz/spinel#641. Apps that need
+    # Note: automatic server-side intercept of diffs (a background
+    # fiber per WS that pulls from the presence diff topic and
+    # calls apply_presence_diff_json) is not provided -- the WS
+    # DSL doesn't bridge `req` into on_X handler bodies, so the
+    # natural shape needs translator work. Apps that need
     # server-side reaction wire the intercept loop themselves.
     # Apps that only need client-side display can skip this and
     # rely on Tep::Broadcast.subscribe_ws delivering the diff

--- a/lib/tep/websocket/driver.rb
+++ b/lib/tep/websocket/driver.rb
@@ -136,11 +136,10 @@ module Tep
     # Base class for event handlers. Subclass + override
     # `handle_event(event)`. The Driver stores one Handler instance
     # per event type and dispatches via `@h_message.handle_event(evt)`.
-    # Spinel's block-based callback shape (faye's `driver.on(:msg)
-    # { ... }`) wraps a closure with captured locals -- workable
-    # post-matz/spinel#564 but the explicit-Handler shape is simpler
-    # for now and stays compatible with Fiber.storage when Phase 3
-    # routes per-connection state through it.
+    # The explicit-Handler shape (vs faye's block-based `driver.on(:msg)
+    # { ... }`) is chosen because it stays compatible with future
+    # Fiber.storage per-connection state plumbing without re-typing
+    # the callback boundary.
     class Handler
       def handle_event(event)
         0

--- a/test/test_scheduler.rb
+++ b/test/test_scheduler.rb
@@ -9,15 +9,15 @@ require_relative "helper"
 #     (sphttp_connect) to make the listener readable, the scheduler's
 #     next tick picks up the readiness and resumes the fiber.
 class TestScheduler < TepTest
-  # Upstream still has issues: matz/spinel#641 (per-fiber GC root)
-  # is now merged, but the prefork handler in /cooperate still
-  # SIGSEGVs on the Tep::Scheduler.clear + spawn_fiber +
-  # run_until_empty path. Likely a separate spinel issue worth
-  # filing once we have a smaller standalone repro; for now the
-  # class stays skipped so the suite's signal stays useful.
+  # The prefork handler in /cooperate SIGSEGVs on the
+  # Tep::Scheduler.clear + spawn_fiber + run_until_empty path.
+  # Verified still failing on current spinel master (post the
+  # #641 wave). Minimal repro pending -- the prefork-vs-cooperative
+  # crossover here doesn't reproduce from a 6-class fiber probe.
+  # Class stays skipped so the suite's signal stays useful.
   def setup
-    skip "blocked on a separate spinel issue (#641 merged but " \
-         "Tep::Scheduler primitives still SIGSEGV in prefork handlers)"
+    skip "Tep::Scheduler primitives SIGSEGV in prefork handlers; " \
+         "minimal repro pending"
     super
   end
 


### PR DESCRIPTION
Code-smell sweep 3/7 (bundles 6/7).

Three comment touchups against the closed-issue list:

- `lib/tep/live_view.rb` header framed Battery 4 limits as \"needs #641 to be reliable upstream\". #641 is merged; the remaining gap is the WS DSL not bridging \`req\` into on_X handler bodies (translator work, not spinel).
- `lib/tep/websocket/driver.rb` Handler base-class note framed the explicit-Handler shape as \"workable post-#564 but simpler for now\". The real reason it stays is forward compatibility with Fiber.storage routing per-connection state.
- `test/test_scheduler.rb` skip rationale led with \"#641 merged but...\" which suggested #641 was related. It isn't — the Tep::Scheduler primitive crash is a separate failure mode, verified still SIGSEGV on current spinel master.

Comments only; no runtime change. Full `make test` returned a pre-existing parallelism flake in `TestAuthSessionCookie` (verified passes 3/3 standalone across seeds in earlier session) — same flake category as during #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)