### PR TITLE
feat(presence): heartbeat + prune_stale_workers for PG-mirror GC

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -292,6 +292,9 @@ module Tep
   Tep::Presence.mirror_status("_seed", -1, :available, "", 0)
   Tep::Presence.list_global("_seed")
   Tep::Presence.count_global("_seed")
+  Tep::Presence.worker_schema_sql
+  Tep::Presence.heartbeat
+  Tep::Presence.prune_stale_workers(90)
   Tep::Presence.disable_pg_mirror
   # Same APP-setter-via-constant pattern as the broadcast_pg_conn
   # seed: PG::Connection.new can't run inside App#initialize

--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -278,8 +278,9 @@ module Tep
     # Worker ID is PID + boot epoch second so a same-PID restart
     # doesn't alias a prior worker's stale rows. On
     # disable_pg_mirror (or clean shutdown), this worker's rows
-    # get DELETE'd. A crashed worker leaves stale rows -- the
-    # periodic-prune follow-up tracks at OriPekelman/tep#47.
+    # get DELETE'd. Crashed workers leave stale rows; the
+    # heartbeat + prune_stale_workers pair below handles the
+    # garbage-collection.
     #
     # Returns 0 on success, -1 on connect / schema failure.
     def self.enable_pg_mirror(conninfo)
@@ -288,6 +289,14 @@ module Tep
         return -1
       end
       r = conn.exec(Tep::Presence.schema_sql)
+      if !r.ok?
+        r.clear
+        conn.finish
+        return -1
+      end
+      r.clear
+      # Heartbeat table for the prune-stale-workers path (#47).
+      r = conn.exec(Tep::Presence.worker_schema_sql)
       if !r.ok?
         r.clear
         conn.finish
@@ -305,6 +314,10 @@ module Tep
         "DELETE FROM tep_presence WHERE worker_id = $1",
         [worker_id])
       r.clear
+      # Register this worker's heartbeat row immediately. Apps
+      # refresh it periodically via Tep::Presence.heartbeat;
+      # prune_stale_workers deletes rows whose heartbeat is stale.
+      Tep::Presence.heartbeat
       0
     end
 
@@ -314,6 +327,12 @@ module Tep
       end
       r = Tep::APP.presence_pg_conn.exec_params(
         "DELETE FROM tep_presence WHERE worker_id = $1",
+        [Tep::APP.presence_pg_worker_id])
+      r.clear
+      # Remove the heartbeat row so prune_stale_workers doesn't
+      # see this worker as live after we're gone.
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "DELETE FROM tep_presence_worker WHERE worker_id = $1",
         [Tep::APP.presence_pg_worker_id])
       r.clear
       Tep::APP.presence_pg_conn.finish
@@ -338,6 +357,85 @@ module Tep
         "status_until BIGINT NOT NULL, " +
         "PRIMARY KEY (worker_id, topic, fd)" +
       ")"
+    end
+
+    # Heartbeat table -- one row per worker that's mirroring
+    # presence right now. Used by prune_stale_workers to identify
+    # crashed workers (no heartbeat updates in N seconds) and
+    # garbage-collect their orphan tep_presence rows.
+    def self.worker_schema_sql
+      "CREATE TABLE IF NOT EXISTS tep_presence_worker (" +
+        "worker_id    TEXT PRIMARY KEY, " +
+        "last_seen_ts BIGINT NOT NULL" +
+      ")"
+    end
+
+    # Refresh this worker's heartbeat row to the current Unix
+    # timestamp. Apps call this periodically (typical: from a
+    # before-filter, a Tep::Job tick, or an explicit timer fiber)
+    # so prune_stale_workers can tell live workers from crashed
+    # ones. No-op when the PG mirror isn't enabled, or when the
+    # mirror was opened on a different process and we're the
+    # post-fork child (worker_id is empty until enable_pg_mirror
+    # runs locally).
+    #
+    # Returns 1 if the heartbeat row was upserted, 0 if the call
+    # short-circuited (mirror disabled or no worker_id).
+    def self.heartbeat
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      wid = Tep::APP.presence_pg_worker_id
+      if wid.length == 0
+        return 0
+      end
+      r = Tep::APP.presence_pg_conn.exec_params(
+        "INSERT INTO tep_presence_worker (worker_id, last_seen_ts) " +
+        "VALUES ($1, $2) " +
+        "ON CONFLICT (worker_id) DO UPDATE SET " +
+        "  last_seen_ts = EXCLUDED.last_seen_ts",
+        [wid, Time.now.to_i.to_s])
+      r.clear
+      1
+    end
+
+    # Prune crashed-worker rows. Deletes:
+    #   1. tep_presence_worker rows whose last_seen_ts is older than
+    #      ttl_seconds (the worker's heartbeat is stale).
+    #   2. tep_presence rows whose worker_id has no surviving
+    #      heartbeat (orphans left by the crashed worker).
+    #
+    # Apps call this periodically -- the canonical shape is a
+    # before-filter on a "/health" route that internal monitoring
+    # hits every 30s, or a Tep::Job that fires from a cron-like
+    # tick. Returns the number of tep_presence rows deleted.
+    #
+    # ttl_seconds should be at least 3x the app's typical
+    # heartbeat interval so a transient slow response doesn't
+    # evict a live worker. Default callers pass 90 (assumes 30s
+    # heartbeats).
+    def self.prune_stale_workers(ttl_seconds)
+      if Tep::APP.presence_pg_enabled == 0
+        return 0
+      end
+      cutoff = Time.now.to_i - ttl_seconds
+      conn = Tep::APP.presence_pg_conn
+      # Drop dead heartbeats first; the second DELETE then walks
+      # the worker_id space that's still alive.
+      r1 = conn.exec_params(
+        "DELETE FROM tep_presence_worker WHERE last_seen_ts < $1",
+        [cutoff.to_s])
+      r1.clear
+      # Now drop presence rows whose worker_id isn't in the live
+      # heartbeat table. NOT IN handles both crashed-and-pruned
+      # workers and workers that never registered (legacy rows
+      # from before this prune feature shipped).
+      r2 = conn.exec(
+        "DELETE FROM tep_presence " +
+        "WHERE worker_id NOT IN (SELECT worker_id FROM tep_presence_worker)")
+      n = r2.cmd_tuples
+      r2.clear
+      n
     end
 
     # Mirror a track to PG. Called from track() when the PG

--- a/test/test_presence_pg.rb
+++ b/test/test_presence_pg.rb
@@ -122,6 +122,51 @@ class TestPresencePg < TepTest
       ""
     end
 
+    # Heartbeat + prune-stale-workers helpers (chunk per #47).
+    get '/heartbeat' do
+      Tep::Presence.heartbeat.to_s
+    end
+
+    get '/prune_stale_workers' do
+      ttl = params[:ttl].to_i
+      Tep::Presence.prune_stale_workers(ttl).to_s
+    end
+
+    # Inject a heartbeat row at an arbitrary past timestamp so
+    # the prune test can simulate a stale-then-pruned worker.
+    get '/inject_worker_heartbeat' do
+      worker = params[:worker]
+      ts     = params[:ts].to_i
+      c = Tep::APP.presence_pg_conn
+      r = c.exec_params(
+        "INSERT INTO tep_presence_worker (worker_id, last_seen_ts) " +
+        "VALUES ($1, $2) " +
+        "ON CONFLICT (worker_id) DO UPDATE SET last_seen_ts = EXCLUDED.last_seen_ts",
+        [worker, ts.to_s])
+      ok = r.ok? ? "1" : "0"
+      r.clear
+      ok
+    end
+
+    get '/worker_count' do
+      c = Tep::APP.presence_pg_conn
+      r = c.exec("SELECT count(*) FROM tep_presence_worker")
+      n = "0"
+      if r.ok? && r.ntuples > 0
+        n = r.values[0][0]
+      end
+      r.clear
+      n
+    end
+
+    get '/reset_worker_table' do
+      c = Tep::APP.presence_pg_conn
+      r = c.exec("DELETE FROM tep_presence_worker")
+      n = r.cmd_tuples
+      r.clear
+      n.to_s
+    end
+
     # Simulate a row written by ANOTHER worker (different worker_id)
     # so list_global has cross-worker data to aggregate.
     get '/inject_other_worker_row' do
@@ -191,5 +236,54 @@ class TestPresencePg < TepTest
     get("/inject_other_worker_row?topic=room:other&principal=user:100&fd=6&worker=worker-B")
     assert_equal "1", get("/count_global?topic=room:lobby").body
     assert_equal "1", get("/count_global?topic=room:other").body
+  end
+
+  # ---- heartbeat + prune_stale_workers (#47) ----
+
+  def test_enable_pg_mirror_registers_heartbeat
+    # enable_pg_mirror already ran in on_start; its heartbeat
+    # row should be present.
+    n = get("/worker_count").body.to_i
+    assert n >= 1, "expected at least one heartbeat row, got #{n}"
+  end
+
+  def test_heartbeat_is_idempotent
+    # Calling heartbeat multiple times shouldn't multiply rows;
+    # the upsert keeps it at one per worker_id.
+    n_before = get("/worker_count").body.to_i
+    3.times { get("/heartbeat") }
+    n_after = get("/worker_count").body.to_i
+    assert_equal n_before, n_after
+  end
+
+  def test_prune_drops_stale_worker_and_its_presence_rows
+    get("/reset_worker_table")
+    # Inject one fresh + one stale worker, each with their own
+    # presence row.
+    fresh_ts = Time.now.to_i
+    stale_ts = fresh_ts - 3600
+    get("/inject_worker_heartbeat?worker=worker-fresh&ts=#{fresh_ts}")
+    get("/inject_worker_heartbeat?worker=worker-stale&ts=#{stale_ts}")
+    get("/inject_other_worker_row?topic=room:prune&principal=user:1&fd=1&worker=worker-fresh")
+    get("/inject_other_worker_row?topic=room:prune&principal=user:2&fd=2&worker=worker-stale")
+    assert_equal "2", get("/count_global?topic=room:prune").body
+
+    # Prune with a 60s TTL: stale (3600s old) gets dropped; fresh
+    # (just now) stays. count_global drops to 1.
+    pruned = get("/prune_stale_workers?ttl=60").body.to_i
+    assert pruned >= 1, "expected at least one tep_presence row deleted, got #{pruned}"
+    assert_equal "1", get("/count_global?topic=room:prune").body
+  end
+
+  def test_prune_preserves_live_worker_rows
+    get("/reset_worker_table")
+    # Single fresh worker -- prune should leave it alone.
+    fresh_ts = Time.now.to_i
+    get("/inject_worker_heartbeat?worker=worker-live&ts=#{fresh_ts}")
+    get("/inject_other_worker_row?topic=room:keep&principal=user:9&fd=99&worker=worker-live")
+    assert_equal "1", get("/count_global?topic=room:keep").body
+    pruned = get("/prune_stale_workers?ttl=60").body.to_i
+    assert_equal 0, pruned, "expected no rows deleted for live worker, got #{pruned}"
+    assert_equal "1", get("/count_global?topic=room:keep").body
   end
 end


### PR DESCRIPTION
Closes #47.

Crashed-worker rows in \`tep_presence\` used to linger indefinitely: \`disable_pg_mirror\` cleaned its own rows on graceful shutdown, but a crash skipped that path and the dead worker_id's rows stayed in the table forever, polluting \`list_global\` snapshots.

## Shape

Standard presence-with-heartbeat pattern. Apps that don't enable the mirror are unaffected; apps that enable it but don't call \`heartbeat\` / \`prune_stale_workers\` see no behavior change.

| Method | Effect |
|---|---|
| \`enable_pg_mirror\` | Now creates \`tep_presence_worker\` (worker_id, last_seen_ts) alongside \`tep_presence\`, and registers this worker's heartbeat row at boot. |
| \`Tep::Presence.heartbeat\` | Upserts \`last_seen_ts = NOW\` for this worker_id. Apps call from wherever's convenient (before-filter, \`Tep::Job\` tick). |
| \`Tep::Presence.prune_stale_workers(ttl_seconds)\` | Drops heartbeat rows older than ttl + presence rows whose worker_id no longer has a live heartbeat. Returns count of presence rows deleted. |
| \`disable_pg_mirror\` | Also drops this worker's heartbeat row on graceful shutdown. |

The \"needs a background-fiber model\" framing in the issue body was overthinking it — the responsibility-borrowing shape (apps call the methods from wherever's convenient, tep doesn't own the scheduler) matches how the MCP events.jsonl emitter works and is right for the same reasons.

## Test plan

- [x] 4 new tests in \`test/test_presence_pg.rb\` (mirror registers heartbeat, heartbeat idempotent, prune drops stale + their orphans, prune leaves live alone).
- [x] 10/10 green with \`PG_TEST_URL\` set against the docker-compose pg sidecar.
- [x] New tests skip cleanly when \`PG_TEST_URL\` is unset (same gate as existing presence_pg tests).
- [x] Full \`make test\`: **396/0/52** with the recurring TestServerScheduled flake (#52 shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)