### PR TITLE
docs: design drafts for Battery 6 (proxy) + Battery 7 (OpenAI server)

### DIFF
--- a/docs/OPENAI-SERVER-BATTERY.md
+++ b/docs/OPENAI-SERVER-BATTERY.md
@@ -1,0 +1,325 @@
+# OpenAI server battery design: Tep::Llm::OpenAI::Server
+
+Battery 7 — early design draft. **Open with sibling project
+authors to finalize.** Tep apps serve OpenAI-compatible HTTP
+responses from local compute (not a proxy — there's no upstream).
+The route + streaming + auth + caps shell is tep; the actual
+inference computation is a pluggable backend that some other
+project (toy, llama.cpp wrap, ...) implements.
+
+> Status: **early draft, no code yet, open for revision**.
+> Drafted to address two concrete asks from a sibling project
+> (run-dir checkpoint serving + events.jsonl emission). The
+> backend interface + chunking plan freezes once those needs
+> are confirmed against this sketch.
+>
+> Sister doc: [`PROXY-BATTERY.md`](PROXY-BATTERY.md) covers the
+> distinct **proxy** case (tep sits in front of a real upstream
+> OpenAI-compatible server). The two batteries are independent;
+> the proxy battery can be composed with this one if needed
+> (e.g., a router that selects "local vs remote" per request).
+
+## Why two batteries
+
+| Question | `Tep::Proxy` (Battery 6) | `Tep::Llm::OpenAI::Server` (Battery 7) |
+|---|---|---|
+| Where does the response come from? | A real upstream HTTP server | Local compute |
+| Knows the OpenAI wire format? | No (generic HTTP) | Yes (parses + emits OpenAI shape) |
+| Dependencies | Just tep | Tep + a backend implementation |
+| Tao's `serve-from-tao-run-dir` | ❌ no upstream to forward to | ✅ direct fit |
+| Tao's `openai-eval-emit` | Possible as a proxy filter | Built-in hook |
+| "Proxy a remote OpenAI through my own auth" | ✅ | (use Battery 6 instead) |
+
+This battery exists because the origin-compute case is genuinely
+different from the proxy case — different inside, different
+dependencies, different scope. Trying to merge them either makes
+the proxy battery carry inference concerns or makes the server
+battery a degenerate proxy. Two batteries, one shared HTTP
+shape.
+
+## Goal
+
+```ruby
+require 'sinatra'
+require 'tep/llm/openai/server'
+
+# Apps wire a concrete backend at boot. The backend implements
+# Tep::Llm::OpenAI::Backend (interface defined below).
+backend = ToyBackend.new(model_dir: ENV.fetch("TAO_RUN_DIR"))
+Tep::Llm::OpenAI::Server.use(backend)
+
+# One DSL call mounts the standard OpenAI routes + events
+# emission (when an emit path is configured) + capability gating.
+Tep::Llm::OpenAI::Server.serve!(
+  events_jsonl: ENV["EVENTS_JSONL"],   # optional
+  cap:          :infer,                # optional; gates all routes
+)
+```
+
+The `serve!` call registers:
+
+- `GET /v1/models` — backend's catalog.
+- `POST /v1/chat/completions` — streaming + non-streaming.
+- `GET /v1/embeddings` — if the backend supports embeddings.
+- A `before` filter that gates all three on `req.identity.may?(:infer)` when `cap:` is set.
+- An events.jsonl emitter that appends one event per inference when `events_jsonl:` is set.
+
+## Backend interface
+
+The contract tep apps implement (in toy, llama.cpp wrap, or
+elsewhere). Kept narrow so multiple backend projects can target
+it without coordination.
+
+```ruby
+module Tep
+  module Llm
+    module OpenAI
+      class Backend
+        # Enumerate available model names. The catalog is what
+        # /v1/models returns. Backends typically read this from
+        # the configured artifact directory (one model per
+        # subdirectory, or whatever the project's convention is).
+        def list_models
+          # returns Array[String]
+        end
+
+        # Generate a completion for the given messages against
+        # the named model. sampling carries temperature /
+        # max_tokens / top_p / etc. The block yields per token
+        # (or per delta-chunk); tep wraps each yielded value
+        # into the OpenAI streaming chunk envelope.
+        def generate(model_name, messages, sampling, &on_token)
+          # yield String per token; return final usage hash
+          # {prompt_tokens: N, completion_tokens: N}
+        end
+
+        # Optional. When backend supports embeddings,
+        # implement this; tep mounts /v1/embeddings only if so.
+        # Returning false from the base class is the opt-out.
+        def supports_embeddings?
+          false
+        end
+
+        # Compute an embedding for a single input string. Only
+        # called when supports_embeddings? returns true.
+        def embed(model_name, input)
+          # returns Array[Float]
+        end
+      end
+    end
+  end
+end
+```
+
+The interface is **read-only from tep's perspective** — tep
+calls it, doesn't store state on it. Backends own their own
+state (model handles, KV caches, batching queues, etc.). This
+keeps tep oblivious to ML concerns and lets each backend
+implementation make its own performance choices.
+
+## HTTP surface
+
+### `GET /v1/models`
+
+Response (OpenAI-compat):
+
+```json
+{
+  "object": "list",
+  "data": [
+    {"id": "smollm2-135m", "object": "model", "owned_by": "tep"},
+    {"id": "qwen-410m",    "object": "model", "owned_by": "tep"}
+  ]
+}
+```
+
+Backed by `backend.list_models`.
+
+### `POST /v1/chat/completions` (non-streaming)
+
+Standard OpenAI request:
+
+```json
+{
+  "model": "smollm2-135m",
+  "messages": [
+    {"role": "system", "content": "..."},
+    {"role": "user",   "content": "Hello"}
+  ],
+  "temperature": 0.7,
+  "max_tokens":  256,
+  "stream":      false
+}
+```
+
+Tep parses the request, calls `backend.generate`, accumulates
+the yielded tokens, returns:
+
+```json
+{
+  "id": "chatcmpl-abc",
+  "object": "chat.completion",
+  "created": 1716615000,
+  "model": "smollm2-135m",
+  "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi! ..."},
+               "finish_reason": "stop"}],
+  "usage": {"prompt_tokens": 12, "completion_tokens": 8, "total_tokens": 20}
+}
+```
+
+### `POST /v1/chat/completions` (streaming, `stream: true`)
+
+SSE response. Each yielded backend token becomes a chunk:
+
+```
+data: {"id":"chatcmpl-abc","object":"chat.completion.chunk","created":1716615000,"model":"smollm2-135m","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-abc","object":"chat.completion.chunk","created":1716615000,"model":"smollm2-135m","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+
+...
+
+data: {"id":"chatcmpl-abc","object":"chat.completion.chunk","created":1716615000,"model":"smollm2-135m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+```
+
+`Tep::Streamer` handles the SSE write side; the route handler
+calls `backend.generate` with a block that wraps each token in
+the chunk envelope and writes it through the streamer.
+
+### `GET /v1/embeddings`
+
+Mounted only when `backend.supports_embeddings?` returns true.
+Standard OpenAI shape; calls `backend.embed`.
+
+## Checkpoint loading from a directory
+
+The natural integration with training pipelines that emit
+checkpoints: training writes to a directory; tep boots pointing
+at the directory; the backend's `load_model` (or `list_models`)
+reads from it.
+
+```sh
+TAO_RUN_DIR=/srv/runs/abc-2026-05-25 ./my_inference_app -p 4567
+```
+
+`Tep::Llm::OpenAI::Server` itself doesn't know about
+`TAO_RUN_DIR` — that's a backend-side convention. The backend
+reads the env var at boot, scans the directory for
+checkpoints, returns the names from `list_models`, loads them
+on demand from `generate`.
+
+A `latest` symlink convention (training pipeline updates
+`$TAO_RUN_DIR/latest` after each new checkpoint) lets the same
+running tep process pick up new weights without restart — the
+backend can re-scan on every request, on a TTL, or expose a
+`reload!` admin route. None of that is tep's concern.
+
+## Events emission
+
+The `events_jsonl:` argument to `serve!` wires a built-in
+post-completion hook that appends one JSON-encoded line per
+inference to the configured path. Schema target:
+
+```json
+{"ts": 1716615000.42, "kind": "eval", "model": "smollm2-135m",
+ "prompt_tokens": 12, "completion_tokens": 8, "latency_ms": 87,
+ "sampling": {"temperature": 0.7, "max_tokens": 256},
+ "request_id": "chatcmpl-abc",
+ "principal_id": "user:42"}
+```
+
+The exact field names + types **need to be aligned with the
+sibling project's training-events schema** so a single ingest
+consumes both training and serving telemetry. Held open until
+the sibling project publishes the v1 schema; this design will
+follow that.
+
+For apps not configuring an emit path, the hook is a no-op (no
+disk I/O, no latency overhead). For apps configuring it, the
+append happens after the response is sent to the client —
+emission failures (disk full, etc.) get logged but don't fail
+the request.
+
+## Identity and capabilities
+
+Same shape as `Tep::MCP` (Battery 5). The `serve!` call accepts
+a `cap:` keyword:
+
+```ruby
+Tep::Llm::OpenAI::Server.serve!(cap: :infer)
+```
+
+A `before` filter on all three routes checks
+`req.identity.may?(:infer)`; anonymous or under-capped callers
+get a 403 with `{"error": {"message": "missing capability:
+infer", "code": "permission_denied"}}` in the OpenAI error
+shape.
+
+The auth chain works as it does elsewhere in tep —
+`Authorization: Bearer <jwt>` with `Tep::AuthBearerToken`,
+session cookies with `Tep::AuthSessionCookie`, OAuth2 delegation
+with `Tep::AuthOAuth2`. OpenAI clients passing API keys as
+bearer tokens slot in cleanly.
+
+## What's deliberately NOT in this battery
+
+- **The compute substrate.** No KV cache, no batching, no
+  sampling, no tokenizer. All backend concerns. The backend
+  project ships whichever subset it wants; tep doesn't care.
+- **Cross-version OpenAI spec coverage.** v1 targets the
+  `chat/completions` + `models` + `embeddings` shape current
+  as of late 2025. The Responses API, Threads, Assistants,
+  Realtime — all distinct surfaces, each gets its own future
+  battery sub-namespace (`Tep::Llm::OpenAI::Realtime`, etc.)
+  when an actual use case files.
+- **Anthropic / Cohere / Bedrock wire formats.** Each gets its
+  own sub-namespace (`Tep::Llm::Anthropic::Server`, etc.)
+  modeled after this one, when demand surfaces. The
+  `Tep::Llm::OpenAI::*` naming is deliberate: OpenAI is one
+  wire format among several, not "the" LLM format.
+- **Pre-loaded model registry.** No "tep ships a model zoo".
+  Backends serve whatever's in their configured directory.
+
+## How sibling projects fit
+
+| Sibling | Role here |
+|---|---|
+| **toy** (Ruby ML framework) | Likely implements the first concrete `Tep::Llm::OpenAI::Backend`. Owns the FFI to ggml + sampling + KV cache + batching. The backend lives in toy, not tep. |
+| **(research-lab orchestrator)** | Drives the serving side after training: spawns a `Tep::Llm::OpenAI::Server` process pointing at a run directory, runs benchmark suites against it (lm-eval-harness, etc.), ingests the events.jsonl that drops alongside. Files the original `tep#serve-from-tao-run-dir` + `tep#openai-eval-emit` asks against this battery. |
+| **Future remote-backend** | If someone wants a `Tep::Llm::OpenAI::Backend` that *itself* proxies to a remote OpenAI server (degenerate "tep-as-LLM-router-with-shape-validation"), they implement the backend interface with `Tep::Proxy` inside. The `Tep::Proxy` battery exists exactly for this composition. |
+
+## Chunking (open for revision)
+
+Initial sketch — the actual chunk shape locks in after sibling
+projects confirm the backend interface fits their needs.
+
+| Chunk | Scope |
+|---|---|
+| **7.1** | Backend interface (`Tep::Llm::OpenAI::Backend` base class), `Tep::Llm::OpenAI::Server.use` + `.serve!` DSL, `/v1/models` + non-streaming `/v1/chat/completions`. A reference backend that delegates to `Tep::Llm` (the existing OpenAI-compat client) so the server can be exercised end-to-end without an ML dependency — useful for tests + demos. |
+| **7.2** | Streaming `/v1/chat/completions` (SSE) via `Tep::Streamer` + per-token block yielded by `backend.generate`. |
+| **7.3** | Events.jsonl emission (schema aligned with sibling-project's training events). |
+| **7.4** | `/v1/embeddings` (gated on `backend.supports_embeddings?`). |
+| **7.5+** | Function-calling / tool-use surface (when a real use case surfaces). Possibly the OpenAI Responses API (separate surface, possibly its own sub-namespace). |
+
+## Open questions for sibling-project conversation
+
+1. **Backend interface fit.** Does the `list_models` / `generate(model, messages, sampling, &on_token)` shape match what toy (or whichever concrete backend) wants to implement? Are KV cache + batching internal to the backend, or do they need tep-side hooks for sharing across requests?
+
+2. **Events schema.** What's the v1 event-stream schema training emits? The events.jsonl emitter here aligns with it; if the schema isn't frozen yet, we co-design.
+
+3. **Checkpoint discovery convention.** Is `TAO_RUN_DIR` + `latest` symlink the right shape, or does the backend project want a different convention (e.g., per-checkpoint subdirectories with manifest files)? Tep doesn't care — the backend owns it — but documenting the convention in tep's design helps coordination.
+
+4. **Streaming semantics.** Does the backend yield per token, per word, per N tokens, or per arbitrary chunk? OpenAI's spec is permissive (any sub-sentence delta is valid). v1 assumes per-token; if backends want bigger units for batching efficiency, this is easy to relax.
+
+5. **Capability set.** Is `:infer` the right single cap, or does the integration need finer-grained caps (`:infer:small_model` vs `:infer:large_model`, etc.) for billing/quota reasons? Probably defer until a real use case.
+
+6. **Hot reload.** Does the backend need a tep-mounted admin route (`POST /admin/reload`) to trigger re-scanning the run directory, or does the backend handle re-scanning autonomously (TTL, file-watch, etc.)? Tep can ship both — empty by default, opt-in.
+
+Filing answers to these is what unblocks freezing this design + starting chunk 7.1. Until then, the doc stays at "early draft, open for revision".
+
+## Non-goals (firm)
+
+- **Multi-tenant model isolation per request.** v1 assumes a single tep process serves one backend instance. Different models served from the same process is fine (the backend handles it via `list_models`); different backends in the same process is not (use multiple tep processes).
+- **Replacing OpenAI's own server.** This battery serves OpenAI-compat traffic from local compute. It's not a drop-in replacement for OpenAI's hosted service — there's no chat history, no thread management, no model fine-tuning API, no playground. Apps that need those surfaces build them on top.
+- **Compute scheduling.** Backends decide how to batch / pipeline / parallelize. Tep is the HTTP shell.

--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -1,0 +1,297 @@
+# Proxy battery design: Tep::Proxy
+
+Battery 6 — design draft. Generic HTTP proxy with a middleware
+filter chain. A primitive every tep app composes for: API
+gateways, observability layers, key-swap proxies, multi-upstream
+routing, mirror-to-staging, fan-out, LLM proxies. Whatever sits
+between a client and a real upstream HTTP server.
+
+> Status: **design draft, no code yet**. Sister doc:
+> [`OPENAI-SERVER-BATTERY.md`](OPENAI-SERVER-BATTERY.md) covers
+> the *origin-server* case (no upstream — tep is the source of
+> truth). The two batteries are independent; an OpenAI gateway
+> uses this one, an OpenAI server uses that one.
+
+## Goal
+
+One DSL declaration: ~10 lines of Ruby give you a tep route that
+forwards HTTP requests to an upstream, runs filter chains in
+both directions, and supports streaming bodies (SSE, chunked
+transfer) end-to-end.
+
+```ruby
+require 'sinatra'
+require 'tep/proxy'
+
+api = Tep::Proxy.new(upstream: "https://api.openai.com")
+
+api.before do |req, upstream_req|
+  upstream_req.headers["Authorization"] = "Bearer " + ENV.fetch("OPENAI_KEY")
+end
+
+api.after do |upstream_res, res|
+  Logger.info "upstream returned " + upstream_res.status.to_s
+end
+
+api.on_stream_chunk do |chunk, out|
+  out.write(chunk)   # could rewrite, count tokens, etc.
+end
+
+Tep.post "/v1/chat/completions", api
+Tep.get  "/v1/models",           api
+```
+
+## What it IS
+
+- An **HTTP reverse proxy**: client → tep (filters) → upstream → tep (filters) → client.
+- A **middleware chain** with three stages: `before` (pre-forward), `after` (post-response, non-streaming), `on_stream_chunk` (per-chunk for streaming responses).
+- A **`Tep::Handler` subclass** that mounts at any `Tep.<verb> "/path"` like a normal route handler. One proxy instance can serve many paths.
+- **Streaming-aware**: detects chunked / SSE responses and switches modes; client sees the same chunked stream the upstream emitted, with filter transformations applied per chunk.
+- **Identity-flowing**: `req.identity` from `Tep::Auth` is in scope in every filter, so capability checks, rate-limiting-by-user, audit logging all work uniformly.
+
+## What it ISN'T
+
+- **Not an origin server.** If you want tep to serve responses from local compute (model inference, business logic, anything where there's no upstream URL), the proxy battery doesn't help. See [`OPENAI-SERVER-BATTERY.md`](OPENAI-SERVER-BATTERY.md) for the OpenAI-shape origin case; for general origin work, just use plain `Tep.<verb>` routes.
+- **Not a service mesh.** No service discovery, no health checks, no automatic retries. One upstream URL per `Tep::Proxy` instance (composition via routing happens at a higher layer; see "Multi-upstream routing" below).
+- **Not protocol-aware.** The proxy speaks HTTP; the filters can inspect bodies but the battery itself doesn't know about OpenAI, REST conventions, GraphQL, etc. Protocol-specific logic lives in user filters or in higher-level batteries that compose this one.
+
+## Filter shape
+
+Three filter chains, each runs in declaration order:
+
+```ruby
+# before(req, upstream_req) — runs after request body is fully
+# received, before forwarding. upstream_req is mutable; tweak
+# its headers / path / query / body. Halt the chain entirely
+# by setting res.set_status + returning early (the proxy will
+# skip forwarding and send res directly to the client).
+api.before do |req, upstream_req|
+  if !req.identity.may?(:call_upstream)
+    res.set_status(403)
+    res.body = "missing capability: call_upstream"
+    return   # short-circuits — no upstream call happens
+  end
+  upstream_req.headers["X-Forwarded-For"] = req.remote_host
+end
+
+# after(upstream_res, res) — runs after upstream sends its full
+# (non-streaming) response, before res is written to the client.
+# upstream_res is read-only; res is mutable. Use to transform
+# the final response, emit logs/metrics, etc.
+api.after do |upstream_res, res|
+  res.headers["X-Proxy-Latency-Ms"] = (...).to_s
+end
+
+# on_stream_chunk(chunk, out) — runs for each chunk of a
+# streaming response (chunked transfer encoding or SSE). out is
+# a Tep::Stream-shape writer; whatever you write goes to the
+# client. Drop a chunk by not calling out.write. Transform by
+# writing modified bytes. Emit additional chunks by calling
+# out.write multiple times.
+api.on_stream_chunk do |chunk, out|
+  out.write(chunk)
+end
+```
+
+Filters run in order; multiple `before` / `after` / `on_stream_chunk`
+declarations stack.
+
+## DSL
+
+```ruby
+# Single-upstream proxy.
+proxy = Tep::Proxy.new(
+  upstream: "https://api.openai.com",
+  timeout:  30,           # seconds; defaults to 30
+  # Optional: rewrite the path-and-query that gets forwarded.
+  # Default: forward as-is. If set, gets the request's
+  # path+query and returns the upstream path+query.
+  path_rewrite: ->(p) { p },
+)
+
+proxy.before { |req, up| ... }
+proxy.after  { |up_res, res| ... }
+proxy.on_stream_chunk { |chunk, out| ... }
+
+# Mount as a handler at any tep route. One proxy serves many
+# routes; routing decisions happen at Tep.<verb> declaration time.
+Tep.get  "/v1/models",            proxy
+Tep.post "/v1/chat/completions",  proxy
+```
+
+For the spinel-friendly path, filters are stored as instance
+methods on translator-emitted Handler subclasses (similar to how
+`mcp_tool` lowers); the `before` / `after` / `on_stream_chunk`
+calls collect bodies at translate time and emit one Handler
+subclass per `Tep::Proxy` instance. This avoids the
+PtrArray<Block>-shape that spinel doesn't handle well.
+
+## Streaming
+
+Most interesting case + most subtle. Three sub-shapes:
+
+### 1. Plain non-streaming response
+
+Upstream sends a fixed-length body. tep reads it all, runs the
+`after` chain, writes the full response. Easy.
+
+### 2. Chunked transfer encoding
+
+Upstream sends `Transfer-Encoding: chunked`. tep reads chunks
+as they arrive, runs `on_stream_chunk` per chunk, forwards
+each one (with whatever transformation the filter applied) to
+the client as chunked output. `after` chain does not run for
+streaming responses (it's for the full-body shape).
+
+### 3. SSE (`text/event-stream`)
+
+Upstream sends `Content-Type: text/event-stream` with
+`event:` / `data:` / `id:` lines separated by `\n\n`. tep
+recognizes the content type and switches the `on_stream_chunk`
+unit to "one SSE event" rather than "one HTTP chunk" — so the
+filter sees coherent event records rather than raw HTTP chunks.
+
+```ruby
+# Per-event SSE filter (recognized automatically when upstream
+# Content-Type is text/event-stream):
+api.on_stream_chunk do |event, out|
+  # event is the full event record: "data: {...}\n\n"
+  parsed_data = event[/data:\s*(.+)/, 1]
+  # transform / inspect / re-encode
+  out.write(event)
+end
+```
+
+The transport implementation reuses tep's existing primitives:
+`Tep::Llm.read_sse_response` (already used by the chatbot
+example for inbound SSE) becomes the engine for SSE-aware
+chunk dispatch; `Tep::Streamer` (already used for outbound SSE)
+becomes the engine for writing to the client.
+
+## Multi-upstream routing
+
+Routing across multiple upstreams happens at the **Tep route**
+layer, not inside `Tep::Proxy`. Pattern:
+
+```ruby
+openai     = Tep::Proxy.new(upstream: "https://api.openai.com")
+anthropic  = Tep::Proxy.new(upstream: "https://api.anthropic.com")
+
+# Route by model name in the request body
+post "/v1/chat/completions" do
+  body = req.raw_body
+  model = Tep::Json.get_str(body, "model")
+  if model.start_with?("claude-")
+    anthropic.handle(req, res)
+  else
+    openai.handle(req, res)
+  end
+  res.body
+end
+```
+
+A future helper (`Tep::Proxy::Router`) could DSL this
+pattern, but v1 keeps it as plain Ruby route handlers
+selecting from a dictionary of proxies. Smaller surface, more
+predictable.
+
+## Identity and capabilities
+
+`req.identity` from `Tep::Auth` is in scope in every filter
+(same as in route handlers). Common pattern:
+
+```ruby
+api.before do |req, upstream_req|
+  if !req.identity.may?(:call_upstream)
+    res.set_status(403)
+    res.body = "missing capability"
+    return
+  end
+end
+```
+
+The proxy can ALSO swap auth on the way out — strip the
+client's credential, attach the upstream credential:
+
+```ruby
+api.before do |req, upstream_req|
+  upstream_req.headers["Authorization"] =
+    "Bearer " + ENV.fetch("UPSTREAM_KEY")
+  # client's req.identity stays in scope for filter logic, but
+  # the upstream sees only the server-side key.
+end
+```
+
+## Discovery / observability
+
+The proxy battery doesn't auto-publish anything (unlike MCP's
+`/llms.txt` + `/openapi.json`). A proxy is an internal infra
+component; what it forwards is the upstream's surface, and the
+upstream is responsible for advertising itself. If an app wants
+discovery on top of a proxy, they declare it explicitly
+(e.g., proxy `GET /v1/models` from upstream and serve a static
+`/openapi.json` describing the proxied subset).
+
+## Chunking
+
+| Chunk | Scope |
+|---|---|
+| **6.1** | `Tep::Proxy.new(upstream:)` base; `before` + `after` filter chains; non-streaming bodies; mount as `Tep::Handler` at any verb/path. |
+| **6.2** | Streaming proxy — chunked transfer encoding pass-through, SSE-aware `on_stream_chunk` for `text/event-stream` upstreams. |
+| **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + events emission). |
+| **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |
+
+## Spinel-related risks
+
+- **Outbound HTTP/1.1 keep-alive.** Tep's current outbound
+  client (`Tep::Http`) is HTTP/1.0 — a connection per upstream
+  request. For high-volume proxying this is wasteful. v1 ships
+  on HTTP/1.0; chunk 6.4+ adds an opt-in pooled HTTP/1.1
+  outbound client (probably extends `Tep::Http` rather than
+  creating a new battery).
+- **Streaming SSE re-encoding under fibers.** Works today —
+  `Tep::Server::Scheduled` + `Tep::Streamer` already exercise
+  the shape via LiveView/counter/agentic_chat. Re-using the
+  inbound-SSE consumer from `Tep::Llm.read_sse_response`
+  shouldn't trip spinel's recent landings, but watch for
+  poly-cascade if the filter blocks store callbacks across
+  multiple Proxy instances (PtrArray<Block> territory).
+- **Large request bodies.** Forwarding a 100MB upload through
+  filters means tep holds the body in memory. v1 caps at
+  `Tep::Server`'s existing SPHTTP_BUFSIZE (64 KiB) for the
+  start-line + headers; body up to `Content-Length` is
+  drained. Apps that need to proxy multi-megabyte bodies
+  should mount the proxy under a path that bypasses body
+  filtering and stream the body through unchanged (a 6.4+
+  opt-in).
+
+## Non-goals
+
+- **Multi-protocol.** This is an HTTP proxy. WebSocket
+  proxying is a separate problem (WS upgrade handshake, bi-
+  directional frames). If a demand surfaces, a sibling
+  `Tep::WebSocketProxy` battery is the right shape, not
+  growing this one.
+- **TLS termination.** tep doesn't do TLS itself (a fronting
+  nginx/Caddy does); the proxy operates on plaintext HTTP.
+  Upstream TLS works if `upstream:` is `https://` because
+  the outbound client uses libcurl-shape semantics, but the
+  proxy isn't a TLS-aware traffic inspector.
+- **Body transformation across content-type.** Filters see
+  raw bytes. If you want to JSON-parse, transform, re-encode,
+  you do it explicitly. The battery doesn't auto-deserialize.
+
+## Open questions
+
+- **Filter ordering vs short-circuit.** When a `before` filter
+  short-circuits (sets `res` + returns early), should later
+  `before` filters run? v1 stops at the short-circuit. If
+  symmetry with Rack-style middleware matters, we revisit.
+- **Header allow-list / deny-list defaults.** Should hop-by-hop
+  headers (`Connection`, `Keep-Alive`, `Transfer-Encoding`,
+  `Upgrade`, `Proxy-Authorization`, `TE`, `Trailers`) be
+  stripped automatically per RFC 7230? Yes — v1 strips them
+  by default; explicit `pass_hop_headers: true` overrides.
+- **WebSocket upgrade pass-through.** Out of scope for v1 (see
+  Non-goals). Worth confirming there's no near-term proxy use
+  case that needs it before locking the doc.


### PR DESCRIPTION
Two new design docs covering the natural split between \"HTTP proxy with middleware\" and \"OpenAI-compat origin server with pluggable backend\". Both design-only; no code in this PR.

## [`docs/PROXY-BATTERY.md`](docs/PROXY-BATTERY.md) — Battery 6

Generic HTTP reverse proxy with `before` / `after` / `on_stream_chunk` filter chains. Covers API gateways, observability layers, key-swap proxies, multi-upstream routing, LLM proxies (when fronting a remote OpenAI-compat upstream). Streaming-aware (chunked transfer + SSE). One `Tep::Proxy` mounts at any number of routes.

Explicitly **not** an origin server — if tep is the source of truth for the response (no upstream URL to forward to), the proxy battery doesn't help. That case is Battery 7.

## [`docs/OPENAI-SERVER-BATTERY.md`](docs/OPENAI-SERVER-BATTERY.md) — Battery 7 (OPEN FOR REVISION)

OpenAI-compat HTTP origin server backed by a pluggable `Backend` interface that some other project implements (ML framework with FFI to ggml, llama.cpp wrap, etc.). Tep ships the route + streaming + auth + caps + events.jsonl emission shell; the compute substrate lives in the backend project.

Sub-namespaced as `Tep::Llm::OpenAI::Server` (not `Tep::LlmServer`) since OpenAI is one wire format among many; Anthropic / Bedrock / Cohere shapes get sibling namespaces when demand surfaces.

Marked **\"early draft, open with sibling project to finalize\"** — the backend interface + events schema + checkpoint discovery convention all need a real conversation with the project that asked for this surface before freezing. Six open questions enumerated in the doc.

## Separation of concerns

- \`Tep::Proxy\` stays generic + HTTP-only (no LLM knowledge).
- \`Tep::Llm::OpenAI::Server\` doesn't proxy; uses Battery 6 only if a user wants a remote-OpenAI-backed backend composition.

No code changes; design docs only. Implementation chunks (6.1-6.4 + 7.1-7.5) sketched in each doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)