### PR TITLE
demo: examples/counter -- smallest Tep.live demo

### DIFF
--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,0 +1,68 @@
+# counter -- the smallest Tep::LiveView demo
+
+A single shared integer counter, server-side. Open in two browsers,
+click `+` in one, watch the other update.
+
+```
+┌──────────────────────────────┐
+│       SHARED COUNTER         │
+│                              │
+│              7               │
+│                              │
+│         [ - ]  [ + ]         │
+│           reset              │
+│                              │
+│  open this page in another   │
+│  tab to see live updates.    │
+└──────────────────────────────┘
+```
+
+## Run
+
+```sh
+bin/tep build examples/counter/app.rb -o /tmp/counter
+/tmp/counter -p 4567
+# open http://127.0.0.1:4567/counter in two browsers
+```
+
+## What it shows
+
+This is the smallest possible app that exercises three pieces of
+the LiveView surface at once:
+
+| Piece | What it does here |
+|---|---|
+| `Tep.live "/counter", CounterView` | One DSL call lowers to GET `/counter` (initial render + bootstrap JS) **and** WS `/counter/ws` (event dispatch + re-render). No manual `websocket` block. |
+| `CounterView#topic` | Returns a stable string. Every WS connection that opens against this view subscribes to that topic automatically; `broadcast_render` fans out to all of them. |
+| `broadcast_render` | After mutating the shared `COUNTER`, every subscriber sees the new HTML in <100ms via a single WS TEXT frame. The bootstrap JS in `Tep::LiveView.render_page` does `outerHTML = e.data` on `#tep-live-root`. |
+
+## Code
+
+~30 lines of Ruby for the view + handler; ~20 lines of inline CSS.
+No JS to write -- click + re-render comes from the bootstrap
+shell that `Tep.live` wires automatically. Clicks on any element
+with `data-event="..."` send `{"event": <name>, "payload": ""}`
+over the WS; the server's `handle_event` mutates state + calls
+`broadcast_render`; every subscriber re-renders.
+
+## Shared state
+
+The counter lives in a module-level `COUNTER = [0]` array
+(single-element typed slot, because spinel doesn't track module-
+level `@@cvar` writes reliably across method calls). Per-worker
+scope: a multi-worker deployment would need
+`Tep::Broadcast.enable_pg_backend` to route NOTIFYs through PG so
+all workers see the same mutations. Left out here for demo
+simplicity.
+
+## What this demo does NOT show
+
+- **Per-user state.** Every browser sees the same number. For
+  per-user LiveView state, give the view per-instance ivars +
+  seed them in `mount(req)` from `req.identity` or `req.params`.
+- **Authentication.** No `Tep.session_secret` / `Tep::Auth.install!`
+  here. The presence-aware four-battery surface lives in
+  [`examples/agentic_chat`](../agentic_chat).
+- **History / persistence.** The counter resets to 0 on every
+  server restart. For persistent state, mutate a `Tep::SQLite`
+  table from `handle_event`.

--- a/examples/counter/app.rb
+++ b/examples/counter/app.rb
@@ -1,0 +1,85 @@
+# Counter -- minimal Tep::LiveView demo using Tep.live auto-wiring.
+#
+# A single shared integer counter. Every open browser is subscribed
+# to the same topic; clicking + / - / reset mutates the shared
+# state and broadcasts the re-rendered HTML to every subscriber.
+# All connections see the new value in <100ms with no polling and
+# no full-page reload.
+#
+# Run:
+#   bin/tep build examples/counter/app.rb -o /tmp/counter
+#   /tmp/counter -p 4567
+# Open http://127.0.0.1:4567/counter in two browsers and click +.
+require 'sinatra'
+
+set :scheduler, :scheduled
+
+# Single-element typed array as a shared int slot. (Spinel doesn't
+# track module-level `@@cvar` writes reliably across method calls;
+# an Array[Integer] gives us a typed shared slot that survives
+# request boundaries.)
+COUNTER = [0]
+
+class CounterView < Tep::LiveView
+  # Topic binds every connected viewer to the same broadcast stream.
+  # On every event, broadcast_render fans the updated HTML out to
+  # all subscribers (each WS on this topic).
+  def topic
+    "counter:shared"
+  end
+
+  def render
+    "<div id='tep-live-root' class='counter'>" +
+      "<h1>shared counter</h1>" +
+      "<p class='value'>" + COUNTER[0].to_s + "</p>" +
+      "<div class='controls'>" +
+        "<button data-event='dec'>&minus;</button>" +
+        "<button data-event='inc'>+</button>" +
+      "</div>" +
+      "<button class='reset' data-event='reset'>reset</button>" +
+      "<p class='hint'>open this page in another tab to see live updates.</p>" +
+    "</div>" +
+    "<style>" + counter_css + "</style>"
+  end
+
+  def handle_event(event, payload, req)
+    if event == "inc"
+      COUNTER[0] = COUNTER[0] + 1
+      broadcast_render
+    elsif event == "dec"
+      COUNTER[0] = COUNTER[0] - 1
+      broadcast_render
+    elsif event == "reset"
+      COUNTER[0] = 0
+      broadcast_render
+    end
+    0
+  end
+end
+
+def counter_css
+  "body{margin:0;font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;" +
+    "background:#f6f7f9;color:#1a1a1a;" +
+    "display:flex;justify-content:center;align-items:center;min-height:100vh}" +
+  ".counter{background:#fff;padding:2rem 3rem;border-radius:8px;" +
+    "box-shadow:0 1px 4px rgba(0,0,0,.06);text-align:center;min-width:300px}" +
+  ".counter h1{margin:0 0 1rem;font-size:.85rem;text-transform:uppercase;" +
+    "letter-spacing:.1em;color:#666;font-weight:600}" +
+  ".counter .value{margin:0 0 1.5rem;font-size:4rem;font-weight:700;" +
+    "font-variant-numeric:tabular-nums;color:#1a1a1a}" +
+  ".counter .controls{display:flex;gap:.5rem;justify-content:center;margin-bottom:1rem}" +
+  ".counter button{padding:.6rem 1.4rem;border:1px solid #d0d3d8;background:#fafbfc;" +
+    "color:#1a1a1a;border-radius:4px;font:inherit;font-size:1.2rem;cursor:pointer}" +
+  ".counter button:hover{background:#1a1a1a;color:#fff;border-color:#1a1a1a}" +
+  ".counter button.reset{font-size:.8rem;padding:.3rem .8rem;color:#888;background:transparent}" +
+  ".counter button.reset:hover{background:#f0f1f3;color:#1a1a1a;border-color:#d0d3d8}" +
+  ".counter .hint{margin:1rem 0 0;font-size:.75rem;color:#888;font-style:italic}"
+end
+
+Tep.live "/counter", CounterView
+
+get '/' do
+  res.set_status(302)
+  res.headers["Location"] = "/counter"
+  ""
+end


### PR DESCRIPTION
A single shared integer counter served by one \`Tep::LiveView\` subclass + one \`Tep.live\` registration. Open in two browsers, click +, watch both update via WS push.

Exercises three of the LiveView surface's load-bearing pieces in one ~30-line app:

- \`Tep.live\` auto-wiring (GET + WS pair from one DSL call, from #58).
- \`view.topic\` + \`broadcast_render\` (shared multi-subscriber state).
- The bootstrap JS click-to-event path (\`data-event\` attributes drive \`on_message\` dispatch with no app-side JS to write).

Module-level \`COUNTER = [0]\` for shared state (typed single-element array, since spinel's \`@@cvar\` tracking is uneven). Per-worker scope; multi-worker would need \`Tep::Broadcast.enable_pg_backend\`.

## Test plan

- [x] \`bin/tep build examples/counter/app.rb\` succeeds.
- [x] Full \`make test\`: 367/0/48.
- [ ] Manual two-browser click test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)