### PR TITLE
feat(mcp): chunk 5.2 — caps gating + notifications/initialized

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -486,6 +486,16 @@ def translate(input_path)
     mcp_tools.each_with_index do |t, i|
       body = rewrite_block(t[:call_body], force_string: false)
       out << "  def self.call_#{i}(req, args_json)"
+      # Per-cap may? checks (chunk 5.2). One inline check per cap
+      # rather than a loop -- spinel's symbol-array iteration is
+      # uneven, and a flat sequence of identical branches is the
+      # safest emit. Anonymous identity has empty caps so any
+      # capped tool denies anonymous callers cleanly.
+      t[:caps].each do |cap|
+        out << "    if !req.identity.may?(:#{cap})"
+        out << "      return Tep::MCP.error(\"missing capability: #{cap}\")"
+        out << "    end"
+      end
       t[:params].each do |p|
         if p[:type] == "Integer"
           out << "    #{p[:name]} = Tep::Json.get_int(args_json, #{p[:name].inspect})"
@@ -539,6 +549,13 @@ def translate(input_path)
     out << "    req_id = Tep::Json.get_int(body, \"id\")"
     out << "    if method == \"initialize\""
     out << "      return Tep::MCP.initialize_envelope(req_id, #{server_name.inspect}, #{server_version.inspect})"
+    out << "    end"
+    # notifications/initialized is a JSON-RPC notification (no
+    # response per spec). Return 204 No Content with an empty body
+    # to satisfy HTTP while honoring the no-response semantics.
+    out << "    if method == \"notifications/initialized\""
+    out << "      res.set_status(204)"
+    out << "      return \"\""
     out << "    end"
     out << "    if method == \"tools/list\""
     out << "      return Tep::MCP.tools_list_envelope(req_id, #{tools_const})"
@@ -696,6 +713,32 @@ def handle_mcp_tool(node, mcp_tools, warnings)
     return warnings << "skipped mcp_tool -- second arg must be a string literal description"
   end
 
+  # Optional caps: [:foo, :bar] keyword (chunk 5.2). Required
+  # capabilities checked against req.identity.may?(...) at the
+  # top of call_<i>. Missing any -> Tep::MCP.error("missing
+  # capability: <name>") returned without running the on_call
+  # body.
+  caps = []
+  if args.length >= 3 && args[2].is_a?(Prism::KeywordHashNode)
+    args[2].elements.each do |el|
+      next unless el.is_a?(Prism::AssocNode)
+      k = el.key
+      next unless k.is_a?(Prism::SymbolNode) && k.value.to_s == "caps"
+      v = el.value
+      unless v.is_a?(Prism::ArrayNode)
+        warnings << "mcp_tool #{name_node.unescaped}: caps: must be an array literal of symbols"
+        next
+      end
+      v.elements.each do |sym|
+        unless sym.is_a?(Prism::SymbolNode)
+          warnings << "mcp_tool #{name_node.unescaped}: caps: entry must be a symbol literal"
+          next
+        end
+        caps << sym.value.to_s
+      end
+    end
+  end
+
   params      = []
   call_body   = nil
   call_kwargs = []
@@ -767,6 +810,7 @@ def handle_mcp_tool(node, mcp_tools, warnings)
   mcp_tools << {
     name:        name_node.unescaped,
     description: desc_node.unescaped,
+    caps:        caps,
     params:      params,
     call_kwargs: call_kwargs,
     call_body:   call_body,

--- a/docs/MCP-BATTERY.md
+++ b/docs/MCP-BATTERY.md
@@ -209,7 +209,7 @@ inside the `on_call` body — same pattern as routes. There's no
 special "MCP authorization" layer; the existing capability model
 is enough.
 
-The DSL could optionally accept a `caps:` argument:
+The DSL accepts a `caps:` keyword (chunk 5.2):
 
 ```ruby
 mcp_tool 'start_experiment', "...", caps: [:start_experiment] do
@@ -218,8 +218,12 @@ end
 ```
 
 When the calling identity is missing any of `caps`, the dispatch
-short-circuits with `error("missing capability: start_experiment")`
-before the `on_call` body runs. Chunk 5.2.
+short-circuits with `Tep::MCP.error("missing capability: <name>")`
+before the `on_call` body runs. Implementation: the translator
+emits one inline `req.identity.may?(:<cap>)` check per declared
+cap at the top of `call_<i>`. Loops over a symbol array aren't
+used (spinel's symbol-array iteration is uneven); a flat sequence
+of identical branches is the safest emit.
 
 ## Streaming (chunk 5.3)
 
@@ -261,8 +265,8 @@ For HTTP-direct callers, the stream maps to chunked
 
 | Chunk | Scope | Status |
 |---|---|---|
-| **5.1** | Tool DSL (`mcp_tool`, `param`, `on_call`, `text`/`error`). Translator emission. JSON-RPC dispatch at `POST /mcp` with `initialize` + `tools/list` + `tools/call`. HTTP-direct `POST /tools/<name>`. `GET /llms.txt`. | Building now |
-| **5.2** | `caps:` gating. Test coverage for unauthorized + missing-tool error paths. `notifications/initialized` handling. | After 5.1 |
+| **5.1** | Tool DSL (`mcp_tool`, `param`, `on_call`, `text`/`error`). Translator emission. JSON-RPC dispatch at `POST /mcp` with `initialize` + `tools/list` + `tools/call`. HTTP-direct `POST /tools/<name>`. `GET /llms.txt`. | Shipped (#65) |
+| **5.2** | `caps:` keyword on `mcp_tool` -> inline per-cap `req.identity.may?(:...)` check at the top of `call_<i>`. `notifications/initialized` returns 204 No Content. | Shipping |
 | **5.3** | `mcp_resource` DSL. Streaming via `stream do |out| ... end`. MCP progress notifications over the same `/mcp` SSE channel. Reuse `Tep::Streamer` where possible. | After 5.2 |
 | **5.4** | OpenAPI auto-generation from the tool registry. `AGENTS.md` convention doc. `examples/experiments` demo (training-runs scenario). | After 5.3 |
 

--- a/test/test_mcp.rb
+++ b/test/test_mcp.rb
@@ -7,6 +7,17 @@ class TestMCP < TepTest
   app_source <<~RB
     require 'sinatra'
 
+    # Grant capabilities via an X-Test-Cap header for the auth
+    # gating tests. No real auth provider needed for the dispatch
+    # paths -- we just override req.identity with a synthetic one
+    # so req.identity.may?(:admin) returns true on demand.
+    before do
+      if req.req_headers["x-test-cap-admin"].length > 0
+        req.identity = Tep::Identity.new(
+          "user:42", nil, [:admin])
+      end
+    end
+
     mcp_tool 'greet', "Say hi to someone" do
       param :name, String, "person to greet"
 
@@ -25,6 +36,13 @@ class TestMCP < TepTest
 
       on_call do |a:, b:|
         Tep::MCP.text((a + b).to_s)
+      end
+    end
+
+    # Capped tool -- requires :admin in the calling identity.
+    mcp_tool 'wipe_db', "Drop everything (requires :admin)", caps: [:admin] do
+      on_call do
+        Tep::MCP.text("wiped")
       end
     end
   RB
@@ -111,6 +129,46 @@ class TestMCP < TepTest
     assert_equal "200", res.code
     assert_includes res.body, "\"code\":-32601"
     assert_includes res.body, "method not found"
+  end
+
+  # ---- caps gating (chunk 5.2) ----
+
+  def test_capped_tool_denies_anonymous_caller
+    res = post("/tools/wipe_db", "{}",
+               "Content-Type" => "application/json")
+    # Anonymous identity has empty caps, so :admin check fails.
+    # The tool returns an error Result; HTTP-direct surfaces it
+    # as 400 + the error text.
+    assert_equal "400", res.code
+    assert_includes res.body, "missing capability: admin"
+  end
+
+  def test_capped_tool_allows_caller_with_required_cap
+    res = post("/tools/wipe_db", "{}",
+               "Content-Type"   => "application/json",
+               "X-Test-Cap-Admin" => "1")
+    assert_equal "200", res.code
+    assert_equal "wiped", res.body
+  end
+
+  def test_capped_tool_over_mcp_returns_isError
+    # Same denial path through the JSON-RPC envelope: anonymous
+    # caller -> wipe_db -> error Result -> isError:true.
+    body = "{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"tools/call\"," +
+           "\"params\":{\"name\":\"wipe_db\",\"arguments\":{}}}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "200", res.code
+    assert_includes res.body, "\"isError\":true"
+    assert_includes res.body, "missing capability: admin"
+  end
+
+  # ---- notifications/initialized (chunk 5.2) ----
+
+  def test_notifications_initialized_returns_204_no_body
+    body = "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "204", res.code
+    assert_equal "", res.body.to_s
   end
 
   # ---- llms.txt discovery ----


### PR DESCRIPTION
Two small additions on top of #65.

## \`caps:\` keyword

\`\`\`ruby
mcp_tool 'wipe_db', \"...\", caps: [:admin] do
  on_call { Tep::MCP.text(\"wiped\") }
end
\`\`\`

The translator extracts \`caps: [...]\` from the optional third argument (a \`KeywordHashNode\` in Prism), validates each entry as a \`SymbolNode\`, and emits one inline \`req.identity.may?(:<cap>)\` check at the top of \`call_<i>\`. Missing any cap → immediate \`Tep::MCP.error(\"missing capability: <name>\")\` return; \`on_call\` body never runs.

Inline sequence instead of iterating a symbol array — spinel's symbol-array iteration is uneven; flat branches stay safe.

## \`notifications/initialized\`

JSON-RPC notifications carry no \`id\` and expect no response. The dispatcher now recognizes the canonical \`notifications/initialized\` method, sets the response to 204 No Content, and returns an empty body. Honors the no-response spec semantics while satisfying HTTP.

## Test plan

- [x] 4 new tests in \`test/test_mcp.rb\` covering anonymous denial, cap'd allow, JSON-RPC isError surface, notification 204.
- [x] Full \`make test\`: **381/0/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)