### PR TITLE
refactor(ws): drop sphttp_recv_frame_byte_at -- matz/spinel#657 closed

### DIFF
--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -29,12 +29,6 @@ module Sock
   ffi_func :sphttp_recv_into_frame, [:int],         :int
   ffi_func :sphttp_recv_frame_buf, [],              :str
   ffi_func :sphttp_recv_frame_len, [],              :int
-  # Per-byte accessor -- workaround for spinel's slice + bytes[i]
-  # paths truncating past the first NUL (matz/spinel#657). The
-  # Ruby-side WS frame codec walks bytes one at a time via this;
-  # bulk read via sphttp_recv_frame_buf returns when the slice +
-  # bytes[i] sides land binary-safe.
-  ffi_func :sphttp_recv_frame_byte_at, [:int],     :int
 
   ffi_func :sphttp_sendfile,      [:int, :str],     :int
   ffi_func :sphttp_filesize,      [:str],           :int

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -223,28 +223,6 @@ int sphttp_recv_frame_len(void) {
     return sphttp_frame_len;
 }
 
-/* Byte-level accessor. Workaround for the spinel `:str` FFI return
- * shape being NUL-bound (the Ruby-side String stops at the first
- * 0x00 byte regardless of the buffer's actual length). Callers that
- * need to walk arbitrary bytes -- WebSocket frame codec, file uploads
- * with embedded NULs, anything binary -- use this fn in a loop:
- *
- *   n = Sock.sphttp_recv_into_frame(fd)
- *   i = 0
- *   while i < n
- *     byte = Sock.sphttp_recv_frame_byte_at(i)
- *     ...
- *     i += 1
- *   end
- *
- * Returns the unsigned byte value (0..255), or -1 if `i` is out of
- * bounds. Slow but correct; replace with a bulk-read variant when
- * spinel grows a binary-safe FFI return shape. */
-int sphttp_recv_frame_byte_at(int i) {
-    if (i < 0 || i >= sphttp_frame_len) return -1;
-    return (int)(unsigned char)sphttp_frame_buf[i];
-}
-
 /* Send a file's contents straight from disk -- used for static
  * file serving. Returns -1 on open/read failure (caller falls back
  * to 404), 0 on success. */

--- a/lib/tep/websocket/frame.rb
+++ b/lib/tep/websocket/frame.rb
@@ -59,13 +59,13 @@ module Tep
         (n & 0xff).chr
       end
 
-      # Parse one frame from the sphttp recv frame buffer (accessed
-      # via Sock.sphttp_recv_frame_byte_at because spinel's :str
-      # FFI return + the slice / .bytes[i] paths still NUL-truncate
-      # past the first 0x00 byte -- a frame with NULs anywhere in
-      # the payload would parse wrong via bulk-buffer + slice).
-      # Tracked at matz/spinel#657. `start` is the byte offset to
-      # begin reading; `avail` is the count of valid bytes.
+      # Parse one frame from the sphttp recv frame buffer. `start`
+      # is the byte offset to begin reading; `avail` is the count of
+      # valid bytes in the buffer. Byte reads go through the Ruby
+      # String binding sphttp_recv_frame_buf returns; matz/spinel#657
+      # made slice / bytes[i] survive embedded NULs so binary
+      # payloads parse correctly without the per-byte C accessor we
+      # used before.
       #
       # Returns a ParseResult with one of three shapes:
       #   .status == "ok"      -> .frame populated + .consumed bytes used
@@ -78,8 +78,10 @@ module Tep
           return out
         end
 
-        b0 = Sock.sphttp_recv_frame_byte_at(start)
-        b1 = Sock.sphttp_recv_frame_byte_at(start + 1)
+        buf = Sock.sphttp_recv_frame_buf
+        bs  = buf.bytes
+        b0 = bs[start]
+        b1 = bs[start + 1]
         fin    = (b0 & 0x80) != 0
         rsv    = b0 & 0x70
         opcode = b0 & 0x0f
@@ -125,8 +127,8 @@ module Tep
             out.outcome = "need"
             return out
           end
-          h = Sock.sphttp_recv_frame_byte_at(pos)
-          l = Sock.sphttp_recv_frame_byte_at(pos + 1)
+          h = bs[pos]
+          l = bs[pos + 1]
           plen = (h << 8) | l
           pos += 2
         else
@@ -138,7 +140,7 @@ module Tep
           plen = 0
           i = 0
           while i < 8
-            plen = (plen << 8) | Sock.sphttp_recv_frame_byte_at(pos + i)
+            plen = (plen << 8) | bs[pos + i]
             i += 1
           end
           pos += 8
@@ -149,10 +151,10 @@ module Tep
           out.outcome = "need"
           return out
         end
-        m0 = Sock.sphttp_recv_frame_byte_at(pos)
-        m1 = Sock.sphttp_recv_frame_byte_at(pos + 1)
-        m2 = Sock.sphttp_recv_frame_byte_at(pos + 2)
-        m3 = Sock.sphttp_recv_frame_byte_at(pos + 3)
+        m0 = bs[pos]
+        m1 = bs[pos + 1]
+        m2 = bs[pos + 2]
+        m3 = bs[pos + 3]
         pos += 4
 
         # Payload bytes.
@@ -165,7 +167,7 @@ module Tep
         payload = ""
         i = 0
         while i < plen
-          b = Sock.sphttp_recv_frame_byte_at(pos + i)
+          b = bs[pos + i]
           mask_byte = 0
           if (i & 3) == 0
             mask_byte = m0


### PR DESCRIPTION
matz/spinel#657 (commit \`22203f7\`) made slice + \`bytes[i]\` survive embedded NULs end-to-end. Re-probed locally:

\`\`\`
nul = 0.chr; s = \"abc\" + nul + \"def\"
s.length       # => 7  ✓
s[2, 3].length # => 3  ✓ (was 1)
s.bytes[3]     # => 0  ✓
s.bytes[4]     # => 100 ✓ (was 0)
\`\`\`

The WS frame parser switches back to bulk-buffer access:

\`\`\`ruby
buf = Sock.sphttp_recv_frame_buf   # :str FFI return
bs  = buf.bytes                    # Array of integers
# ... bs[pos], bs[pos + 1] ...
\`\`\`

Surface changes:
- \`lib/tep/websocket/frame.rb\` — \`parse_from_buf\` reads one Ruby String + walks \`bs[i]\` in the same shape as before. Header docstring updated.
- \`lib/tep/net.rb\` — drop the \`sphttp_recv_frame_byte_at\` FFI binding + its workaround comment.
- \`lib/tep/sphttp.c\` — drop the \`sphttp_recv_frame_byte_at\` C helper.

~50 LoC of workaround scaffolding gone.

## Test plan

- [x] \`make test\`: 367/0/48.
- [x] \`test_websocket.rb\`: 10/10.
- [x] \`test_websocket_echo.rb\` (real RFC 6455 raw-socket round-trip with masked TEXT payload): 1/1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)