### PR TITLE
feat(liveview): Tep.live "/path", ViewClass auto-wiring

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -68,6 +68,7 @@ def translate(input_path)
   prog = parsed.value
   routes        = []
   websockets    = []
+  live_views    = []
   filters       = { "before" => [], "after" => [] }
   not_founds    = []
   startup_block = nil
@@ -87,6 +88,18 @@ def translate(input_path)
   views_used     = source.scan(/(?<![\w.])erb\s+:(\w+)/).flatten.uniq
   mustaches_used = source.scan(/(?<![\w.])mustache\s+:(\w+)/).flatten.uniq
   process = lambda do |node|
+    # `Tep.live "/path", ViewClass` -- the one Tep::*-receiver call
+    # the translator owns. Lowers to a GET route (render_page) +
+    # WS route (per-connection view instance, event dispatch +
+    # re-render). Other Tep.*  calls (Tep.before, Tep.get, ...)
+    # pass through as runtime method calls.
+    if call?(node) && node.name == :live &&
+       node.receiver.is_a?(Prism::ConstantReadNode) &&
+       node.receiver.name == :Tep
+      handle_tep_live(node, live_views, warnings)
+      return
+    end
+
     # Only bare top-level method calls (no receiver) are candidates
     # for DSL handling -- `get '/'`, `before do`, `set :public_dir`,
     # etc. A call with a receiver (`$arr.delete_at(0)`,
@@ -325,6 +338,105 @@ def translate(input_path)
     w[:cls] = rt_cls
   end
 
+  # Tep.live emission. For each `Tep.live "/path", ViewClass`:
+  #   * TepLive_N_Get handles GET /path -- instantiate view per
+  #     request, mount(req), wrap in render_page targeting /path/ws.
+  #   * TepLive_N_WsOpen / TepLive_N_WsMessage are Handler subclasses;
+  #     each connection's route handler creates ONE ViewClass instance
+  #     and stashes it on both handlers so on_open and on_message
+  #     share state. on_open mounts + subscribes to view.topic (when
+  #     non-empty) + sends initial render; on_message dispatches the
+  #     JSON event + sends re-render.
+  #   * TepLive_N_WsRoute handles the WS upgrade at /path/ws.
+  live_views.each_with_index do |lv, i|
+    base   = "TepLive_#{i}"
+    klass  = lv[:view_class]
+    path   = lv[:path]
+    ws_path = path + "/ws"
+
+    get_cls = "#{base}_Get"
+    out << "class #{get_cls} < Tep::Handler"
+    out << "  def handle(req, res)"
+    out << "    v = #{klass}.new"
+    out << "    v.mount(req)"
+    out << "    Tep::LiveView.render_page(v.render, #{ws_path.inspect})"
+    out << "  end"
+    out << "end"
+    out << ""
+
+    open_cls = "#{base}_WsOpen"
+    out << "class #{open_cls} < Tep::WebSocket::Handler"
+    out << "  attr_accessor :ws, :view"
+    out << "  def initialize"
+    out << "    super"
+    out << "    @ws   = Tep::WebSocket::Driver.new(0)"
+    out << "    @view = #{klass}.new"
+    out << "  end"
+    out << "  def handle_event(evt)"
+    out << "    ws   = @ws"
+    out << "    req  = @req"
+    out << "    view = @view"
+    out << "    view.mount(req)"
+    out << "    t = view.topic"
+    out << "    if t.length > 0"
+    out << "      Tep::Broadcast.subscribe_ws(t, ws.fd)"
+    out << "    end"
+    out << "    ws.text(view.render)"
+    out << "    0"
+    out << "  end"
+    out << "end"
+    out << ""
+
+    msg_cls = "#{base}_WsMessage"
+    out << "class #{msg_cls} < Tep::WebSocket::Handler"
+    out << "  attr_accessor :ws, :view"
+    out << "  def initialize"
+    out << "    super"
+    out << "    @ws   = Tep::WebSocket::Driver.new(0)"
+    out << "    @view = #{klass}.new"
+    out << "  end"
+    out << "  def handle_event(evt)"
+    out << "    ws   = @ws"
+    out << "    req  = @req"
+    out << "    view = @view"
+    out << "    view.dispatch_event_json(evt.data, req)"
+    out << "    ws.text(view.render)"
+    out << "    0"
+    out << "  end"
+    out << "end"
+    out << ""
+
+    ws_route_cls = "#{base}_WsRoute"
+    out << "class #{ws_route_cls} < Tep::Handler"
+    out << "  def handle(req, res)"
+    out << "    hs = Tep::WebSocket::Handshake.check(req)"
+    out << "    if !hs.valid"
+    out << "      res.set_status(400)"
+    out << "      return \"\""
+    out << "    end"
+    out << "    drv = Tep::WebSocket::Driver.new(0)"
+    out << "    v = #{klass}.new"
+    out << "    _cb_on_open = #{open_cls}.new"
+    out << "    _cb_on_open.ws   = drv"
+    out << "    _cb_on_open.req  = req"
+    out << "    _cb_on_open.view = v"
+    out << "    drv.set_on_open(_cb_on_open)"
+    out << "    _cb_on_message = #{msg_cls}.new"
+    out << "    _cb_on_message.ws   = drv"
+    out << "    _cb_on_message.req  = req"
+    out << "    _cb_on_message.view = v"
+    out << "    drv.set_on_message(_cb_on_message)"
+    out << "    res.start_websocket(hs.accept_key, drv)"
+    out << "    \"\""
+    out << "  end"
+    out << "end"
+    out << ""
+
+    lv[:get_cls] = get_cls
+    lv[:ws_cls]  = ws_route_cls
+    lv[:ws_path] = ws_path
+  end
+
   # Registrations.
   out << Tep_public_dir(config[:public_dir]) if config[:public_dir]
   out << %(Tep.before #{filter_classes["before"]}.new) if filter_classes["before"]
@@ -349,6 +461,10 @@ def translate(input_path)
   end
   websockets.each do |w|
     out << %(Tep.get #{w[:path].inspect}, #{w[:cls]}.new)
+  end
+  live_views.each do |lv|
+    out << %(Tep.get #{lv[:path].inspect},    #{lv[:get_cls]}.new)
+    out << %(Tep.get #{lv[:ws_path].inspect}, #{lv[:ws_cls]}.new)
   end
   out << ""
 
@@ -407,6 +523,25 @@ end
 
 def call?(node)
   node.is_a?(Prism::CallNode)
+end
+
+def handle_tep_live(node, live_views, warnings)
+  args = node.arguments&.arguments || []
+  if args.length < 2
+    return warnings << "skipped Tep.live -- needs (\"/path\", ViewClass)"
+  end
+  path = args[0]
+  view = args[1]
+  unless path.is_a?(Prism::StringNode)
+    return warnings << "skipped Tep.live -- first arg must be a string literal path"
+  end
+  unless view.is_a?(Prism::ConstantReadNode) || view.is_a?(Prism::ConstantPathNode)
+    return warnings << "skipped Tep.live -- second arg must be a class constant"
+  end
+  live_views << {
+    path:       path.unescaped,
+    view_class: view.slice,
+  }
 end
 
 def handle_top_call(node, routes, websockets, filters, not_founds, config, warnings, passthrough)

--- a/lib/tep/live_view.rb
+++ b/lib/tep/live_view.rb
@@ -3,9 +3,10 @@
 #
 # Ships the base class apps subclass + a pair of cmeths
 # (render_page / dispatch_event) for the manual wiring path, the
-# topic + broadcast_render binding, and the handle_presence_diff
-# hook. Auto-wiring (Tep.live "/path", CounterView) is tracked at
-# OriPekelman/tep#53.
+# topic + broadcast_render binding, the handle_presence_diff
+# hook, and auto-wiring via `Tep.live "/path", ViewClass` which
+# lowers to a GET (render_page) + WS (event dispatch + re-render)
+# pair in one DSL call.
 #
 # Usage (chunk 4.1):
 #

--- a/test/test_live_view.rb
+++ b/test/test_live_view.rb
@@ -120,6 +120,15 @@ class TestLiveView < TepTest
       Tep::LiveView.new.broadcast_render.to_s
     end
 
+    # ---- Tep.live auto-wiring ----
+    #
+    # `Tep.live "/auto", CounterView` is lowered by the translator
+    # into a GET handler at /auto (initial render + bootstrap JS)
+    # and a WS handler at /auto/ws (event dispatch + re-render).
+    # The blocking server returns 501 for the WS upgrade, so the
+    # test exercises the GET side only.
+    Tep.live "/auto", CounterView
+
     # ---- chunk 4.3: presence diff binding ----
 
     # A view that records every presence diff it receives -- the
@@ -274,5 +283,42 @@ class TestLiveView < TepTest
     # After applying a join diff, render reflects the new state.
     res = get("/presence_diff_render_after_apply").body
     assert_equal "<div id='tep-live-root'>user:99:available</div>", res
+  end
+
+  # ---- Tep.live auto-wiring ----
+
+  def test_tep_live_get_returns_initial_render_wrapped_in_page
+    # GET /auto runs the translator-emitted route: instantiate
+    # CounterView, mount(req), render, wrap in render_page targeted
+    # at /auto/ws.
+    res = get("/auto")
+    assert_equal "200", res.code
+    body = res.body
+    # Initial render comes from CounterView#render with @count = 0.
+    assert_includes body, "<div id='tep-live-root'>Count: 0</div>"
+    # render_page bootstrap JS targets the auto-generated WS path.
+    assert_includes body, "/auto/ws"
+    # render_page wraps in a full HTML doc with the bootstrap shell.
+    assert_includes body, "<!doctype html>"
+    assert_includes body, "var ws=new WebSocket("
+  end
+
+  def test_tep_live_get_honors_view_mount
+    # CounterView#mount reads ?seed= from req.params and seeds @count.
+    res = get("/auto?seed=42")
+    assert_includes res.body, "<div id='tep-live-root'>Count: 42</div>"
+  end
+
+  def test_tep_live_ws_path_returns_501_under_blocking_server
+    # The auto-wired WS path requires the scheduled server. The
+    # blocking server returns 501 for WS upgrade attempts (same
+    # behavior as a hand-written `websocket` block).
+    res = req(:get, "/auto/ws", nil, {
+      "Upgrade"               => "websocket",
+      "Connection"            => "Upgrade",
+      "Sec-WebSocket-Key"     => "x3JJHMbDL1EzLkh9GBhXDw==",
+      "Sec-WebSocket-Version" => "13",
+    })
+    assert_equal "501", res.code
   end
 end


### PR DESCRIPTION
Closes #53.

One DSL call lowers to the full LiveView wiring pair:

\`\`\`ruby
Tep.live \"/counter\", CounterView
\`\`\`

The translator generates four classes:

| Class | Role |
|---|---|
| \`TepLive_0_Get\` | GET /counter — instantiate view, \`mount(req)\`, render, wrap in \`Tep::LiveView.render_page\` targeting \`/counter/ws\`. |
| \`TepLive_0_WsRoute\` | GET /counter/ws — handshake, create per-connection view, stash on event handlers. |
| \`TepLive_0_WsOpen\` | on_open — \`view.mount(req)\`, subscribe to \`view.topic\` when non-empty, send initial render. |
| \`TepLive_0_WsMessage\` | on_message — \`view.dispatch_event_json(evt.data, req)\`, send re-render. |

The WS route creates one view instance per upgraded connection and assigns it to both event handlers (\`.view = v\`), so on_open and on_message share state per connection. Auto-cleanup on close still applies via the existing \`Tep::WebSocket::Connection.dispatch_close\` hook (drops Broadcast + Presence rows keyed on the closed fd).

## Test plan

- [x] 3 new tests in \`test_live_view.rb\` exercise the GET side (initial render, \`mount\` honoring \`?seed=\`, blocking-server 501 behavior).
- [x] WS event-loop wiring shares the code shape the rest of the file already exercises (\`dispatch_event_json\`, \`render\` chains).
- [x] Full \`make test\`: 367/0/48 (+3 runs, +12 assertions).
- [x] End-to-end smoke build of a CounterView app exercising the click-to-increment flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)