### PR TITLE
feat(sqlite): Tep::SQLite#prepare_cached + cached-finalize semantic

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -340,6 +340,13 @@ module Tep
     _tep_seed_db.finalize
     _tep_seed_db.first_str("SELECT k FROM _seed", "")
     _tep_seed_db.first_int("SELECT v FROM _seed", "")
+    # Pin the prepare_cached param type so apps that don't call it
+    # still see the FFI shape (`Sqlite.tep_sqlite_prepare_cached(int,
+    # str)`) at module-load. Cache hit / miss / reuse paths are
+    # exercised by test/test_sqlite_cached.rb at runtime.
+    _tep_seed_db.prepare_cached("SELECT k FROM _seed")
+    _tep_seed_db.step
+    _tep_seed_db.finalize
     _tep_seed_db.close
   end
 

--- a/lib/tep/sqlite.rb
+++ b/lib/tep/sqlite.rb
@@ -55,6 +55,7 @@ module Sqlite
   ffi_func :tep_sqlite_close,             [:int],          :int
   ffi_func :tep_sqlite_exec,              [:int, :str],    :int
   ffi_func :tep_sqlite_prepare,           [:int, :str],    :int
+  ffi_func :tep_sqlite_prepare_cached,    [:int, :str],    :int
   ffi_func :tep_sqlite_bind_str,          [:int, :str],    :int
   ffi_func :tep_sqlite_bind_int,          [:int, :int],    :int
   ffi_func :tep_sqlite_step,              [],              :int
@@ -123,6 +124,27 @@ module Tep
         return false
       end
       Sqlite.tep_sqlite_prepare(@dbh, sql) == 0
+    end
+
+    # Cached variant. Same surface as `prepare`, but the underlying
+    # `sqlite3_stmt *` is memoised per-(db, sql); subsequent calls
+    # with the same SQL string reuse the prepared statement, paying
+    # the parse cost only once per process. Pair with `finalize` as
+    # usual; on the cached path `finalize` becomes
+    # `sqlite3_reset + sqlite3_clear_bindings` (the slot stays
+    # alive). The cache is bounded (currently 64 distinct SQL
+    # strings per process); apps that exceed the bound fall through
+    # to uncached prepare so correctness is preserved.
+    #
+    # Use for hot-path SQL where the string is known + fixed at
+    # codegen / boot time. Apps that build SQL with varying
+    # whitespace miss the cache (match is literal); format
+    # consistently.
+    def prepare_cached(sql)
+      if @dbh < 0
+        return false
+      end
+      Sqlite.tep_sqlite_prepare_cached(@dbh, sql) == 0
     end
 
     def bind_str(idx, value); Sqlite.tep_sqlite_bind_str(idx, value); end

--- a/lib/tep/tep_sqlite.c
+++ b/lib/tep/tep_sqlite.c
@@ -43,12 +43,29 @@
 #include <string.h>
 #include <sqlite3.h>
 
-#define TEP_SQLITE_MAX_HANDLES   16
-#define TEP_SQLITE_COL_BUFSIZE   65536
-#define TEP_SQLITE_COL_BUF_SLOTS 16
+#define TEP_SQLITE_MAX_HANDLES    16
+#define TEP_SQLITE_COL_BUFSIZE    65536
+#define TEP_SQLITE_COL_BUF_SLOTS  16
+#define TEP_SQLITE_CACHE_SLOTS    64       /* prepare-statement cache */
+#define TEP_SQLITE_CACHE_SQL_MAX  512      /* longest cached SQL */
 
 static sqlite3      *tep_sqlite_handles[TEP_SQLITE_MAX_HANDLES] = {0};
 static sqlite3_stmt *tep_sqlite_stmt = NULL;
+/* When the current cursor came from the prepare-statement cache, we
+ * must NOT sqlite3_finalize it on tep_sqlite_finalize -- the slot
+ * stays alive for reuse, and finalize becomes reset+clear_bindings.
+ * Same applies to tep_sqlite_prepare's stmt-swap path. */
+static int           tep_sqlite_stmt_cached = 0;
+
+/* prepare-statement cache (chunk per #75). Linear scan by (h, sql);
+ * n is small so O(n) is fine. Bounded by TEP_SQLITE_CACHE_SLOTS;
+ * if full, prepare_cached falls through to an uncached prepare. */
+typedef struct {
+    int           h;                                 /* db handle index (1-based), 0 = empty */
+    sqlite3_stmt *stmt;
+    char          sql[TEP_SQLITE_CACHE_SQL_MAX];
+} tep_sqlite_cache_entry;
+static tep_sqlite_cache_entry tep_sqlite_cache[TEP_SQLITE_CACHE_SLOTS] = {0};
 /* Rotating return buffers for col_str. spinel's `:str` return type
  * wants a pointer that stays valid until "the caller is done with
  * it", but in practice callers stash multiple col_str results into
@@ -93,8 +110,23 @@ int tep_sqlite_close(int h) {
     /* Finalize any cursor that was on this handle to avoid
      * sqlite_close returning SQLITE_BUSY. */
     if (tep_sqlite_stmt && sqlite3_db_handle(tep_sqlite_stmt) == db) {
-        sqlite3_finalize(tep_sqlite_stmt);
+        if (!tep_sqlite_stmt_cached) {
+            sqlite3_finalize(tep_sqlite_stmt);
+        }
+        /* Cached stmts get finalized below by the cache walk. */
         tep_sqlite_stmt = NULL;
+        tep_sqlite_stmt_cached = 0;
+    }
+    /* Finalize every cached statement that belongs to this handle
+     * before closing the db. Cache slots are owner-keyed by `h`. */
+    int i;
+    for (i = 0; i < TEP_SQLITE_CACHE_SLOTS; i++) {
+        if (tep_sqlite_cache[i].h == h && tep_sqlite_cache[i].stmt) {
+            sqlite3_finalize(tep_sqlite_cache[i].stmt);
+            tep_sqlite_cache[i].stmt = NULL;
+            tep_sqlite_cache[i].h    = 0;
+            tep_sqlite_cache[i].sql[0] = '\0';
+        }
     }
     sqlite3_close(db);
     tep_sqlite_handles[h - 1] = NULL;
@@ -111,18 +143,93 @@ int tep_sqlite_exec(int h, const char *sql) {
     return rc == SQLITE_OK ? 0 : -1;
 }
 
+/* Drop or reset whatever's currently on the singleton cursor before
+ * we install a new one. Cached stmts get reset+clear_bindings (so
+ * the cached slot stays valid); uncached stmts get finalized. */
+static void tep_sqlite_release_current(void) {
+    if (!tep_sqlite_stmt) return;
+    if (tep_sqlite_stmt_cached) {
+        sqlite3_reset(tep_sqlite_stmt);
+        sqlite3_clear_bindings(tep_sqlite_stmt);
+    } else {
+        sqlite3_finalize(tep_sqlite_stmt);
+    }
+    tep_sqlite_stmt = NULL;
+    tep_sqlite_stmt_cached = 0;
+}
+
 int tep_sqlite_prepare(int h, const char *sql) {
     if (h < 1 || h > TEP_SQLITE_MAX_HANDLES) return -1;
     sqlite3 *db = tep_sqlite_handles[h - 1];
     if (db == NULL) return -1;
-    if (tep_sqlite_stmt) {
-        sqlite3_finalize(tep_sqlite_stmt);
-        tep_sqlite_stmt = NULL;
-    }
+    tep_sqlite_release_current();
     if (sqlite3_prepare_v2(db, sql, -1, &tep_sqlite_stmt, NULL) != SQLITE_OK) {
         tep_sqlite_stmt = NULL;
         return -1;
     }
+    /* uncached */
+    return 0;
+}
+
+/* Cached variant: looks up `sql` for db handle `h` in the cache;
+ * on hit reuses the prepared statement (with reset + clear_bindings);
+ * on miss prepares + stashes in the first free slot; if the cache is
+ * full, falls back to an uncached prepare so the caller still works.
+ *
+ * SQL is matched literally (no normalization). Apps that generate
+ * SQL with varying whitespace miss the cache; format consistently. */
+int tep_sqlite_prepare_cached(int h, const char *sql) {
+    if (h < 1 || h > TEP_SQLITE_MAX_HANDLES) return -1;
+    sqlite3 *db = tep_sqlite_handles[h - 1];
+    if (db == NULL) return -1;
+    /* SQL longer than the cache's per-slot buffer: just do an
+     * uncached prepare. The caller still gets correct behavior. */
+    size_t sql_len = strlen(sql);
+    if (sql_len >= TEP_SQLITE_CACHE_SQL_MAX) {
+        return tep_sqlite_prepare(h, sql);
+    }
+    tep_sqlite_release_current();
+    /* Cache lookup. */
+    int i;
+    for (i = 0; i < TEP_SQLITE_CACHE_SLOTS; i++) {
+        if (tep_sqlite_cache[i].h == h &&
+            tep_sqlite_cache[i].stmt &&
+            strcmp(tep_sqlite_cache[i].sql, sql) == 0) {
+            tep_sqlite_stmt = tep_sqlite_cache[i].stmt;
+            sqlite3_reset(tep_sqlite_stmt);
+            sqlite3_clear_bindings(tep_sqlite_stmt);
+            tep_sqlite_stmt_cached = 1;
+            return 0;
+        }
+    }
+    /* Cache miss -- find an empty slot. */
+    int empty = -1;
+    for (i = 0; i < TEP_SQLITE_CACHE_SLOTS; i++) {
+        if (tep_sqlite_cache[i].h == 0) { empty = i; break; }
+    }
+    if (empty < 0) {
+        /* Cache full: prepare uncached so the caller works. The
+         * existing tep_sqlite_finalize path will sqlite3_finalize
+         * this one as today. */
+        if (sqlite3_prepare_v2(db, sql, -1, &tep_sqlite_stmt, NULL) != SQLITE_OK) {
+            tep_sqlite_stmt = NULL;
+            return -1;
+        }
+        tep_sqlite_stmt_cached = 0;
+        return 0;
+    }
+    /* Prepare + stash. */
+    sqlite3_stmt *new_stmt = NULL;
+    if (sqlite3_prepare_v2(db, sql, -1, &new_stmt, NULL) != SQLITE_OK) {
+        tep_sqlite_stmt = NULL;
+        return -1;
+    }
+    tep_sqlite_cache[empty].h    = h;
+    tep_sqlite_cache[empty].stmt = new_stmt;
+    memcpy(tep_sqlite_cache[empty].sql, sql, sql_len);
+    tep_sqlite_cache[empty].sql[sql_len] = '\0';
+    tep_sqlite_stmt        = new_stmt;
+    tep_sqlite_stmt_cached = 1;
     return 0;
 }
 
@@ -171,10 +278,21 @@ int tep_sqlite_col_count(void) {
     return sqlite3_column_count(tep_sqlite_stmt);
 }
 
+/* Finalize semantics depend on whether the current stmt came from
+ * the prepare-statement cache. Cached stmts get reset + clear_bindings
+ * and stay alive in their slot (the whole point of the cache); only
+ * uncached stmts actually sqlite3_finalize. The Ruby-side API
+ * (`db.finalize`) is unchanged either way. */
 int tep_sqlite_finalize(void) {
     if (!tep_sqlite_stmt) return 0;
-    sqlite3_finalize(tep_sqlite_stmt);
+    if (tep_sqlite_stmt_cached) {
+        sqlite3_reset(tep_sqlite_stmt);
+        sqlite3_clear_bindings(tep_sqlite_stmt);
+    } else {
+        sqlite3_finalize(tep_sqlite_stmt);
+    }
     tep_sqlite_stmt = NULL;
+    tep_sqlite_stmt_cached = 0;
     return 0;
 }
 

--- a/test/test_sqlite_cached.rb
+++ b/test/test_sqlite_cached.rb
@@ -1,0 +1,171 @@
+require_relative "helper"
+
+# Tep::SQLite#prepare_cached -- cache hit / miss / reset-on-finalize
+# semantics. Backs the perf-leverage win documented in issue #75.
+class TestSqliteCached < TepTest
+  TMP_DB = "/tmp/tep_test_cache_#{$$}.db"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    on_start do
+      db = Tep::SQLite.new
+      if db.open("#{TMP_DB}")
+        db.exec("CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY, name TEXT)")
+        db.exec("DELETE FROM items")
+        db.prepare("INSERT INTO items (name) VALUES (?)")
+        db.bind_str(1, "alpha")
+        db.step
+        db.reset
+        db.bind_str(1, "beta")
+        db.step
+        db.reset
+        db.bind_str(1, "gamma")
+        db.step
+        db.finalize
+        db.close
+      end
+    end
+
+    # Repeated prepare_cached with the SAME sql + DIFFERENT
+    # bindings -- the cache reuse path must reset+clear_bindings
+    # so the second call's binding wins.
+    get '/cached_rebind' do
+      db = Tep::SQLite.new
+      db.open("#{TMP_DB}")
+      sql = "SELECT name FROM items WHERE id = ?"
+      out = ""
+      i = 1
+      while i <= 3
+        db.prepare_cached(sql)
+        db.bind_int(1, i)
+        if db.step == 1
+          if out.length > 0
+            out = out + ","
+          end
+          out = out + db.col_str(0)
+        end
+        db.finalize
+        i += 1
+      end
+      db.close
+      out
+    end
+
+    # Mix prepare + prepare_cached + prepare -- exercises both
+    # paths in alternation. Uncached prepare after a cached one
+    # must release the cached cursor via reset (NOT finalize),
+    # leaving the cache slot valid for the next prepare_cached.
+    get '/mixed_prepare' do
+      db = Tep::SQLite.new
+      db.open("#{TMP_DB}")
+      cached_sql = "SELECT name FROM items WHERE id = ?"
+      # First cached hit (cache miss -> populate slot)
+      db.prepare_cached(cached_sql)
+      db.bind_int(1, 1)
+      db.step
+      first = db.col_str(0)
+      db.finalize
+      # Uncached prepare in between
+      db.prepare("SELECT name FROM items WHERE id = ?")
+      db.bind_int(1, 2)
+      db.step
+      middle = db.col_str(0)
+      db.finalize
+      # Cached hit again (slot still alive)
+      db.prepare_cached(cached_sql)
+      db.bind_int(1, 3)
+      db.step
+      last = db.col_str(0)
+      db.finalize
+      db.close
+      first + "|" + middle + "|" + last
+    end
+
+    # Cache survives across a different db (per-handle scope) --
+    # the cached_sql here belongs to db1; db2 with the same SQL
+    # gets a separate cache slot.
+    get '/per_handle' do
+      sql = "SELECT name FROM items WHERE id = ?"
+      db1 = Tep::SQLite.new
+      db1.open("#{TMP_DB}")
+      db1.prepare_cached(sql)
+      db1.bind_int(1, 1)
+      db1.step
+      r1 = db1.col_str(0)
+      db1.finalize
+      db1.close   # close while a cache slot still exists for this handle
+
+      db2 = Tep::SQLite.new
+      db2.open("#{TMP_DB}")
+      db2.prepare_cached(sql)
+      db2.bind_int(1, 2)
+      db2.step
+      r2 = db2.col_str(0)
+      db2.finalize
+      db2.close
+      r1 + "|" + r2
+    end
+
+    # Smoke: a tight loop of cached calls works without leaks --
+    # exercises the cache hit path repeatedly with the same SQL.
+    get '/loop_count' do
+      db = Tep::SQLite.new
+      db.open("#{TMP_DB}")
+      sql = "SELECT count(*) FROM items"
+      n = 0
+      i = 0
+      while i < 50
+        db.prepare_cached(sql)
+        if db.step == 1
+          n = db.col_int(0)
+        end
+        db.finalize
+        i += 1
+      end
+      db.close
+      "loops=" + i.to_s + " count=" + n.to_s
+    end
+  RB
+
+  Minitest.after_run do
+    File.unlink(TMP_DB) if File.exist?(TMP_DB)
+  end
+
+  def test_cache_hit_rebinds_correctly
+    # Same SQL, three different bindings, three different rows.
+    # If clear_bindings didn't fire, the int param would leak
+    # across calls and rows would repeat.
+    res = get("/cached_rebind")
+    assert_equal "200", res.code
+    assert_equal "alpha,beta,gamma", res.body
+  end
+
+  def test_mixed_prepare_paths_coexist
+    # The uncached prepare in the middle must not invalidate the
+    # cached slot for the surrounding prepare_cached calls.
+    res = get("/mixed_prepare")
+    assert_equal "200", res.code
+    assert_equal "alpha|beta|gamma", res.body
+  end
+
+  def test_close_finalizes_cached_stmts_for_handle
+    # /per_handle opens db1, caches a stmt, closes db1, opens db2,
+    # caches the same SQL (separate slot), closes db2. If close()
+    # didn't finalize db1's cached stmt, sqlite3_close would
+    # SQLITE_BUSY and the second open would land an invalid handle.
+    res = get("/per_handle")
+    assert_equal "200", res.code
+    assert_equal "alpha|beta", res.body
+  end
+
+  def test_loop_of_cached_calls_no_leak
+    # 50 reuses of the same cached SQL. If the cache flag handling
+    # was wrong, sqlite would either leak or error out around
+    # iteration 16+ (SQLITE_MAX_STATEMENT_PARAMETERS / stack
+    # exhaustion).
+    res = get("/loop_count")
+    assert_equal "200", res.code
+    assert_match(/loops=50 count=3/, res.body)
+  end
+end


### PR DESCRIPTION
Closes #75.

Hot-path SQL skips the \`sqlite3_prepare_v2\` parse cost on repeat calls by memoising the prepared statement per-(db, sql). Pair with \`finalize\` as usual; on cached statements, finalize becomes \`sqlite3_reset + sqlite3_clear_bindings\` — the slot stays alive for the next \`prepare_cached(sql)\` call.

## Surface

\`\`\`ruby
db.prepare_cached(\"SELECT name FROM users WHERE id = ?\")
db.bind_int(1, 42)
db.step
db.col_str(0)
db.finalize    # reset + clear_bindings on cached; finalize on uncached
\`\`\`

\`prepare\` keeps its uncached semantics exactly as today. \`prepare_cached\` is opt-in per call; mixing the two in any order works — the C side tracks per-cursor whether the current stmt came from the cache.

## Implementation

Cache lives at the C level (\`lib/tep/tep_sqlite.c\`) as a static 64-slot table keyed on (db handle index, sql string). Linear lookup; n is small. Cache full → prepare_cached falls through to an uncached prepare so correctness is preserved.

\`tep_sqlite_close(h)\` walks the cache and finalises every slot that belongs to the closing handle.

## Test plan

- [x] 4 new tests in \`test/test_sqlite_cached.rb\` (cache hit + clear_bindings, mixed prepare paths, close-with-cached-stmts, 50-iter loop).
- [x] Existing \`test/test_sqlite.rb\` stays green (uncached path unchanged).
- [x] Full \`make test\`: **392/0/48** (+4 new tests).

## Cross-cite

[rubys/roundhouse#12](https://github.com/rubys/roundhouse/issues/12) — the original asymmetry that filed #75 (Rails has stmt cache, roundhouse-emit targets don't). Once this lands on tep main, roundhouse's \`runtime/spinel/db.rb\` vendors the new \`prepare_cached\` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)