### PR TITLE
docs: integrate tao's ISSUES-FOR-TEP feedback (2026-05-25)

### DIFF
--- a/docs/OPENAI-SERVER-BATTERY.md
+++ b/docs/OPENAI-SERVER-BATTERY.md
@@ -230,46 +230,79 @@ same downstream consumers.
 
 ```json
 {
-  "kind": "run_start",
-  "t": 0,
-  "host": "gx10",
-  "backend": {"kind": "cpu"},
-  "git": {"sha": "abc123...", "dirty": false},
-  "model": {"name": "smollm2-135m", "path": "/srv/runs/.../weights/100.gguf"},
-  "config": {"server": "tep-llm-openai", "cap": "infer", "events_jsonl": "..."}
+  "kind":       "run_start",
+  "schema":     "toy/v1",
+  "t":          0,
+  "started_at": "2026-05-25T10:42:01Z",
+  "host":       "gx10",
+  "backend":    {"kind": "cpu"},
+  "git":        {"sha": "abc123...", "dirty": false},
+  "model":      {"name": "smollm2-135m", "path": "/srv/runs/.../weights/100.gguf"},
+  "config":     {"server": "tep-llm-openai", "cap": "infer", "events_jsonl": "..."}
 }
 ```
 
 Emitted once at `Tep::Llm::OpenAI::Server.serve!` invocation.
-`backend.kind` reads from `backend.device_kind` so `DEVICE=cuda`
-at boot propagates into the stream cleanly.
 
-### `eval` (one per request)
+- **`schema: "toy/v1"`** makes the stream self-identifying; a
+  downstream ingest that reads any line first looks at the
+  `run_start` for the schema version.
+- **`started_at`** is the absolute ISO-8601 wall-clock; subsequent
+  events use the relative `t` (float seconds since `run_start`).
+  Mirrors the training stream's shape so a single ingest reads
+  both without special-casing.
+- **`backend.kind`** reads from `backend.device_kind`, so
+  `DEVICE=cuda` at boot propagates into the stream cleanly.
 
-Serving telemetry rides on toy/v1's existing `eval` event with a
-new `phase: "serve"` value:
+### `inference` (one per request)
+
+Per-request serving telemetry is a **distinct event kind** rather
+than an overload of toy/v1's `eval` (which is reserved for
+held-out evaluation results during training: `loss`, `ppl`,
+`samples`, etc.). Sharing the `kind` would break tao's existing
+ingest (which keys on `kind` alone to find the "final eval"),
+and a served completion has none of `eval`'s defining fields
+anyway. Same envelope shape — only the `kind` value is new.
 
 ```json
 {
-  "kind": "eval",
-  "phase": "serve",
-  "t": 87.42,
-  "name": "request",
+  "kind":              "inference",
+  "phase":             "serve",
+  "t":                 12.4,
+  "model":             "smollm2-135m",
+  "prompt_tokens":     12,
+  "completion_tokens": 8,
+  "wall_us":           87000,
   "extra": {
-    "model": "smollm2-135m",
-    "prompt_tokens": 12,
-    "completion_tokens": 8,
-    "latency_us": 87000,
-    "sampling": {"temperature": 0.7, "max_tokens": 256},
-    "request_id": "cmpl-abc",
+    "sampling":     {"temperature": 0.7, "max_tokens": 256},
+    "request_id":   "cmpl-abc",
     "principal_id": "user:42"
   }
 }
 ```
 
-Per-request fields go in `extra` (the open-bag pattern toy/v1
-uses). Tep doesn't add new top-level fields beyond `kind / phase
-/ t / name / extra` — keeps the envelope stable.
+Stable per-request fields (`model`, `prompt_tokens`,
+`completion_tokens`, `wall_us`) are named top-level; caller-
+specific fields (`sampling`, `request_id`, `principal_id`) live
+in `extra` (the open-bag pattern toy/v1 uses for fields that
+vary per producer).
+
+**Status of the `kind` choice.** Tao's `ISSUES-FOR-TEP` makes
+the case for `kind: "inference"`; toy's earlier review proposed
+`kind: "eval", phase: "serve"`. The schema owner (toy) has the
+final say. This doc currently encodes tao's recommendation
+because:
+
+- Tao's downstream ingest breaks under the `eval` overload
+  (concrete cost).
+- Toy's "single envelope, single consumer" benefit is delivered
+  identically by either choice (the envelope shape doesn't
+  change; only the `kind` value does).
+- toy/v1's §Versioning explicitly welcomes new kinds as minor
+  revisions.
+
+If toy revises in favor of `eval+phase:"serve"`, this doc
+updates in lockstep and tao adds a one-line ingest guard.
 
 ### `step` (optional, per-token during streaming)
 
@@ -283,16 +316,21 @@ token in the streaming response:
 ```
 
 For backends that don't surface logprobs (toy today), the step
-event is not emitted — the `eval` event at request end is the
-only per-request record. Wiring logprobs into the decode loop is
-a separate toy-side issue; defer until a real consumer (e.g., a
-research-lab spec) needs it.
+event is not emitted — the `inference` event at request end is
+the only per-request record. Wiring logprobs into the decode
+loop is a separate backend-side issue; defer until a real
+consumer (e.g., a research-lab spec) needs it.
 
 ### `run_end` (one per server shutdown)
 
 ```json
-{ "kind": "run_end", "t": 28845.12, "reason": "ok",
-  "stats": {"requests": 4823, "errors": 2, "tokens_out": 1284013} }
+{
+  "kind":     "run_end",
+  "t":        28845.12,
+  "ended_at": "2026-05-26T03:34:46Z",
+  "reason":   "ok",
+  "stats":    {"requests": 4823, "errors": 2, "tokens_out": 1284013}
+}
 ```
 
 `reason` semantics (consistent with toy/v1):
@@ -316,24 +354,60 @@ correctness.
 
 ## Checkpoint loading
 
-Backend-side concern, not tep's. Common patterns:
+Backend-side concern, not tep's. Two modes, landing
+independently:
+
+### Mode A — Fixed model path (ships in 7.1)
 
 ```sh
-# Fixed model path (works today with toy's existing demo).
 MODEL_PATH=/srv/models/smollm2-135m.gguf ./serve -p 4567
-
-# Run directory + `latest` symlink (works once backends can
-# scan dirs + projects emit checkpoints to a known shape).
-TAO_RUN_DIR=/srv/runs/abc-2026-05-25 ./serve -p 4567
 ```
 
-The backend reads whichever env var(s) it cares about at boot,
-populates `list_models`, loads on demand from `generate_*`. Tep
-itself doesn't know about either env var.
+Works today against toy's existing
+`tep_demo/openai_api_smollm2.rb`. Backend reads the env var at
+boot, populates `list_models` with the single resolved file,
+loads on demand. **Tep's chunk 7.1 ships against this mode.**
 
-A future `Tep::Llm::OpenAI::Server.reload!` admin route can
-trigger a re-scan without restart — opt-in, lives in a 7.4+
-chunk if real demand surfaces.
+### Mode B — Run-directory auto-discovery (waits on backend)
+
+```sh
+TAO_RUN_DIR=/srv/runs/<run_key> ./serve -p 4567
+```
+
+Tao's run-directory layout convention:
+
+```
+runs/<run_key>/
+├── events.jsonl          # training stream (toy-emitted)
+├── run.json              # provenance manifest
+├── weights/
+│   ├── step_2000.gguf
+│   ├── step_4000.gguf
+│   └── latest -> step_4000.gguf
+└── artifacts/
+```
+
+Backend scans `weights/` for checkpoints, lists each via
+`list_models`, serves the latest by default. The
+`weights/latest` symlink convention lets the running server
+pick up new weights without restart (backend re-checks the
+symlink target on a TTL or per-request).
+
+**Blocked on a toy-side enable**: toy's training currently emits
+`events.jsonl` only, not weights. Once toy adds checkpoint
+writing (tracked toy-side), tao's scheduler maintains
+`weights/latest` after each successful step, and tep's
+run-directory mode is end-to-end.
+
+Tep doesn't know about either env var — that's a backend-side
+convention. `list_models` is the seam that supports both modes
+without tep caring which.
+
+### Future: hot reload
+
+A `Tep::Llm::OpenAI::Server.reload!` admin route can trigger a
+re-scan without restart — opt-in, lives in 7.4+ if demand
+surfaces. Backends can also self-watch.
 
 ## Identity and capabilities
 

--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -57,15 +57,16 @@ Tep.get  "/v1/models",           api
 
 ## Filter shape
 
-Three filter chains, each runs in declaration order:
+Four filter chains, each runs in declaration order:
 
 ```ruby
-# before(req, upstream_req) — runs after request body is fully
-# received, before forwarding. upstream_req is mutable; tweak
-# its headers / path / query / body. Halt the chain entirely
-# by setting res.set_status + returning early (the proxy will
-# skip forwarding and send res directly to the client).
-api.before do |req, upstream_req|
+# before(req, res, upstream_req) — runs after request body is
+# fully received, before forwarding. upstream_req is mutable;
+# tweak its headers / path / query / body. res is the client-
+# facing response; setting res.set_status + returning early
+# short-circuits the chain (the proxy skips forwarding and
+# sends res directly to the client).
+api.before do |req, res, upstream_req|
   if !req.identity.may?(:call_upstream)
     res.set_status(403)
     res.body = "missing capability: call_upstream"
@@ -74,27 +75,70 @@ api.before do |req, upstream_req|
   upstream_req.headers["X-Forwarded-For"] = req.remote_host
 end
 
-# after(upstream_res, res) — runs after upstream sends its full
-# (non-streaming) response, before res is written to the client.
-# upstream_res is read-only; res is mutable. Use to transform
-# the final response, emit logs/metrics, etc.
-api.after do |upstream_res, res|
-  res.headers["X-Proxy-Latency-Ms"] = (...).to_s
+# after(req, upstream_res, res) — runs after upstream sends its
+# full (non-streaming) response, before res is written to the
+# client. upstream_res is read-only; res is mutable. Use to
+# transform the final response, emit logs/metrics, etc.
+#
+# ALSO runs when a `before` filter short-circuited: in that case
+# upstream_res is nil and res carries the short-circuit body. This
+# is deliberate — audit logging should see rejected requests too.
+api.after do |req, upstream_res, res|
+  res.headers["X-Proxy-Latency-Us"] = (...).to_s
 end
 
 # on_stream_chunk(chunk, out) — runs for each chunk of a
-# streaming response (chunked transfer encoding or SSE). out is
-# a Tep::Stream-shape writer; whatever you write goes to the
-# client. Drop a chunk by not calling out.write. Transform by
-# writing modified bytes. Emit additional chunks by calling
-# out.write multiple times.
+# streaming response (chunked transfer encoding or SSE). For
+# text/event-stream upstreams, each chunk is one complete SSE
+# event record (`event: ...\n` + zero or more `data: ...\n`
+# lines + `\n`). out is a Tep::Stream-shape writer; whatever
+# you write goes to the client. Drop a chunk by not calling
+# out.write. Transform by writing modified bytes. Emit
+# additional chunks by calling out.write multiple times.
 api.on_stream_chunk do |chunk, out|
   out.write(chunk)
 end
+
+# on_stream_end(req, out, stats) — fires exactly once when a
+# streaming response finishes (last chunk seen + upstream closed).
+# stats is a Hash the on_stream_chunk filters accumulated into
+# (chunk count, byte count, whatever the filter chain stored on
+# stats[:foo] = ...). Use this to emit one final telemetry event
+# at end-of-stream -- the streaming analog of `after`.
+api.on_stream_end do |req, out, stats|
+  EVENTS.write(req_id: req.headers["x-request-id"],
+               tokens_out: stats[:tokens],
+               wall_us: stats[:wall_us])
+end
 ```
 
-Filters run in order; multiple `before` / `after` / `on_stream_chunk`
-declarations stack.
+Filters run in order; multiple `before` / `after` /
+`on_stream_chunk` / `on_stream_end` declarations stack.
+
+The `stats` Hash passed to `on_stream_end` is the same Hash
+each `on_stream_chunk` invocation receives as a fourth optional
+argument (`|chunk, out, _, stats|`). Filters that accumulate
+across chunks (token counting, byte counting, parsing for an
+end-of-stream `[DONE]` marker) write to it.
+
+### SSE caveat
+
+For `text/event-stream` upstreams, tep dispatches each SSE event
+record as one chunk to `on_stream_chunk`. An event record can
+contain **multiple `data:` lines** per the SSE spec:
+
+```
+event: message
+data: line one
+data: line two
+
+```
+
+A filter that extracts data payloads must handle the multi-line
+shape, not just the first `data:` line. For OpenAI-shaped
+streams the events are single-line and the simple
+`event[/data:\s*(.+)/, 1]` pattern works; for other producers
+join the `data:` lines with `\n` per spec.
 
 ## DSL
 
@@ -109,9 +153,10 @@ proxy = Tep::Proxy.new(
   path_rewrite: ->(p) { p },
 )
 
-proxy.before { |req, up| ... }
-proxy.after  { |up_res, res| ... }
-proxy.on_stream_chunk { |chunk, out| ... }
+proxy.before          { |req, res, upstream_req|       ... }
+proxy.after           { |req, upstream_res, res|       ... }
+proxy.on_stream_chunk { |chunk, out, stats|            ... }
+proxy.on_stream_end   { |req, out, stats|              ... }
 
 # Mount as a handler at any tep route. One proxy serves many
 # routes; routing decisions happen at Tep.<verb> declaration time.
@@ -237,8 +282,8 @@ discovery on top of a proxy, they declare it explicitly
 | Chunk | Scope |
 |---|---|
 | **6.1** | `Tep::Proxy.new(upstream:)` base; `before` + `after` filter chains; non-streaming bodies; mount as `Tep::Handler` at any verb/path. |
-| **6.2** | Streaming proxy — chunked transfer encoding pass-through, SSE-aware `on_stream_chunk` for `text/event-stream` upstreams. |
-| **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + events emission). |
+| **6.2** | Streaming proxy — chunked transfer encoding pass-through, SSE-aware `on_stream_chunk` for `text/event-stream` upstreams, **`on_stream_end` finalizer hook** for one-shot end-of-stream telemetry. |
+| **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + per-request `inference` event emission via `on_stream_end`). |
 | **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |
 
 ## Spinel-related risks
@@ -284,9 +329,11 @@ discovery on top of a proxy, they declare it explicitly
 ## Open questions
 
 - **Filter ordering vs short-circuit.** When a `before` filter
-  short-circuits (sets `res` + returns early), should later
-  `before` filters run? v1 stops at the short-circuit. If
-  symmetry with Rack-style middleware matters, we revisit.
+  short-circuits (sets `res` + returns early), later `before`
+  filters do NOT run. The `after` chain DOES run — with
+  `upstream_res = nil` and `res` carrying the short-circuit
+  body — so audit logging sees rejected requests. (Set in this
+  revision; was open in the first draft.)
 - **Header allow-list / deny-list defaults.** Should hop-by-hop
   headers (`Connection`, `Keep-Alive`, `Transfer-Encoding`,
   `Upgrade`, `Proxy-Authorization`, `TE`, `Trailers`) be


### PR DESCRIPTION
Tao (with toy's earlier review folded in) sent six concrete items against the Battery 6 + 7 design docs from #76 / #77. Five are concrete revisions; the sixth (chunking) was already done in #77 and re-confirmed here.

## OPENAI-SERVER-BATTERY.md changes

| Item | Change |
|---|---|
| Schema kind | `kind:\"eval\" + phase:\"serve\"` → `kind:\"inference\"`. Tao's downstream `Ingest.summary` keys on kind alone; reusing `eval` makes \"final eval\" be the last HTTP request. New kind is the cleaner answer per toy/v1's §Versioning. Schema owner (toy) gets the final word; this doc encodes tao's recommendation with the trade-off documented inline. |
| Schema marker | `run_start` gains `schema:\"toy/v1\"` so the stream is self-identifying. |
| Timestamps | `started_at` / `ended_at` ISO-8601 on run_start/run_end (absolute wall-clock); subsequent events use relative `t` (seconds float). Mirrors training stream. |
| Stable vs caller fields | Named top-level fields for the stable parts (model, prompt_tokens, completion_tokens, wall_us); `extra` open-bag for caller-specific (sampling, request_id, principal_id). |
| Run-dir layout | Mode A (fixed `MODEL_PATH`) ships in 7.1. Mode B (run-dir auto-discovery) documents the tao convention: `runs/<run_key>/{events.jsonl, run.json, weights/, artifacts/}` with `weights/latest` symlink. Mode B waits on a backend-side enable but doesn't block Mode A. |

## PROXY-BATTERY.md changes

| Item | Change |
|---|---|
| New hook | `on_stream_end(req, out, stats)` fires exactly once at end-of-stream. Seam for emitting one final telemetry event during streamed proxy traffic. Moved into chunk 6.2. |
| `on_stream_chunk` 3rd arg | `stats` Hash that accumulates across chunks and reaches `on_stream_end`. |
| `before` signature | Now `|req, res, upstream_req|` (was missing `res`; short-circuit example didn't run). |
| `after` signature | Now `|req, upstream_res, res|`. |
| `after` on short-circuit | Specified to run with `upstream_res=nil`; audit logging sees rejected requests. |
| SSE multi-line `data:` | Caveat added; single-line example flagged as OpenAI-specific. |

## Trail

- [`tao/ISSUES-FOR-TEP.md`](https://github.com/OriPekelman/tao/...) — the ready-to-paste issue bodies that drove this round (private repo).
- [`toy/docs/notes/tep-openai-server-comments-2026-05-25.md`](https://github.com/OriPekelman/toy_ruby_neural_network/...) — earlier producer review (private repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)