### PR TITLE
chore: revert two matz/spinel#684-shape workarounds

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -571,10 +571,6 @@ module Tep
   # off both so attr_accessor types pin to String / Integer.
   _tep_seed_mcp_result     = Tep::MCP.text("seed")
   _tep_seed_mcp_result_err = Tep::MCP.error("seed")
-  _tep_seed_mcp_txt        = _tep_seed_mcp_result.text
-  _tep_seed_mcp_err_int    = _tep_seed_mcp_result_err.is_error
-  Tep::MCP.json_quote(_tep_seed_mcp_txt)
-  Tep::MCP.json_quote("")
   Tep::MCP.nested_extract("{}", "")
   Tep::MCP.initialize_envelope(0, "", "")
   Tep::MCP.tools_list_envelope(0, "[]")

--- a/lib/tep/mcp.rb
+++ b/lib/tep/mcp.rb
@@ -79,38 +79,6 @@ module Tep
       c
     end
 
-    # JSON-quote a String for embedding in our envelope output.
-    # The escape body is inlined (vs split into a separate
-    # json_escape helper) because the helper-shape param kept
-    # widening to poly through spinel's iterative inference even
-    # with a concrete seed -- single-function scope keeps the type
-    # signal tight. Names live in Tep::MCP (not Tep::Json) to
-    # keep the param-type inference isolated from Tep::Json.quote's
-    # wider caller graph.
-    def self.json_quote(s)
-      out = "\""
-      i = 0
-      n = s.length
-      while i < n
-        c = s[i]
-        if c == "\""
-          out = out + "\\\""
-        elsif c == "\\"
-          out = out + "\\\\"
-        elsif c == "\n"
-          out = out + "\\n"
-        elsif c == "\r"
-          out = out + "\\r"
-        elsif c == "\t"
-          out = out + "\\t"
-        else
-          out = out + c
-        end
-        i += 1
-      end
-      out + "\""
-    end
-
     # Pull a nested JSON value out of `json` by top-level key,
     # returning the value's JSON-string form. Used by the
     # translator-emitted dispatcher to dig `params` out of the
@@ -141,8 +109,8 @@ module Tep
           "\"protocolVersion\":\"" + Tep::MCP::PROTOCOL_VERSION + "\"," +
           "\"capabilities\":{\"tools\":{},\"resources\":{}}," +
           "\"serverInfo\":{" +
-            "\"name\":"    + Tep::MCP.json_quote(server_name)    + "," +
-            "\"version\":" + Tep::MCP.json_quote(server_version) +
+            "\"name\":"    + Tep::Json.quote(server_name)    + "," +
+            "\"version\":" + Tep::Json.quote(server_version) +
           "}" +
         "}" +
       "}"
@@ -170,7 +138,7 @@ module Tep
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"result\":{" +
           "\"content\":[" +
-            "{\"type\":\"text\",\"text\":" + Tep::MCP.json_quote(text) + "}" +
+            "{\"type\":\"text\",\"text\":" + Tep::Json.quote(text) + "}" +
           "]," +
           "\"isError\":" + is_err_str +
         "}" +
@@ -195,9 +163,9 @@ module Tep
     def self.resources_read_envelope(req_id, uri, mime, text)
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"result\":{\"contents\":[" +
-          "{\"uri\":" + Tep::MCP.json_quote(uri) + "," +
-           "\"mimeType\":" + Tep::MCP.json_quote(mime) + "," +
-           "\"text\":" + Tep::MCP.json_quote(text) + "}" +
+          "{\"uri\":" + Tep::Json.quote(uri) + "," +
+           "\"mimeType\":" + Tep::Json.quote(mime) + "," +
+           "\"text\":" + Tep::Json.quote(text) + "}" +
         "]}" +
       "}"
     end
@@ -207,7 +175,7 @@ module Tep
     def self.unknown_resource_envelope(req_id, uri)
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"error\":{\"code\":-32602," +
-          "\"message\":" + Tep::MCP.json_quote("unknown resource: " + uri) +
+          "\"message\":" + Tep::Json.quote("unknown resource: " + uri) +
         "}" +
       "}"
     end
@@ -217,7 +185,7 @@ module Tep
     def self.unknown_tool_envelope(req_id, tool_name)
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"error\":{\"code\":-32602," +
-          "\"message\":" + Tep::MCP.json_quote("unknown tool: " + tool_name) +
+          "\"message\":" + Tep::Json.quote("unknown tool: " + tool_name) +
         "}" +
       "}"
     end
@@ -227,7 +195,7 @@ module Tep
     def self.method_not_found_envelope(req_id, method_name)
       "{\"jsonrpc\":\"2.0\",\"id\":" + req_id.to_s + "," +
         "\"error\":{\"code\":-32601," +
-          "\"message\":" + Tep::MCP.json_quote("method not found: " + method_name) +
+          "\"message\":" + Tep::Json.quote("method not found: " + method_name) +
         "}" +
       "}"
     end

--- a/lib/tep/session.rb
+++ b/lib/tep/session.rb
@@ -10,12 +10,7 @@ module Tep
   COOKIE_NAME = "tep.session"
 
   class Session
-    # @data intentionally NOT exposed as attr_accessor: a `data`
-    # method on Session would collide with `Tep::WebSocket::Event#data`
-    # under spinel's virtual imeth dispatch (matz/spinel#513 shape),
-    # widening `evt.data` to poly inside on_message handler bodies.
-    # Public surface is get/set/has?/length/clear only.
-    attr_accessor :dirty
+    attr_accessor :data, :dirty
 
     def initialize
       @data  = Tep.str_hash

--- a/sig/tep/mcp.rbs
+++ b/sig/tep/mcp.rbs
@@ -17,10 +17,6 @@ module Tep
     def self.text:  (String s) -> Tep::MCP::Result
     def self.error: (String s) -> Tep::MCP::Result
 
-    # JSON helpers (kept in this module to avoid the cross-module
-    # widening from Tep::Json.escape/quote).
-    def self.json_quote: (String s) -> String
-
     # Nested-key JSON value extraction (sub-string).
     def self.nested_extract: (String json, String key) -> String
 

--- a/sig/tep/session.rbs
+++ b/sig/tep/session.rbs
@@ -4,7 +4,7 @@
 # session secret.
 module Tep
   class Session
-    # @data intentionally NOT an accessor: see lib/tep/session.rb.
+    attr_accessor data: Hash[String, String]
     attr_accessor dirty: bool
 
     def initialize: () -> void


### PR DESCRIPTION
\`ac7720e\` on spinel master fixes the same-named attr_accessor widening that bit tep in two places. Both revertable now.

## 1. Restore \`Tep::Session#data\` accessor (PR #36 revert)

\`Tep::Session#data\` (Hash) and \`Tep::WebSocket::Event#data\` (String) shared a method name; virtual imeth dispatch widened \`evt.data\` to poly inside WS on_message bodies. PR #36 dropped the accessor. Goes back as it was.

## 2. Revert \`Tep::MCP\` json_quote inlined-escape workaround

The MCP envelope builders carried an inlined escape loop (\`Tep::MCP.json_quote\`) because \`Tep::Json.quote\` widened to poly through the cross-module call graph. Same #684 shape. Drop the inline body, use \`Tep::Json.quote\` in all four envelope cmeths, drop the seed.

## Test plan

- [x] \`bin/tep build examples/agentic_chat/app.rb\` (originally triggered the Session#data widening) succeeds.
- [x] \`bin/tep build examples/experiments/app.rb\` (originally triggered the json_quote widening) succeeds.
- [x] \`ruby test/test_mcp.rb\` 21/21 green.
- [x] Full \`make test\`: **388/0/48** with the pre-existing TestAuthSessionCookie parallelism flake (#52) — passes 12/12 standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)