### PR TITLE
chore: link NUL-bound workaround comments to matz/spinel#657

### DIFF
--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -29,10 +29,11 @@ module Sock
   ffi_func :sphttp_recv_into_frame, [:int],         :int
   ffi_func :sphttp_recv_frame_buf, [],              :str
   ffi_func :sphttp_recv_frame_len, [],              :int
-  # Per-byte accessor -- workaround for spinel's :str FFI return
-  # truncating at the first NUL. The Ruby-side WS frame codec walks
-  # bytes one at a time via this; bulk read returns when spinel
-  # grows a binary-safe FFI shape.
+  # Per-byte accessor -- workaround for spinel's slice + bytes[i]
+  # paths truncating past the first NUL (matz/spinel#657). The
+  # Ruby-side WS frame codec walks bytes one at a time via this;
+  # bulk read via sphttp_recv_frame_buf returns when the slice +
+  # bytes[i] sides land binary-safe.
   ffi_func :sphttp_recv_frame_byte_at, [:int],     :int
 
   ffi_func :sphttp_sendfile,      [:int, :str],     :int

--- a/lib/tep/websocket/frame.rb
+++ b/lib/tep/websocket/frame.rb
@@ -60,10 +60,12 @@ module Tep
       end
 
       # Parse one frame from the sphttp recv frame buffer (accessed
-      # via Sock.sphttp_recv_frame_byte_at because the :str FFI is
-      # NUL-bound under spinel master). `start` is the byte offset
-      # to begin reading; `avail` is the count of valid bytes in the
-      # buffer.
+      # via Sock.sphttp_recv_frame_byte_at because spinel's :str
+      # FFI return + the slice / .bytes[i] paths still NUL-truncate
+      # past the first 0x00 byte -- a frame with NULs anywhere in
+      # the payload would parse wrong via bulk-buffer + slice).
+      # Tracked at matz/spinel#657. `start` is the byte offset to
+      # begin reading; `avail` is the count of valid bytes.
       #
       # Returns a ParseResult with one of three shapes:
       #   .status == "ok"      -> .frame populated + .consumed bytes used


### PR DESCRIPTION
Probed current spinel master (\`d59926a\`) against the String NUL-bound behavior. Concat now preserves NULs cleanly (\`0.chr.length == 1\`, the canonical symptom flipped) — but \`s[a, n]\` slice and \`s.bytes[i]\` past a NUL still truncate. Filed upstream as [matz/spinel#657](https://github.com/matz/spinel/issues/657) with a 4-line repro.

Tep workaround stays: the per-byte recv via \`Sock.sphttp_recv_frame_byte_at\` is what makes WS frames with NUL bytes in the payload parse correctly. Comments in \`lib/tep/net.rb\` + \`lib/tep/websocket/frame.rb\` now point at #657 so future readers can check the tracker.

Comments only; no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)