### PR TITLE
feat(proxy): Tep::Proxy base — non-streaming reverse proxy (chunk 6.1)

### DIFF
--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -6,7 +6,10 @@ gateways, observability layers, key-swap proxies, multi-upstream
 routing, mirror-to-staging, fan-out, LLM proxies. Whatever sits
 between a client and a real upstream HTTP server.
 
-> Status: **design draft, no code yet**. Sister doc:
+> Status: **chunk 6.1 shipped** (`lib/tep/proxy.rb` — non-streaming
+> forward + `before_forward` / `after_forward` hooks via subclass-
+> override; see "Filter shape" note below). Streaming (6.2) and the
+> block-form DSL are still draft. Sister doc:
 > [`OPENAI-SERVER-BATTERY.md`](OPENAI-SERVER-BATTERY.md) covers
 > the *origin-server* case (no upstream — tep is the source of
 > truth). The two batteries are independent; an OpenAI gateway
@@ -57,7 +60,39 @@ Tep.get  "/v1/models",           api
 
 ## Filter shape
 
-Four filter chains, each runs in declaration order:
+> **Shipped form (chunk 6.1): subclass + override.** The block DSL
+> below (`api.before do … end`) is the *target* API, but it needs a
+> bin/tep translator pass that doesn't exist yet (#88) — a
+> receiver-method call with a block can't lower to spinel without it
+> (`PtrArray<Block>` isn't representable). So 6.1 ships the lowering
+> target directly: subclass `Tep::Proxy` and override the hooks. The
+> imeths are named `before_forward` / `after_forward` (not bare
+> `before` / `after`) to avoid colliding with the 2-arg `before` /
+> `after` on `Tep::Filter` / `Security` / `Auth` under spinel's
+> same-name virtual dispatch. Same staging `Tep::LiveView` used
+> before its `Tep.live` auto-wire helper.
+>
+> ```ruby
+> class OpenAIProxy < Tep::Proxy
+>   def rewrite_path(path)
+>     path                      # forward verbatim (default)
+>   end
+>   def before_forward(req, res, ureq)
+>     ureq.set_header("Authorization", "Bearer " + ENV["OPENAI_KEY"])
+>     false                     # return true to short-circuit
+>   end
+>   def after_forward(req, ures, res)
+>     Tep::Logger.info("upstream " + ures.status.to_s)
+>     0
+>   end
+> end
+>
+> api = OpenAIProxy.new("http://api.internal:8080")
+> Tep.post "/v1/chat/completions", api
+> Tep.get  "/v1/models",           api
+> ```
+
+Four filter chains (block-DSL target form), each runs in declaration order:
 
 ```ruby
 # before(req, res, upstream_req) — runs after request body is
@@ -281,7 +316,7 @@ discovery on top of a proxy, they declare it explicitly
 
 | Chunk | Scope |
 |---|---|
-| **6.1** | `Tep::Proxy.new(upstream:)` base; `before` + `after` filter chains; non-streaming bodies; mount as `Tep::Handler` at any verb/path. |
+| **6.1** ✅ | `Tep::Proxy.new(upstream)` base; `before_forward` + `after_forward` overridable hooks; non-streaming bodies; hop-by-hop header stripping; connect-failure → 502; mount as `Tep::Handler` at any verb/path. Block-form DSL deferred to #88. |
 | **6.2** | Streaming proxy — chunked transfer encoding pass-through, SSE-aware `on_stream_chunk` for `text/event-stream` upstreams, **`on_stream_end` finalizer hook** for one-shot end-of-stream telemetry. |
 | **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + per-request `inference` event emission via `on_stream_end`). |
 | **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -61,6 +61,7 @@ require_relative "tep/assets"
 require_relative "tep/scheduler"
 require_relative "tep/shell"
 require_relative "tep/http"
+require_relative "tep/proxy"
 require_relative "tep/llm"
 require_relative "tep/websocket"
 require_relative "tep/parallel"
@@ -538,6 +539,23 @@ module Tep
   # parse_response and index_from are internal; let spinel infer
   # their types from the send_req call site rather than seeding
   # separately (which widens `out` to poly).
+
+  # Tep::Proxy seed -- a base-class Proxy instance pins the handler
+  # slot + every overridable hook signature so subclass call sites
+  # in user code resolve cleanly (same idiom as set_before(Filter.new)
+  # and the Parallel/Job seeds). handle() exercises the full forward
+  # path against a dead port (status 0 -> 502), which fails fast like
+  # the Tep::Http seed above.
+  _tep_seed_proxy     = Tep::Proxy.new("http://127.0.0.1:1")
+  _tep_seed_proxy_req = Tep::Request.new
+  _tep_seed_proxy_res = Response.new
+  _tep_seed_proxy_ureq = Tep::Proxy::UpstreamRequest.new
+  _tep_seed_proxy_ureq.set_header("k", "v")
+  _tep_seed_proxy.rewrite_path("/")
+  _tep_seed_proxy.before_forward(_tep_seed_proxy_req, _tep_seed_proxy_res, _tep_seed_proxy_ureq)
+  _tep_seed_proxy.after_forward(_tep_seed_proxy_req, Tep::Http::Response.new, _tep_seed_proxy_res)
+  _tep_seed_proxy.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
+  Tep::Proxy.hop_by_hop?("connection")
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -1,0 +1,179 @@
+# Tep::Proxy -- HTTP reverse proxy battery (chunk 6.1).
+#
+# A Tep::Handler subclass that forwards a request to an upstream
+# HTTP server, runs user hooks in both directions, and copies the
+# response back to the client. Mount it at any route like a normal
+# handler; one instance can serve many paths:
+#
+#   class OpenAIProxy < Tep::Proxy
+#     def before_forward(req, res, ureq)
+#       ureq.set_header("Authorization", "Bearer " + ENV["OPENAI_KEY"])
+#       false   # forward (return true to short-circuit)
+#     end
+#
+#     def after_forward(req, ures, res)
+#       Tep::Logger.info("upstream " + ures.status.to_s)
+#       0
+#     end
+#   end
+#
+#   api = OpenAIProxy.new("http://api.internal:8080")
+#   Tep.post "/v1/chat/completions", api
+#   Tep.get  "/v1/models",           api
+#
+# Why subclass-and-override instead of the `api.before do ... end`
+# block DSL in docs/PROXY-BATTERY.md: that block form needs the
+# bin/tep translator to recognise `<proxyvar>.before do ... end`
+# (a receiver-method call with a block) and lower it into instance
+# methods on a generated subclass -- spinel can't store a
+# PtrArray<Block> on the instance. Until that translator chunk
+# lands, overriding `before_forward` / `after_forward` on a
+# subclass IS the lowering target, just hand-authored. This mirrors
+# how Tep::LiveView shipped its overridable hooks before the
+# `Tep.live` auto-wire helper (see lib/tep/live_view.rb).
+#
+# The hook names are `before_forward` / `after_forward` rather than
+# bare `before` / `after` on purpose: Tep::Filter / Tep::Security /
+# Tep::Auth already define 2-arg `before(req, res)` / `after(req,
+# res)` imeths, and spinel's virtual-imeth dispatch unifies on the
+# method name -- a 3-arg `before` here would collide with those
+# (see [[spinel-widening-dispatch]]). Distinct names sidestep it.
+#
+# Scope (6.1): non-streaming bodies only. Streaming (chunked / SSE
+# pass-through) + the on_stream_chunk / on_stream_end hooks land in
+# chunk 6.2. Outbound is HTTP/1.0 via Tep::Http, so the upstream
+# must be reachable over plaintext http:// (https:// upstreams need
+# the TLS-capable outbound client deferred to a later chunk).
+module Tep
+  class Proxy < Tep::Handler
+    attr_accessor :upstream, :timeout
+
+    def initialize(upstream)
+      @upstream = upstream
+      @timeout  = 30
+    end
+
+    # ---- Overridable hooks (subclasses customise these) ----
+
+    # Map the inbound request's path+query to the upstream
+    # path+query. Default: forward verbatim. Override to strip a
+    # mount prefix, pin a fixed upstream path, etc.
+    def rewrite_path(path)
+      path
+    end
+
+    # Runs after the request body is fully received, before
+    # forwarding. `ureq` is a mutable Tep::Proxy::UpstreamRequest
+    # (verb / path / headers / body) pre-filled from the inbound
+    # request with hop-by-hop headers stripped. Mutate it to tweak
+    # what the upstream sees. Return `true` to short-circuit -- the
+    # upstream call is skipped and `res` (which you set) is sent to
+    # the client. Return `false` to forward. Default: forward.
+    def before_forward(req, res, ureq)
+      false
+    end
+
+    # Runs after the upstream responds, before `res` is written to
+    # the client. `ures` is the Tep::Http::Response from upstream
+    # (status 0 + empty body on connect failure; an empty Response
+    # when a before_forward short-circuited). `res` is mutable and
+    # already carries the upstream status / headers / body. Use this
+    # to transform the final response or emit logs/metrics. Runs on
+    # the short-circuit path too, so audit logging sees rejected
+    # requests. Default: no-op.
+    def after_forward(req, ures, res)
+      0
+    end
+
+    # ---- Tep::Handler interface ----
+
+    def handle(req, res)
+      ureq = Tep::Proxy::UpstreamRequest.new
+      ureq.verb = req.verb
+      ureq.path = rewrite_path(req.raw_path)
+      ureq.body = req.raw_body
+      # Copy inbound headers minus: hop-by-hop (RFC 7230), `host`
+      # (Tep::Http derives Host from the upstream URL -- forwarding
+      # the client's Host would emit a duplicate, which nginx-class
+      # upstreams 400), and `content-length` (Tep::Http computes its
+      # own from the body, same duplicate risk).
+      req.req_headers.each do |k, v|
+        lc = k.downcase
+        if !Tep::Proxy.hop_by_hop?(k) && lc != "host" && lc != "content-length"
+          ureq.headers[k] = v
+        end
+      end
+
+      short = before_forward(req, res, ureq)
+      if short
+        # Short-circuited: no upstream call. after_forward still
+        # runs (audit), with an empty upstream Response.
+        after_forward(req, Tep::Http::Response.new, res)
+        return res.body
+      end
+
+      url  = @upstream + ureq.path
+      ures = Tep::Http.send_req(ureq.verb, url, ureq.body, ureq.headers)
+
+      if ures.status > 0
+        res.set_status(ures.status)
+      else
+        # Connect / send failure, or non-http upstream scheme.
+        res.set_status(502)
+      end
+
+      # Copy upstream response headers, minus hop-by-hop AND
+      # content-length: the tep server writer computes its own
+      # Content-Length from res.body, so a copied one would
+      # duplicate the header.
+      ures.headers.each do |k, v|
+        if !Tep::Proxy.hop_by_hop?(k) && k.downcase != "content-length"
+          res.headers[k] = v
+        end
+      end
+
+      # Force the body assignment through a Response method (self is
+      # unambiguously Response there) -- a direct `res.body =` from
+      # this poly-dispatched handle() mis-codegens under spinel.
+      res.set_body(ures.body)
+
+      after_forward(req, ures, res)
+      res.body
+    end
+
+    # RFC 7230 §6.1 hop-by-hop headers: meaningful only for a single
+    # transport-level connection, never forwarded by a proxy. Lower-
+    # cased compare since both inbound and upstream header names are
+    # downcased by tep's parsers.
+    def self.hop_by_hop?(name)
+      lc = name.downcase
+      lc == "connection" ||
+        lc == "keep-alive" ||
+        lc == "transfer-encoding" ||
+        lc == "upgrade" ||
+        lc == "proxy-authorization" ||
+        lc == "proxy-authenticate" ||
+        lc == "te" ||
+        lc == "trailer"
+    end
+
+    # Mutable descriptor of the outbound request, handed to
+    # before_forward so hooks can rewrite verb / path / headers /
+    # body before the upstream call. `set_header` mirrors
+    # Tep::Http#set_header for muscle-memory parity.
+    class UpstreamRequest
+      attr_accessor :verb, :path, :headers, :body
+
+      def initialize
+        @verb    = "GET"
+        @path    = "/"
+        @headers = Tep.str_hash
+        @body    = ""
+      end
+
+      def set_header(k, v)
+        @headers[k] = v
+      end
+    end
+  end
+end

--- a/lib/tep/response.rb
+++ b/lib/tep/response.rb
@@ -77,6 +77,15 @@ module Tep
       end
     end
 
+    # Unconditional body setter. Same poly-write rationale as
+    # set_body_if_empty (self is unambiguously Response here, so the
+    # `@body = s` codegens correctly), but always assigns -- used by
+    # Tep::Proxy, which writes the upstream body whether or not it's
+    # empty (a 204 / empty upstream body must overwrite, not skip).
+    def set_body(s)
+      @body = s
+    end
+
     def set_status(n); @status = n; end
 
     def halted_close?

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -1,0 +1,204 @@
+require_relative "helper"
+
+# Tep::Proxy -- HTTP reverse-proxy battery (chunk 6.1, non-streaming).
+#
+# Same self-calling shape as test_http.rb: the app boots both the
+# "upstream" endpoints (/ping, /echo_body, /headers_back, /teapot)
+# and proxy routes that forward to 127.0.0.1:<own-port>. The proxy
+# instance's upstream is fixed at construction, so each proxy route
+# builds its Tep::Proxy subclass inside the handler with the runtime
+# port from a path capture (the harness can't tell a load-time
+# constructor its own port).
+#
+# Runs under Tep::Server::Scheduled with workers=1 -- the only shape
+# where a handler can make an outbound call back to its own server
+# under cooperative I/O (see docs/MACOS-CONCURRENCY.md, test_http.rb).
+class TestProxy < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # ---- upstream endpoints (what the proxies forward to) ----
+
+    get '/ping' do
+      "pong"
+    end
+
+    post '/echo_body' do
+      res.headers["Content-Type"] = "text/plain"
+      req.raw_body
+    end
+
+    get '/headers_back' do
+      "x-custom=" + req.req_headers["x-custom"]
+    end
+
+    get '/teapot' do
+      res.set_status(418)
+      "i'm a teapot"
+    end
+
+    get '/sets_header' do
+      res.headers["X-Upstream"] = "from-upstream"
+      "ok"
+    end
+
+    # ---- proxy subclasses (the overridable-hook lowering target) ----
+
+    # Forward to a fixed upstream path regardless of inbound path.
+    class PingProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/ping"
+      end
+    end
+
+    class TeapotProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/teapot"
+      end
+    end
+
+    class HeaderBackProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/headers_back"
+      end
+    end
+
+    class SetsHeaderProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/sets_header"
+      end
+    end
+
+    # Inject a header into the upstream request.
+    class InjectProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/headers_back"
+      end
+      def before_forward(req, res, ureq)
+        ureq.set_header("X-Custom", "injected-by-proxy")
+        false
+      end
+    end
+
+    # Short-circuit: never reach upstream.
+    class GuardProxy < Tep::Proxy
+      def before_forward(req, res, ureq)
+        res.set_status(403)
+        res.set_body("denied by proxy")
+        true
+      end
+    end
+
+    # Stamp the response on the way back out.
+    class StampProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/ping"
+      end
+      def after_forward(req, ures, res)
+        res.headers["X-Proxied"] = "yes"
+        0
+      end
+    end
+
+    # Pass the request body straight through to /echo_body.
+    class EchoProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/echo_body"
+      end
+    end
+
+    # ---- proxy mount routes (build with runtime port) ----
+
+    get '/p/ping/:port' do
+      PingProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/teapot/:port' do
+      TeapotProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/inject/:port' do
+      InjectProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/guard/:port' do
+      GuardProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/stamp/:port' do
+      StampProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/upstreamhdr/:port' do
+      SetsHeaderProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    post '/p/echo/:port' do
+      EchoProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    # Dead upstream port -> connect failure -> 502.
+    get '/p/deadport' do
+      PingProxy.new("http://127.0.0.1:1").handle(req, res)
+      res.body
+    end
+  RB
+
+  def test_forwards_get_and_returns_upstream_body
+    res = get("/p/ping/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "pong", res.body
+  end
+
+  def test_propagates_upstream_status
+    res = get("/p/teapot/#{@port}")
+    assert_equal "418", res.code
+    assert_equal "i'm a teapot", res.body
+  end
+
+  def test_before_forward_can_inject_upstream_header
+    res = get("/p/inject/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "x-custom=injected-by-proxy", res.body
+  end
+
+  def test_before_forward_short_circuits
+    res = get("/p/guard/#{@port}")
+    assert_equal "403", res.code
+    assert_equal "denied by proxy", res.body
+  end
+
+  def test_after_forward_can_stamp_response
+    res = get("/p/stamp/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "pong", res.body
+    assert_equal "yes", res["X-Proxied"]
+  end
+
+  def test_propagates_upstream_response_headers
+    res = get("/p/upstreamhdr/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "from-upstream", res["X-Upstream"]
+  end
+
+  def test_forwards_post_body
+    res = post("/p/echo/#{@port}", "round trip body")
+    assert_equal "200", res.code
+    assert_equal "round trip body", res.body
+  end
+
+  def test_connect_failure_maps_to_502
+    res = get("/p/deadport")
+    assert_equal "502", res.code
+  end
+end


### PR DESCRIPTION
## Summary

First chunk of the **proxy battery** ([`docs/PROXY-BATTERY.md`](docs/PROXY-BATTERY.md)). `Tep::Proxy < Tep::Handler` forwards a request to an upstream HTTP server via `Tep::Http`, runs user hooks both directions, and copies the response back. Mount at any `Tep.<verb> "/path", proxy_instance`; one instance serves many routes.

```ruby
class OpenAIProxy < Tep::Proxy
  def before_forward(req, res, ureq)
    ureq.set_header("Authorization", "Bearer " + ENV["OPENAI_KEY"])
    false                       # return true to short-circuit
  end
  def after_forward(req, ures, res)
    Tep::Logger.info("upstream " + ures.status.to_s)
    0
  end
end
Tep.post "/v1/chat/completions", OpenAIProxy.new("http://api.internal:8080")
```

## Design decisions

- **Subclass-override, not the block DSL.** The doc shows `api.before do…end`, but bin/tep only treats *bare top-level calls* as DSL — a receiver-method call with a block passes through verbatim and can't lower to spinel (`PtrArray<Block>` isn't representable). 6.1 ships the lowering target directly (override `rewrite_path` / `before_forward` / `after_forward`), exactly as `Tep::LiveView` shipped overridable hooks before its `Tep.live` auto-wire helper. Block-DSL translator pass tracked as #88.
- **Hook names `before_forward` / `after_forward`** (not bare `before`/`after`) to avoid spinel same-name virtual-dispatch collisions with the 2-arg `before(req,res)`/`after(req,res)` on `Tep::Filter`/`Security`/`Auth`.
- **Header hygiene:** strips RFC 7230 hop-by-hop both directions; strips inbound `Host` + `Content-Length` (`Tep::Http` derives its own from the upstream URL/body — forwarding the client's emits duplicates that nginx-class upstreams 400) and the upstream `Content-Length` on the way back (the tep server writer computes its own from `res.body`).
- **Connect/send failure or non-http upstream → 502.**

## Changes

- `lib/tep/proxy.rb` — new battery.
- `lib/tep/response.rb` — `set_body` (unconditional, poly-write-safe sibling of `set_body_if_empty`).
- `lib/tep.rb` — require + spinel type seeds.
- `test/test_proxy.rb` — 8 tests (self-calling scheduled-server shape like `test_http.rb`).
- `docs/PROXY-BATTERY.md` — status + "shipped form" note + chunk table.

## Test plan

- [x] `test/test_proxy.rb` — 8/8 green (forward GET/POST, status + header + body propagation, before_forward inject + short-circuit, after_forward stamp, connect-failure→502).
- [x] Full `make test` — 404 runs, 0 failures, 0 errors (52 skips), against fresh spinel master.

> Note on the duplicate-header fix: can't be regression-tested with tep-as-upstream (tep's parser collapses duplicate headers last-wins); it's verified by code review + matters for strict upstreams (nginx). Real-upstream coverage arrives with `examples/llm_gateway` in chunk 6.3.

## Scope deferred

Streaming (chunked/SSE) + `on_stream_chunk`/`on_stream_end` (#81), block-form DSL (#88), https:// upstreams.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)