### PR TITLE
docs(readme): add examples/counter to demos callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,11 @@ lives in [`docs/BATTERIES-DESIGN.md`](docs/BATTERIES-DESIGN.md).
 
 ~360 tests pass `make test`. End-to-end demos that build and run:
 
+- **[`examples/counter/`](examples/counter/app.rb)** — the
+  smallest `Tep.live` demo. Shared integer counter; click in one
+  tab, every other tab updates in <100ms. ~80 lines of Ruby + CSS,
+  no JS to write (the bootstrap shell wires `data-event` clicks
+  through the WS).
 - **[`examples/agentic_chat/`](examples/agentic_chat/app.rb)** —
   the four-battery agentic demo. Sub-second WS push, multi-user
   chat, agent-spawn with OAuth2-style delegation. ~270 lines.


### PR DESCRIPTION
Tiny doc update. The new counter demo (PR #59) deserves a slot in the demos list — it's the smallest viable LiveView and a better \"first step\" than jumping straight into agentic_chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)