### PR TITLE
chore: bump version to 0.8.0 (pre-alpha)

### DIFF
--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Pre-alpha release covering the post-0.7.0 work.

## New surface (features)

- **Tep::Multipart** + \`req.multipart?\` (#41) — \`new FormData(form)\` posts flow into \`req.params\` automatically; text fields parsed, file uploads skipped (\`req.files\` is the follow-up).
- **WS DSL \`req\` bridge** (#56, closes #54) — \`on_open\`/\`on_message\`/\`on_close\` blocks now see \`req\` (the upgrade-time request) alongside \`ws\`. \`req.identity\`, \`req.session\`, headers all accessible from event bodies.
- **WS auto-cleanup on close** (#51, #56) — Tep::WebSocket::Connection.dispatch_close now drops Broadcast subscriptions AND Presence rows keyed on the closed fd automatically.
- **\`Tep.live \"/path\", ViewClass\`** (#58, closes #53) — one DSL call lowers to a GET (render_page) + WS (event dispatch + re-render) pair. New \`examples/counter/\` demo (#59) showcases this in ~80 lines.

## Cleanups (sweep)

- \`consume_body\` factored from both servers (#43).
- \`spawn_one_silent\` collapsed into \`spawn_one\` (#44).
- Stale \"follow-up chunk\" / pre-#641 comments refreshed across live_view, websocket/driver, broadcast, presence (#45, #50, #55, #57).
- Dead \`spinel575_minimal_repro\` fixture removed (#46).
- \`test_security.rb\` skip replaced with a real override-guard exercise (#49).
- Multipart row + \`req\`-in-WS row added to SINATRA_COMPAT.md.

## Spinel alignment

Rides on matz/spinel master \`568cf0d\`. Filed \`matz/spinel#657\` for the remaining String NUL-bound work (slice + \`bytes[i]\` past NUL still truncate; concat is fixed now). Two open spinel issues remain affecting tep: #626 + #282 + the new #657.

## Open tep follow-ups

- #47 — Presence PG mirror periodic prune (cosmetic; apps using PG can run a SQL sweep).
- #52 — TestAuthSessionCookie ~10% parallelism flake (low impact; passes 12/12 standalone).

Pre-alpha. API still in motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)