### PR TITLE
feat(mcp): chunk 5.3 — mcp_resource DSL + resources/list + resources/read

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -70,6 +70,7 @@ def translate(input_path)
   websockets    = []
   live_views    = []
   mcp_tools     = []
+  mcp_resources = []
   filters       = { "before" => [], "after" => [] }
   not_founds    = []
   startup_block = nil
@@ -107,7 +108,7 @@ def translate(input_path)
     # `something.frob`) is just user code: pass it through verbatim
     # so spinel sees it at program load.
     if call?(node) && node.receiver.nil?
-      result = handle_top_call(node, routes, websockets, mcp_tools, filters, not_founds, config, warnings, passthrough)
+      result = handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough)
       startup_block = result if result.is_a?(Hash) && result[:kind] == :startup
       return
     end
@@ -458,7 +459,7 @@ def translate(input_path)
   #     trace types end-to-end.
   #   * TepMCP_LlmsTxt -- GET /llms.txt, returns the tool catalog as
   #     a markdown index any LLM-friendly client can fetch.
-  unless mcp_tools.empty?
+  if !mcp_tools.empty? || !mcp_resources.empty?
     # Build the tools/list JSON once, at translate time. Each entry
     # is {name, description, inputSchema}; inputSchema follows the
     # JSON Schema object form with property type/description per
@@ -533,6 +534,46 @@ def translate(input_path)
     out << "#{tools_const} = #{tools_list_json.inspect}"
     out << ""
 
+    # Per-resource read cmeths + HTTP-direct Handler subclasses
+    # (chunk 5.3). One Handler per resource for GET /resources/<name>
+    # plus a sibling cmeth `TepMCP_Resources.read_<i>(req)` that the
+    # dispatcher's resources/read arm calls statically (no
+    # PtrArray<Resource> dispatch, same pattern as tools).
+    unless mcp_resources.empty?
+      out << "module TepMCP_Resources"
+      mcp_resources.each_with_index do |rdef, i|
+        body = rewrite_block(rdef[:read_body], force_string: false)
+        out << "  def self.read_#{i}(req)"
+        out << indent(body, 4)
+        out << "  end"
+        out << ""
+      end
+      out << "end"
+      out << ""
+
+      mcp_resources.each_with_index do |rdef, i|
+        http_cls = "TepMCP_Res_#{i}_HttpRoute"
+        out << "class #{http_cls} < Tep::Handler"
+        out << "  def handle(req, res)"
+        out << "    c = TepMCP_Resources.read_#{i}(req)"
+        out << "    res.headers[\"Content-Type\"] = c.mime"
+        out << "    c.text"
+        out << "  end"
+        out << "end"
+        out << ""
+        rdef[:http_cls] = http_cls
+      end
+
+      # resources/list array, pre-built at translate time.
+      res_list_parts = mcp_resources.map do |rdef|
+        %({"uri":#{rdef[:name].inspect},"name":#{rdef[:name].inspect},"description":#{rdef[:description].inspect},"mimeType":"text/plain"})
+      end
+      resources_list_json = "[" + res_list_parts.join(",") + "]"
+      resources_const = "TepMCP_RESOURCES_LIST_JSON"
+      out << "#{resources_const} = #{resources_list_json.inspect}"
+      out << ""
+    end
+
     server_name    = (config[:mcp_server_name] || "tep-mcp-server").to_s
     server_version = config[:mcp_server_version] || begin
       vfile = File.read(File.expand_path("../lib/tep/version.rb", __dir__))
@@ -572,18 +613,47 @@ def translate(input_path)
     end
     out << "      return Tep::MCP.unknown_tool_envelope(req_id, tool_name)"
     out << "    end"
+    unless mcp_resources.empty?
+      out << "    if method == \"resources/list\""
+      out << "      return Tep::MCP.resources_list_envelope(req_id, TepMCP_RESOURCES_LIST_JSON)"
+      out << "    end"
+      out << "    if method == \"resources/read\""
+      out << "      res_params = Tep::MCP.nested_extract(body, \"params\")"
+      out << "      res_uri = Tep::Json.get_str(res_params, \"uri\")"
+      mcp_resources.each_with_index do |rdef, i|
+        out << "      if res_uri == #{rdef[:name].inspect}"
+        out << "        c = TepMCP_Resources.read_#{i}(req)"
+        out << "        return Tep::MCP.resources_read_envelope(req_id, c.uri, c.mime, c.text)"
+        out << "      end"
+      end
+      out << "      return Tep::MCP.unknown_resource_envelope(req_id, res_uri)"
+      out << "    end"
+    end
     out << "    Tep::MCP.method_not_found_envelope(req_id, method)"
     out << "  end"
     out << "end"
     out << ""
 
-    # llms.txt: minimal markdown index of the tool catalog. Stable
-    # ASCII so even a non-LLM reader can scan it.
-    llms_lines = ["# " + server_name, "", "MCP-endpoint: /mcp", "", "## Tools", ""]
-    mcp_tools.each do |t|
-      llms_lines << "- " + t[:name] + " -- " + t[:description]
+    # llms.txt: minimal markdown index of the tool + resource
+    # catalogs. Stable ASCII so even a non-LLM reader can scan it.
+    llms_lines = ["# " + server_name, "", "MCP-endpoint: /mcp", ""]
+    unless mcp_tools.empty?
+      llms_lines << "## Tools"
+      llms_lines << ""
+      mcp_tools.each do |t|
+        llms_lines << "- " + t[:name] + " -- " + t[:description]
+      end
+      llms_lines << ""
     end
-    llms_body = llms_lines.join("\n") + "\n"
+    unless mcp_resources.empty?
+      llms_lines << "## Resources"
+      llms_lines << ""
+      mcp_resources.each do |rdef|
+        llms_lines << "- " + rdef[:name] + " -- " + rdef[:description]
+      end
+      llms_lines << ""
+    end
+    llms_body = llms_lines.join("\n")
 
     out << "class TepMCP_LlmsTxt < Tep::Handler"
     out << "  def handle(req, res)"
@@ -623,9 +693,12 @@ def translate(input_path)
     out << %(Tep.get #{lv[:path].inspect},    #{lv[:get_cls]}.new)
     out << %(Tep.get #{lv[:ws_path].inspect}, #{lv[:ws_cls]}.new)
   end
-  unless mcp_tools.empty?
+  if !mcp_tools.empty? || !mcp_resources.empty?
     mcp_tools.each do |t|
       out << %(Tep.post "/tools/#{t[:name]}", #{t[:http_cls]}.new)
+    end
+    mcp_resources.each do |rdef|
+      out << %(Tep.get "/resources/#{rdef[:name]}", #{rdef[:http_cls]}.new)
     end
     out << %(Tep.post "/mcp", TepMCP_Dispatcher.new)
     out << %(Tep.get  "/llms.txt", TepMCP_LlmsTxt.new)
@@ -695,6 +768,60 @@ end
 # optional `default:` and `enum:` keyword args, kept verbatim into
 # the JSON Schema we emit). Each `on_call do |kwargs| ... end`
 # block becomes the tool's invocation body.
+# `mcp_resource 'name', "description" do; on_read do ... end; end`
+# (chunk 5.3). Each resource gets a read-only fetch endpoint at
+# `GET /resources/<name>` plus a `resources/list` + `resources/read`
+# dispatch arm via the /mcp dispatcher. The on_read body returns
+# Tep::MCP::ResourceContent (built via Tep::MCP.resource_text). No
+# URI templating + no streaming in this chunk -- both defer.
+def handle_mcp_resource(node, mcp_resources, warnings)
+  args  = node.arguments&.arguments || []
+  block = node.block
+  unless block.is_a?(Prism::BlockNode)
+    return warnings << "skipped mcp_resource -- needs a `do ... end` block"
+  end
+  if args.length < 2
+    return warnings << "skipped mcp_resource -- needs (\"name\", \"description\", &block)"
+  end
+  name_node = args[0]
+  desc_node = args[1]
+  unless name_node.is_a?(Prism::StringNode)
+    return warnings << "skipped mcp_resource -- first arg must be a string literal name"
+  end
+  unless desc_node.is_a?(Prism::StringNode)
+    return warnings << "skipped mcp_resource -- second arg must be a string literal description"
+  end
+
+  read_body = nil
+  body = block.body
+  if body.is_a?(Prism::StatementsNode)
+    body.body.each do |stmt|
+      next unless call?(stmt) && stmt.receiver.nil?
+      cname = stmt.name.to_s
+      if cname == "on_read"
+        inner = stmt.block
+        unless inner.is_a?(Prism::BlockNode)
+          warnings << "mcp_resource #{name_node.unescaped}: on_read needs a `do ... end` block"
+          next
+        end
+        read_body = block_source(inner)
+      else
+        warnings << "mcp_resource #{name_node.unescaped}: ignored unrecognized statement `#{cname}`"
+      end
+    end
+  end
+
+  if read_body.nil?
+    return warnings << "skipped mcp_resource #{name_node.unescaped} -- missing on_read do ... end"
+  end
+
+  mcp_resources << {
+    name:        name_node.unescaped,
+    description: desc_node.unescaped,
+    read_body:   read_body,
+  }
+end
+
 def handle_mcp_tool(node, mcp_tools, warnings)
   args  = node.arguments&.arguments || []
   block = node.block
@@ -836,11 +963,16 @@ def handle_tep_live(node, live_views, warnings)
   }
 end
 
-def handle_top_call(node, routes, websockets, mcp_tools, filters, not_founds, config, warnings, passthrough)
+def handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough)
   name = node.name.to_s
 
   if name == "mcp_tool"
     handle_mcp_tool(node, mcp_tools, warnings)
+    return
+  end
+
+  if name == "mcp_resource"
+    handle_mcp_resource(node, mcp_resources, warnings)
     return
   end
 

--- a/docs/MCP-BATTERY.md
+++ b/docs/MCP-BATTERY.md
@@ -113,15 +113,29 @@ follow.
 ### Resource declaration (chunk 5.3)
 
 ```ruby
-mcp_resource 'experiment/{id}/metrics', "Live metrics for a run" do |id|
-  stream do |out|
-    metric_subscribe(id) { |m| out.write(m.to_json + "\n") }
+mcp_resource 'server/status', "Current server status" do
+  on_read do
+    Tep::MCP.resource_text("server/status", "uptime: " + uptime.to_s)
   end
 end
 ```
 
-Same DSL shape, returns SSE stream on the HTTP side and
-`resources/read` over MCP.
+generates:
+
+- `GET /resources/server/status` — HTTP-direct read returning the
+  text body with the resource's mimeType as Content-Type.
+- A `resources/list` arm in `/mcp` that returns the catalog
+  (uri / name / description / mimeType per resource).
+- A `resources/read` arm in `/mcp` that looks up by URI and
+  returns the content block.
+
+`on_read` runs with `req` in scope (same shape as tools), so
+identity / caps gating works the same way (`caps:` keyword
+support for resources is a 5.4 follow-up if needed).
+
+URI templating (`'experiment/{id}/metrics'` with extracted
+captures) and streaming (`stream do |out| ... end` over SSE)
+defer beyond 5.3.
 
 ### Prompt declaration (chunk 5.4, maybe)
 
@@ -266,9 +280,9 @@ For HTTP-direct callers, the stream maps to chunked
 | Chunk | Scope | Status |
 |---|---|---|
 | **5.1** | Tool DSL (`mcp_tool`, `param`, `on_call`, `text`/`error`). Translator emission. JSON-RPC dispatch at `POST /mcp` with `initialize` + `tools/list` + `tools/call`. HTTP-direct `POST /tools/<name>`. `GET /llms.txt`. | Shipped (#65) |
-| **5.2** | `caps:` keyword on `mcp_tool` -> inline per-cap `req.identity.may?(:...)` check at the top of `call_<i>`. `notifications/initialized` returns 204 No Content. | Shipping |
-| **5.3** | `mcp_resource` DSL. Streaming via `stream do |out| ... end`. MCP progress notifications over the same `/mcp` SSE channel. Reuse `Tep::Streamer` where possible. | After 5.2 |
-| **5.4** | OpenAPI auto-generation from the tool registry. `AGENTS.md` convention doc. `examples/experiments` demo (training-runs scenario). | After 5.3 |
+| **5.2** | `caps:` keyword on `mcp_tool` -> inline per-cap `req.identity.may?(:...)` check at the top of `call_<i>`. `notifications/initialized` returns 204 No Content. | Shipped (#66) |
+| **5.3** | `mcp_resource 'uri', "desc" do; on_read do; ...; end; end` -> `resources/list` + `resources/read` JSON-RPC + `GET /resources/<uri>` HTTP-direct. No URI templating, no streaming -- both defer. | Shipping |
+| **5.4** | OpenAPI auto-generation. `AGENTS.md` convention doc. `examples/experiments` demo (training-runs scenario). URI templating + streaming for resources. | After 5.3 |
 
 Each chunk is one PR, same cadence as Batteries 1–4. Demo
 (`examples/experiments`) is the gate for considering the battery

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -582,6 +582,16 @@ module Tep
   Tep::MCP.tools_call_envelope(0, "", 1)
   Tep::MCP.unknown_tool_envelope(0, "")
   Tep::MCP.method_not_found_envelope(0, "")
+  # Resource seeds (chunk 5.3). resource_text gives us a typed
+  # ResourceContent for the resources/read path; the envelope
+  # builders take scalars to keep param-type inference tight.
+  _tep_seed_mcp_rc = Tep::MCP.resource_text("seed-uri", "seed-text")
+  _tep_seed_mcp_rc_uri  = _tep_seed_mcp_rc.uri
+  _tep_seed_mcp_rc_mime = _tep_seed_mcp_rc.mime
+  _tep_seed_mcp_rc_text = _tep_seed_mcp_rc.text
+  Tep::MCP.resources_list_envelope(0, "[]")
+  Tep::MCP.resources_read_envelope(0, "", "text/plain", "")
+  Tep::MCP.unknown_resource_envelope(0, "")
 
   # Tep::Llm seeds. attr_accessor return types default to mrb_int
   # if spinel sees no concrete callsite -- and Tep::Llm.build_request_body

--- a/lib/tep/mcp.rb
+++ b/lib/tep/mcp.rb
@@ -54,6 +54,31 @@ module Tep
       r
     end
 
+    # Resource read outcome -- a (uri, mime, text) triple wrapped
+    # in the resources/read response envelope. Kept as a simple
+    # value class (parallel to Result) so spinel tracks the slot
+    # types cleanly across module boundaries.
+    class ResourceContent
+      attr_accessor :uri, :mime, :text
+
+      def initialize
+        @uri  = ""
+        @mime = "text/plain"
+        @text = ""
+      end
+    end
+
+    # Build a text-mime resource content block. URI is the
+    # resource's identifier (echoed back to the client so clients
+    # can correlate the response with the request).
+    def self.resource_text(uri, text)
+      c = Tep::MCP::ResourceContent.new
+      c.uri  = uri
+      c.mime = "text/plain"
+      c.text = text
+      c
+    end
+
     # JSON-quote a String for embedding in our envelope output.
     # The escape body is inlined (vs split into a separate
     # json_escape helper) because the helper-shape param kept
@@ -114,7 +139,7 @@ module Tep
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"result\":{" +
           "\"protocolVersion\":\"" + Tep::MCP::PROTOCOL_VERSION + "\"," +
-          "\"capabilities\":{\"tools\":{}}," +
+          "\"capabilities\":{\"tools\":{},\"resources\":{}}," +
           "\"serverInfo\":{" +
             "\"name\":"    + Tep::MCP.json_quote(server_name)    + "," +
             "\"version\":" + Tep::MCP.json_quote(server_version) +
@@ -148,6 +173,41 @@ module Tep
             "{\"type\":\"text\",\"text\":" + Tep::MCP.json_quote(text) + "}" +
           "]," +
           "\"isError\":" + is_err_str +
+        "}" +
+      "}"
+    end
+
+    # Wrap a pre-built resources-array JSON string into the
+    # resources/list response envelope. Same shape as
+    # tools_list_envelope -- translator emits the array literally
+    # at compile time so spinel doesn't need to walk it at runtime.
+    def self.resources_list_envelope(req_id, resources_array_json)
+      "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
+        "\"result\":{\"resources\":" + resources_array_json + "}" +
+      "}"
+    end
+
+    # Wrap a ResourceContent into a resources/read response
+    # envelope. contents is a one-element array per MCP spec; the
+    # uri / mimeType / text fields are read off as scalars (same
+    # spinel-friendly pattern as tools_call_envelope) before being
+    # spliced into the JSON.
+    def self.resources_read_envelope(req_id, uri, mime, text)
+      "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
+        "\"result\":{\"contents\":[" +
+          "{\"uri\":" + Tep::MCP.json_quote(uri) + "," +
+           "\"mimeType\":" + Tep::MCP.json_quote(mime) + "," +
+           "\"text\":" + Tep::MCP.json_quote(text) + "}" +
+        "]}" +
+      "}"
+    end
+
+    # Error envelope for resources/read on an unknown URI. Same
+    # JSON-RPC code as unknown_tool (-32602 invalid params).
+    def self.unknown_resource_envelope(req_id, uri)
+      "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
+        "\"error\":{\"code\":-32602," +
+          "\"message\":" + Tep::MCP.json_quote("unknown resource: " + uri) +
         "}" +
       "}"
     end

--- a/test/test_mcp.rb
+++ b/test/test_mcp.rb
@@ -45,6 +45,18 @@ class TestMCP < TepTest
         Tep::MCP.text("wiped")
       end
     end
+
+    mcp_resource 'server/status', "Current server status" do
+      on_read do
+        Tep::MCP.resource_text("server/status", "uptime: 42")
+      end
+    end
+
+    mcp_resource 'server/version', "Server build version" do
+      on_read do
+        Tep::MCP.resource_text("server/version", "1.0.0-test")
+      end
+    end
   RB
 
   # ---- HTTP-direct invocation ----
@@ -171,6 +183,51 @@ class TestMCP < TepTest
     assert_equal "", res.body.to_s
   end
 
+  # ---- mcp_resource (chunk 5.3) ----
+
+  def test_http_direct_resource_read_returns_text
+    res = get("/resources/server/status")
+    assert_equal "200", res.code
+    assert_includes res["content-type"].to_s, "text/plain"
+    assert_equal "uptime: 42", res.body
+  end
+
+  def test_mcp_initialize_advertises_resources_capability
+    body = "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"initialize\"}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "200", res.code
+    assert_includes res.body, "\"resources\":{}"
+  end
+
+  def test_mcp_resources_list_returns_both_resources
+    body = "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"resources/list\"}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "200", res.code
+    assert_includes res.body, "\"uri\":\"server/status\""
+    assert_includes res.body, "\"uri\":\"server/version\""
+    assert_includes res.body, "\"description\":\"Current server status\""
+    assert_includes res.body, "\"mimeType\":\"text/plain\""
+  end
+
+  def test_mcp_resources_read_round_trips_content
+    body = "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"resources/read\"," +
+           "\"params\":{\"uri\":\"server/status\"}}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "200", res.code
+    assert_includes res.body, "\"uri\":\"server/status\""
+    assert_includes res.body, "\"mimeType\":\"text/plain\""
+    assert_includes res.body, "\"text\":\"uptime: 42\""
+  end
+
+  def test_mcp_resources_read_unknown_uri_errors
+    body = "{\"jsonrpc\":\"2.0\",\"id\":14,\"method\":\"resources/read\"," +
+           "\"params\":{\"uri\":\"nope\"}}"
+    res = post("/mcp", body, "Content-Type" => "application/json")
+    assert_equal "200", res.code
+    assert_includes res.body, "\"code\":-32602"
+    assert_includes res.body, "unknown resource"
+  end
+
   # ---- llms.txt discovery ----
 
   def test_llms_txt_lists_tools_with_descriptions
@@ -178,7 +235,10 @@ class TestMCP < TepTest
     assert_equal "200", res.code
     assert_includes res["content-type"].to_s, "text/markdown"
     assert_includes res.body, "MCP-endpoint: /mcp"
+    assert_includes res.body, "## Tools"
     assert_includes res.body, "greet -- Say hi to someone"
     assert_includes res.body, "add -- Add two integers"
+    assert_includes res.body, "## Resources"
+    assert_includes res.body, "server/status -- Current server status"
   end
 end


### PR DESCRIPTION
Adds the resource surface as a parallel of tools, with the same spinel-friendly emission pattern (per-resource cmeth + static dispatch by URI).

## DSL

\`\`\`ruby
mcp_resource 'server/status', \"Current server status\" do
  on_read do
    Tep::MCP.resource_text(\"server/status\", \"uptime: \" + uptime.to_s)
  end
end
\`\`\`

generates:

| Endpoint | Role |
|---|---|
| \`GET /resources/server/status\` | HTTP-direct read with declared mimeType |
| \`resources/list\` over \`/mcp\` | Catalog (uri/name/description/mimeType per resource) |
| \`resources/read\` over \`/mcp\` | Look up by URI, returns \`contents:[{uri,mimeType,text}]\` |

Runtime additions in \`lib/tep/mcp.rb\`:
- \`Tep::MCP::ResourceContent\` (uri/mime/text) + \`Tep::MCP.resource_text\`
- \`resources_list_envelope\` / \`resources_read_envelope\` / \`unknown_resource_envelope\`
- \`initialize_envelope\` now advertises both \`tools\` + \`resources\` capabilities

\`llms.txt\` grows a \`## Resources\` section when any resource is declared.

URI templating + streaming defer (5.4 or later).

## Test plan

- [x] 5 new tests (HTTP-direct read, initialize cap advertise, list, read round-trip, unknown URI error).
- [x] Full \`make test\`: **386/0/48**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)