### PR TITLE
fix(server): drive res.streaming under Tep::Server::Scheduled (#90)

### DIFF
--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -146,7 +146,11 @@ module Tep
           res = Response.new
           Tep::APP.dispatch(req, res)
 
-          keep_alive = req.keep_alive? && !res.halted_close?
+          # Streaming responses use chunked Connection: close (same
+          # simplification as the prefork server) -- force the
+          # keep-alive loop to end after this response so the stream's
+          # terminator isn't followed by a stale read on the same fd.
+          keep_alive = req.keep_alive? && !res.halted_close? && !res.streaming
           Tep::Server::Scheduled.write_response(client, req, res, keep_alive)
           keep_going = keep_alive
         end
@@ -200,6 +204,38 @@ module Tep
           conn.run
           return 0
         end
+
+        # Streaming branch -- cooperative mirror of Tep::Server's
+        # streaming path (server.rb). Set by res.start_stream(streamer)
+        # in the handler. Writes a chunked-encoding head immediately,
+        # hands a Tep::Stream writer to the user's Streamer#pump, then
+        # emits the end-of-stream terminator. pump runs cooperatively:
+        # it parks on Tep::Scheduler.io_wait between writes (e.g. the
+        # proxy streamer waits on the upstream fd), so other fibers keep
+        # running while this stream is in flight. Connection: close --
+        # chunked keep-alive is legal but we keep it simple, matching
+        # the prefork server.
+        if res.streaming
+          res.headers["Transfer-Encoding"] = "chunked"
+          if !res.headers.key?("Content-Type")
+            res.headers["Content-Type"] = "text/event-stream"
+          end
+          reason = Tep.reason(res.status)
+          head = req.http_version + " " + res.status.to_s + " " + reason + "\r\n"
+          res.headers.each do |k, v|
+            head = head + k + ": " + v + "\r\n"
+          end
+          res.set_cookies.each do |line|
+            head = head + "Set-Cookie: " + line + "\r\n"
+          end
+          head = head + "Connection: close\r\n\r\n"
+          Sock.sphttp_write_str(client, head)
+          out = Tep::Stream.new(client)
+          res.streamer.pump(out)
+          Sock.sphttp_write_chunk_end(client)
+          return 0
+        end
+
         # Default Content-Type for inline-body responses. Matches
         # Tep::Server#send; without it, the Security::Headers nosniff
         # default leaves the browser refusing to interpret an erb

--- a/test/test_streaming.rb
+++ b/test/test_streaming.rb
@@ -46,3 +46,51 @@ class TestStreaming < TepTest
     assert_equal "regular response", res.body
   end
 end
+
+# Same streaming surface under Tep::Server::Scheduled. Regression
+# guard for #90: the scheduled server's write_response had no
+# res.streaming branch, so streamed responses came back with
+# Content-Length: 0 and an empty body (the Streamer never pumped).
+class TestStreamingScheduled < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    class Ticks < Tep::Streamer
+      def pump(out)
+        out.write("data: 1\\n\\n")
+        out.write("data: 2\\n\\n")
+        out.write("data: 3\\n\\n")
+      end
+    end
+
+    get '/stream' do
+      stream Ticks.new
+    end
+
+    get '/normal' do
+      "regular response"
+    end
+  RB
+
+  def test_scheduled_stream_uses_chunked_encoding
+    res = get("/stream")
+    assert_equal "200", res.code
+    assert_equal "chunked", res["transfer-encoding"]
+    assert_nil res["content-length"]
+  end
+
+  def test_scheduled_stream_emits_all_chunks
+    res = get("/stream")
+    assert_equal "data: 1\n\ndata: 2\n\ndata: 3\n\n", res.body
+  end
+
+  def test_scheduled_normal_route_still_buffered
+    res = get("/normal")
+    assert_equal "200", res.code
+    assert_nil res["transfer-encoding"]
+    assert_equal "regular response", res.body
+  end
+end


### PR DESCRIPTION
## Summary

`Tep::Server::Scheduled#write_response` had no `res.streaming` branch — only `upgrading_ws`, `file_path`, and inline body. A `stream X` / `res.start_stream(streamer)` response under `set :scheduler, :scheduled` fell through to the buffered body path; the streamer was never pumped, so the client got `200` + `Content-Length: 0` + empty body.

**This silently broke `examples/chatbot`'s OpenAI-compat SSE endpoint** (`/api/v1/chat/completions` with `stream:true` — the chatbot runs under the scheduled server and uses `stream s`).

### Proof (before)

```
$ curl -i /stream      # under set :scheduler, :scheduled
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 0      # streamer never ran
```

## Fix

Adds the streaming branch — a cooperative mirror of the prefork `Tep::Server` path: chunked head → `res.streamer.pump(Tep::Stream.new(client))` → `sphttp_write_chunk_end`. `pump` is already cooperative (it parks on `Tep::Scheduler.io_wait` between writes). Forces `Connection: close` for streamed connections (chunked keep-alive is legal but we keep it simple, matching prefork) by excluding `res.streaming` from the keep-alive computation.

## Test plan

- [x] `test/test_streaming.rb` gains `TestStreamingScheduled` (3 tests) — chunked encoding, all-chunks-emitted, normal-route-still-buffered, under the scheduled server. Mirrors the existing prefork `TestStreaming`.
- [x] Full `make test` — 407 runs, 0 failures, 0 errors (52 skips).

## Why now

Hard prerequisite for proxy streaming (chunk 6.2 / #81): the proxy can't stream to the client until the scheduled server can drive a `Streamer`.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)