### PR TITLE
chore(presence): link TODO to tracked follow-up (#47)

### DIFF
--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -275,9 +275,8 @@ module Tep
     # Worker ID is PID + boot epoch second so a same-PID restart
     # doesn't alias a prior worker's stale rows. On
     # disable_pg_mirror (or clean shutdown), this worker's rows
-    # get DELETE'd. A crashed worker leaves stale rows -- apps
-    # that care about that need a periodic prune (TODO: future
-    # chunk).
+    # get DELETE'd. A crashed worker leaves stale rows -- the
+    # periodic-prune follow-up tracks at OriPekelman/tep#47.
     #
     # Returns 0 on success, -1 on connect / schema failure.
     def self.enable_pg_mirror(conninfo)


### PR DESCRIPTION
Code-smell sweep 5/7. The inline \"TODO: future chunk\" for stale-worker pruning in \`Tep::Presence.enable_pg_mirror\` now points at #47, which captures the design constraints + apps' workarounds.

Comments only; no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)