### PR TITLE
chore: drop stale 'follow-up chunk' framing for shipped cross-worker code

### DIFF
--- a/lib/tep/broadcast.rb
+++ b/lib/tep/broadcast.rb
@@ -23,10 +23,11 @@
 # fan-out) use the same subscribe-fd shape with a different fd.
 #
 # Storage scope is per-process: subscriptions live on Tep::APP,
-# which under prefork is per-worker. Cross-worker pub-sub (via PG
-# LISTEN/NOTIFY) is a follow-up chunk -- subscribers will still
-# register fd-local, but publish() will route through the database
-# so other workers see the message too.
+# which under prefork is per-worker. Cross-worker pub-sub goes
+# through PG LISTEN/NOTIFY (Tep::Broadcast.enable_pg_backend) --
+# subscribers always register fd-local; publish() additionally
+# NOTIFY's the configured channel so peer workers' local
+# subscribers see the message too.
 #
 # `subscribe` returns an opaque subscription id (the registry
 # index at insertion time). Callers can pass it back to

--- a/lib/tep/broadcast_subscription.rb
+++ b/lib/tep/broadcast_subscription.rb
@@ -10,10 +10,12 @@
 # connection fds; non-WS use cases (server-sent events, log
 # fan-out, etc.) work the same way.
 #
-# Single-process registry only in v1; cross-worker pub-sub
-# (PG LISTEN/NOTIFY) lands in a follow-up chunk. See
-# docs/BATTERIES-DESIGN.md for the broader Broadcast battery
-# design.
+# Each subscription lives in a single worker's registry. Cross-
+# worker pub-sub goes through PG LISTEN/NOTIFY (see
+# Tep::Broadcast.enable_pg_backend) which fans publishes out
+# without moving subscription state; subscribers always register
+# fd-local. See docs/BATTERIES-DESIGN.md for the broader Broadcast
+# battery design.
 module Tep
   class BroadcastSubscription
     attr_reader :topic   # String

--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -15,9 +15,12 @@
 # the Phoenix.Presence shape extended with the agentic kind/
 # agent_id pair.
 #
-# Storage scope is per-process (Tep::APP). Cross-worker
-# visibility (PG-backed) lands in a follow-up chunk; v1 works
-# best in single-worker prefork or app-internal contexts.
+# Local storage is per-process (Tep::APP) for the fast list /
+# count read path. Cross-worker visibility goes through PG --
+# Tep::Presence.enable_pg_mirror writes each track/untrack/
+# set_status as an UPSERT/DELETE; list_global pulls the union.
+# Apps that don't need cross-worker snapshots run single-worker
+# or skip the mirror entirely.
 #
 # Status handling: every entry carries a Tep::PresenceStatus
 # inline (status_state / status_note / status_until on the


### PR DESCRIPTION
Lower-priority sweep continuation. Three comments still framed PG LISTEN/NOTIFY (Tep::Broadcast) and the Presence PG mirror as future work. Both shipped earlier in the four-battery wave; the framing is now misleading.

Comments only; `make test` green (364/0/48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)