### PR TITLE
chore: bump version to 0.8.1 (patch)

### DIFF
--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Patch release covering two internal-only post-0.8.0 changes:

- #62 — Tep::Auth header comment refresh (all three providers shipped).
- #63 — WS frame byte-by-byte recv workaround dropped; \`Sock.sphttp_recv_frame_byte_at\` retired now that matz/spinel#657 made slice + \`bytes[i]\` past-NUL work end-to-end. ~50 LoC of C + FFI scaffolding gone.

No API surface change. Pre-alpha; API still in motion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)