### PR TITLE
feat(ws): auto-unsubscribe Broadcast subs on connection close

### DIFF
--- a/SINATRA_COMPAT.md
+++ b/SINATRA_COMPAT.md
@@ -31,6 +31,7 @@ shape, lowered by the `websocket '/p' do |ws| ... end` DSL hook).
 | Splat (`*`)                          | ✅ 1    | Last-segment only |
 | Query string                         | ✅ 4    | `params[:q]` reads through |
 | Form-urlencoded body                 | ✅ 2    | Auto-merged into params |
+| Multipart/form-data body             | ✅ 1    | Text fields auto-merged into params; file-upload parts skipped (follow-up `req.files`) |
 | URL-decoding (`%xx`, `+`)            | ✅ 2    | Path captures and query both |
 | Custom status (`status N`)           | ✅ 5    | 201, 204, 401, 418, 500, ... |
 | Default `text/html` Content-Type     | ✅ 1    | |

--- a/examples/agentic_chat/app.rb
+++ b/examples/agentic_chat/app.rb
@@ -222,9 +222,10 @@ websocket "/chat/ws" do |ws|
     Tep::Broadcast.subscribe_ws(CHAT_TOPIC, ws.fd)
   end
 
-  on_close do |evt|
-    Tep::Broadcast.unsubscribe_fd(ws.fd)
-  end
+  # No explicit on_close needed -- Tep::WebSocket::Connection auto-
+  # drops every subscription keyed on the closed fd. Apps that want
+  # to do additional work on close (logging, presence untrack, ...)
+  # still register on_close blocks normally.
 end
 
 # ---- inline assets ----

--- a/lib/tep/broadcast.rb
+++ b/lib/tep/broadcast.rb
@@ -56,13 +56,12 @@ module Tep
     # before delivery -- the peer sees a well-formed WS message,
     # not raw bytes that would close the connection.
     #
-    # Apps unsubscribe in their WS close handler:
-    #
-    #   conn.on(:close) { Tep::Broadcast.unsubscribe_fd(conn.fd) }
-    #
-    # v1 keeps this explicit; an auto-unsubscribe hook on
-    # Tep::WebSocket::Connection lands as a follow-up once we've
-    # used it in a real app and seen what the right shape is.
+    # Cleanup is automatic: when the WS connection closes,
+    # Tep::WebSocket::Connection.dispatch_close runs the user's
+    # on_close handler and then calls unsubscribe_fd(driver.fd),
+    # dropping every subscription tied to the closed connection.
+    # Apps don't need to add their own unsubscribe; if they do,
+    # the second call just finds 0 matches (harmless).
     def self.subscribe_ws(topic, fd)
       subs = Tep::APP.broadcast_subs
       sub = Tep::BroadcastSubscription.new(

--- a/lib/tep/websocket/connection.rb
+++ b/lib/tep/websocket/connection.rb
@@ -147,6 +147,13 @@ module Tep
         evt.code = code
         evt.reason = reason
         driver.h_close.handle_event(evt)
+        # Auto-cleanup: every WS subscription keyed on this fd
+        # gets dropped from the Broadcast registry. Safe even when
+        # the connection never subscribed (no-op match). Apps that
+        # still call Tep::Broadcast.unsubscribe_fd in their
+        # on_close block stay correct -- the second call just
+        # finds 0 matches.
+        Tep::Broadcast.unsubscribe_fd(driver.fd)
         0
       end
     end


### PR DESCRIPTION
Code-smell sweep follow-up.

The \"auto-unsubscribe hook lands as a follow-up once we've used it in a real app\" note in `lib/tep/broadcast.rb` has been outstanding since chunk 2.3. \`agentic_chat\` now exercises the manual pattern (\`subscribe_ws\` on \`on_open\` + \`unsubscribe_fd\` on \`on_close\`), so we have the usage evidence the original comment was waiting for.

\`Tep::WebSocket::Connection.dispatch_close\` now calls \`Tep::Broadcast.unsubscribe_fd(driver.fd)\` after the user's \`on_close\` handler runs. Connections that never subscribed no-op-match. Apps that still call \`unsubscribe_fd\` explicitly stay correct — the second call finds nothing.

Drive-bys:
- Drop the now-redundant \`on_close\` block from agentic_chat.
- Add a \`multipart/form-data\` row to SINATRA_COMPAT.md (missing from the matrix after #41).

## Test plan

- [x] \`bin/tep build examples/agentic_chat/app.rb\` succeeds.
- [x] \`make test\` returned 364/0/48 but with the same pre-existing TestAuthSessionCookie parallelism flake we've seen across the sweep (different test in the class this time, \`test_agent_id_round_trips\`). Verified clean 12/12 standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)