### PR TITLE
feat(proxy): streaming core + on_stream_chunk/on_stream_end (#81)

### DIFF
--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -6,7 +6,17 @@ gateways, observability layers, key-swap proxies, multi-upstream
 routing, mirror-to-staging, fan-out, LLM proxies. Whatever sits
 between a client and a real upstream HTTP server.
 
-> Status: **chunk 6.1 shipped** (`lib/tep/proxy.rb` — non-streaming
+> Status: **chunks 6.1 + 6.2 shipped** (`lib/tep/proxy.rb`). 6.1:
+> non-streaming forward + `before_forward` / `after_forward`. 6.2:
+> streaming forward (chunked + SSE) via `stream_request?` opt-in,
+> `on_stream_chunk(chunk, out, stats)` (chunk is a `StreamChunk` —
+> read `chunk.chunk_text`), `on_stream_end(req, out, stats)`, carried
+> `StreamStats` (byte_count / chunk_count / errored / meta_bag).
+> Streaming requires the scheduled server. The block-form DSL (#88)
+> and https:// upstreams are still draft. (Older one-shot note below.)
+>
+> Old status line follows for context:
+> **chunk 6.1 shipped** (`lib/tep/proxy.rb` — non-streaming
 > forward + `before_forward` / `after_forward` hooks via subclass-
 > override; see "Filter shape" note below). Streaming (6.2) and the
 > block-form DSL are still draft. Sister doc:
@@ -155,6 +165,50 @@ each `on_stream_chunk` invocation receives as a fourth optional
 argument (`|chunk, out, _, stats|`). Filters that accumulate
 across chunks (token counting, byte counting, parsing for an
 end-of-stream `[DONE]` marker) write to it.
+
+> **Shipped form (chunk 6.2): subclass + override + opt-in.** As with
+> 6.1, the block DSL above is the target API; the shipped form is
+> subclass-override, and streaming is opt-in per request:
+>
+> ```ruby
+> class LlmGateway < Tep::Proxy
+>   # Opt this request into streaming (default: false -> buffered
+>   # before_forward/after_forward path). Request-side, not response
+>   # sniffing -- the client signals intent ("stream": true), and the
+>   # buffered path stays on the unchanged Tep::Http.send_req.
+>   def stream_request?(req)
+>     Tep::Json.get_bool(req.raw_body, "stream")
+>   end
+>
+>   # One call per dechunked HTTP chunk / per SSE event record.
+>   # `chunk` is a Tep::Proxy::StreamChunk -- read the bytes via
+>   # chunk.chunk_text (an object, not a bare String, so String
+>   # methods work in the override despite spinel's poly-boxing of
+>   # virtual-hook params). `out` writes to the client.
+>   def on_stream_chunk(chunk, out, stats)
+>     out.write(chunk.chunk_text)        # transform / drop / fan out
+>     0
+>   end
+>
+>   # Fires exactly once at end-of-stream (clean EOF or error --
+>   # stats.errored distinguishes). `stats` is a Tep::Proxy::StreamStats:
+>   # framework-maintained byte_count / chunk_count, plus meta_bag (a
+>   # String=>String bag) for your own counters. This is the seam for
+>   # one per-request telemetry event.
+>   def on_stream_end(req, out, stats)
+>     EVENTS.write(chunks: stats.chunk_count, bytes: stats.byte_count)
+>     0
+>   end
+> end
+> ```
+>
+> Notes vs the block sketch: `after_forward` does NOT run for streamed
+> responses (`on_stream_end` is its streaming counterpart); `stats` is
+> a typed `StreamStats` object, not a `stats[:sym]` hash (spinel hashes
+> are single-value-typed); and streaming requires the scheduled server
+> (the pump parks on `io_wait`). Field/param names are collision-free
+> on purpose (`chunk_text` not `text`, `byte_count`/`chunk_count`/
+> `meta_bag` not `bytes`/`chunks`/`data`) — see lib/tep/proxy.rb for why.
 
 ### SSE caveat
 
@@ -317,7 +371,7 @@ discovery on top of a proxy, they declare it explicitly
 | Chunk | Scope |
 |---|---|
 | **6.1** ✅ | `Tep::Proxy.new(upstream)` base; `before_forward` + `after_forward` overridable hooks; non-streaming bodies; hop-by-hop header stripping; connect-failure → 502; mount as `Tep::Handler` at any verb/path. Block-form DSL deferred to #88. |
-| **6.2** | Streaming proxy — chunked transfer encoding pass-through, SSE-aware `on_stream_chunk` for `text/event-stream` upstreams, **`on_stream_end` finalizer hook** for one-shot end-of-stream telemetry. |
+| **6.2** ✅ | Streaming proxy — `stream_request?` opt-in, chunked + SSE-aware `on_stream_chunk(chunk, out, stats)` (chunk = `StreamChunk`, read `chunk.chunk_text`), **`on_stream_end(req, out, stats)` finalizer** + carried `StreamStats`. Requires the scheduled server. Block-form DSL deferred to #88. |
 | **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + per-request `inference` event emission via `on_stream_end`). |
 | **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |
 

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -556,6 +556,25 @@ module Tep
   _tep_seed_proxy.after_forward(_tep_seed_proxy_req, Tep::Http::Response.new, _tep_seed_proxy_res)
   _tep_seed_proxy.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
   Tep::Proxy.hop_by_hop?("connection")
+  # Streaming surface (chunk 6.2). Pin the hook signatures + the
+  # UpstreamHead parser + the proxy's non-IO pump helpers. run_stream,
+  # pump and read_upstream_head are NOT called here -- they do blocking
+  # io_wait on a real fd; their param/return types self-pin from their
+  # bodies, and ProxyStreamer flows into res.start_stream from
+  # start_streaming_forward (statically reachable from handle), which
+  # wires ProxyStreamer.pump (-> run_stream) into the Streamer dispatch.
+  _tep_seed_proxy.stream_request?(_tep_seed_proxy_req)
+  _tep_seed_pstats = Tep::Proxy::StreamStats.new
+  _tep_seed_pchunk = Tep::Proxy::StreamChunk.new("data: x\n\n")
+  _tep_seed_proxy.on_stream_chunk(_tep_seed_pchunk, _tep_seed_stream, _tep_seed_pstats)
+  _tep_seed_proxy.on_stream_end(_tep_seed_proxy_req, _tep_seed_stream, _tep_seed_pstats)
+  _tep_seed_proxy.drain_events(_tep_seed_stream, _tep_seed_pstats, "data: x\n\n")
+  _tep_seed_proxy.dispatch_one(_tep_seed_stream, _tep_seed_pstats, "data: x\n\n")
+  _tep_seed_uhead = Tep::Proxy::UpstreamHead.new
+  _tep_seed_uhead.fill_from("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked")
+  _tep_seed_pstreamer = Tep::Proxy::ProxyStreamer.new
+  _tep_seed_pstreamer.proxy = _tep_seed_proxy
+  _tep_seed_proxy_res.start_stream(_tep_seed_pstreamer)
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -85,6 +85,61 @@ module Tep
       0
     end
 
+    # Streaming opt-in predicate. Return true to forward this request
+    # over a held-open connection and pump the upstream response
+    # through on_stream_chunk / on_stream_end (chunk 6.2) instead of
+    # the buffered before/after path. Default: false (buffered).
+    #
+    # tep uses a request-side opt-in rather than sniffing the upstream
+    # response Content-Type because (a) it keeps the non-streaming path
+    # on the unchanged buffered Tep::Http.send_req (no manual-connect
+    # tax on the common case), and (b) it matches how streaming APIs
+    # actually signal intent -- an OpenAI client sets `"stream": true`
+    # in the request body, so the proxy knows before it connects.
+    # An LLM gateway typically overrides this as:
+    #
+    #   def stream_request?(req)
+    #     Tep::Json.get_bool(req.raw_body, "stream")
+    #   end
+    def stream_request?(req)
+      false
+    end
+
+    # Per-chunk streaming hook (chunk 6.2). Called once per upstream
+    # body chunk -- one dechunked HTTP chunk for a chunked upstream,
+    # or one complete SSE event record ("...\n\n", including the
+    # trailing blank line) for a text/event-stream upstream. `out` is
+    # the Tep::Stream writer to the client; `stats` is a
+    # Tep::Proxy::StreamStats carried across the whole stream (the
+    # framework maintains stats.byte_count / stats.chunk_count;
+    # accumulate your own counters in stats.meta_bag["key"]). Default:
+    # pass the chunk through unchanged. Drop it by not calling
+    # out.write; transform by writing modified bytes; fan out by
+    # writing more than once.
+    #
+    # `chunk` is a Tep::Proxy::StreamChunk, NOT a bare String: read
+    # the bytes via `chunk.chunk_text`. The wrapper exists because spinel
+    # boxes a primitive String arg to poly when it flows through the
+    # poly-receiver dispatch into this overridable hook -- a bare
+    # String param would arrive poly and block String methods
+    # (chunk.include? etc.). An object param survives the dispatch as
+    # a typed pointer (same reason Tep::WebSocket passes `evt` with an
+    # evt.data accessor). See [[spinel-widening-dispatch]].
+    def on_stream_chunk(chunk, out, stats)
+      out.write(chunk.chunk_text)
+      0
+    end
+
+    # End-of-stream finalizer (chunk 6.2, #81). Fires exactly once
+    # after the last chunk has been emitted and the upstream closed
+    # (cleanly or via error -- stats.errored distinguishes). `out` is
+    # still writable, so a finalizer can emit one last frame (e.g. a
+    # closing SSE event). `stats` is the same object on_stream_chunk
+    # accumulated into. Default: no-op.
+    def on_stream_end(req, out, stats)
+      0
+    end
+
     # ---- Tep::Handler interface ----
 
     def handle(req, res)
@@ -110,6 +165,18 @@ module Tep
         # runs (audit), with an empty upstream Response.
         after_forward(req, Tep::Http::Response.new, res)
         return res.body
+      end
+
+      # Streaming branch (chunk 6.2). When the handler opts the
+      # request into streaming, forward over a held-open connection
+      # and pump the upstream body through on_stream_chunk to the
+      # client, firing on_stream_end once at the end. Requires the
+      # scheduled server (cooperative io_wait), same constraint as
+      # WebSocket. after_forward is NOT run for streamed responses
+      # (it's the non-streaming analog; on_stream_end is its
+      # streaming counterpart).
+      if stream_request?(req)
+        return start_streaming_forward(req, res, ureq)
       end
 
       url  = @upstream + ureq.path
@@ -139,6 +206,219 @@ module Tep
 
       after_forward(req, ures, res)
       res.body
+    end
+
+    # Streaming forward (chunk 6.2). Connects to the upstream, writes
+    # the request, reads just the response head, then hands the still-
+    # open fd to a ProxyStreamer via res.start_stream -- the server
+    # later drives streamer.pump, which recv-loops the upstream body
+    # and dispatches it through on_stream_chunk / on_stream_end.
+    #
+    # Returns "" (the streamed body goes out via the streamer, not the
+    # buffered res.body). On connect/scheme/head-read failure, sets a
+    # 502 and returns "" without starting a stream.
+    def start_streaming_forward(req, res, ureq)
+      url   = @upstream + ureq.path
+      parts = Tep::Url.split_url(url)
+      if parts["scheme"] != "http"
+        res.set_status(502)
+        return ""
+      end
+      host = parts["host"]
+      port = parts["port"].to_i
+      path = parts["path"]
+      if parts["query"].length > 0
+        path = path + "?" + parts["query"]
+      end
+
+      fd = Sock.sphttp_connect(host, port)
+      if fd < 0
+        res.set_status(502)
+        return ""
+      end
+      Sock.sphttp_set_nonblock(fd)
+
+      head = ureq.verb + " " + path + " HTTP/1.1\r\n" +
+             "Host: " + host + "\r\n" +
+             "Connection: close\r\n"
+      ureq.headers.each do |k, v|
+        head = head + k + ": " + v + "\r\n"
+      end
+      if ureq.body.length > 0
+        head = head + "Content-Length: " + ureq.body.length.to_s + "\r\n"
+      end
+      head = head + "\r\n"
+      if Sock.sphttp_write_str(fd, head) < 0
+        Sock.sphttp_close(fd)
+        res.set_status(502)
+        return ""
+      end
+      if ureq.body.length > 0
+        if Sock.sphttp_write_str(fd, ureq.body) < 0
+          Sock.sphttp_close(fd)
+          res.set_status(502)
+          return ""
+        end
+      end
+
+      uh = Tep::Proxy.read_upstream_head(fd)
+      if !uh.ok
+        Sock.sphttp_close(fd)
+        res.set_status(502)
+        return ""
+      end
+
+      res.set_status(uh.status)
+      # Copy upstream headers minus hop-by-hop, content-length (the
+      # client side is chunked -- no fixed length), and transfer-
+      # encoding (the server writer re-applies chunked itself).
+      uh.headers.each do |k, v|
+        lc = k.downcase
+        if !Tep::Proxy.hop_by_hop?(k) && lc != "content-length"
+          res.headers[k] = v
+        end
+      end
+
+      streamer = Tep::Proxy::ProxyStreamer.new
+      streamer.proxy      = self
+      streamer.fd         = fd
+      streamer.leftover   = uh.leftover
+      streamer.is_chunked = uh.is_chunked
+      streamer.is_sse     = uh.is_sse
+      streamer.req        = req
+      res.start_stream(streamer)
+      ""
+    end
+
+    # The streaming pump, called from ProxyStreamer#pump as
+    # @proxy.run_stream(...). It lives here, on Tep::Proxy, rather
+    # than on the streamer so that on_stream_chunk / on_stream_end
+    # below are invoked as plain (implicit-self) calls. spinel
+    # resolves an implicit-self call inside a base-class method
+    # polymorphically -- it includes every subclass arm -- so a
+    # subclass's overrides are reached. A call through the streamer's
+    # @proxy slot (statically Tep::Proxy) would bind only the base
+    # hooks. Same reason rewrite_path / stream_request? (implicit-self
+    # from handle) dispatch to overrides but a slot call would not.
+    #
+    # Recv-loops the held-open upstream fd: dechunks (chunked
+    # upstream), splits SSE event records (text/event-stream), and
+    # dispatches each unit through dispatch_one. Fires on_stream_end
+    # once at EOF / timeout. Cooperative -- parks on io_wait between
+    # recvs, so requires Tep::Server::Scheduled.
+    def run_stream(out, fd, leftover, is_chunked, is_sse, req)
+      stats    = Tep::Proxy::StreamStats.new
+      buf      = leftover    # raw (possibly chunked) bytes
+      body_buf = ""          # dechunked bytes awaiting SSE split
+      done     = false
+      while !done
+        if is_chunked
+          consumed = Tep::Llm.dechunk_consume(buf)
+          buf      = Tep::Llm.dechunk_leftover(buf)
+          if consumed.length > 0
+            body_buf = body_buf + consumed
+          end
+        else
+          body_buf = body_buf + buf
+          buf      = ""
+        end
+
+        if is_sse
+          body_buf = drain_events(out, stats, body_buf)
+        else
+          if body_buf.length > 0
+            dispatch_one(out, stats, body_buf)
+            body_buf = ""
+          end
+        end
+
+        ready = Tep::Scheduler.io_wait(fd, Tep::Scheduler::READ, 60)
+        if ready == 0
+          stats.errored = true
+          done = true
+        else
+          more = Sock.sphttp_recv_some(fd, 4096)
+          if more.length == 0
+            done = true        # clean EOF
+          else
+            buf = buf + more
+          end
+        end
+      end
+
+      # Flush a trailing partial SSE event (some upstreams omit the
+      # final blank line before closing).
+      if is_sse && body_buf.length > 0
+        drain_events(out, stats, body_buf + "\n\n")
+      end
+
+      Sock.sphttp_close(fd)
+      on_stream_end(req, out, stats)
+      0
+    end
+
+    # Split body_buf into complete "\n\n"-terminated SSE event records
+    # and dispatch each (the record includes the trailing blank line,
+    # per the doc's "data: {...}\n\n" contract). Returns the
+    # unconsumed tail.
+    def drain_events(out, stats, body_buf)
+      while true
+        sep = Tep.str_find(body_buf, "\n\n", 0)
+        if sep < 0
+          return body_buf
+        end
+        relay_buf = body_buf[0, sep + 2]
+        body_buf  = body_buf[sep + 2, body_buf.length - sep - 2]
+        dispatch_one(out, stats, relay_buf)
+      end
+      body_buf
+    end
+
+    # Count one unit + dispatch it to on_stream_chunk via implicit
+    # self (polymorphic -- reaches subclass overrides). `relay_buf`
+    # is named distinctly from `chunk` / `frame`: spinel unifies
+    # param types by name file-wide, and both of those names carry
+    # foreign types (poly hook param / WS int-array) that would
+    # mis-type this String. See [[spinel-widening-dispatch]].
+    def dispatch_one(out, stats, relay_buf)
+      stats.byte_count  = stats.byte_count + relay_buf.length
+      stats.chunk_count = stats.chunk_count + 1
+      on_stream_chunk(Tep::Proxy::StreamChunk.new(relay_buf), out, stats)
+      0
+    end
+
+    # Read an upstream response head (status line + headers up to the
+    # blank line) cooperatively. Returns a Tep::Proxy::UpstreamHead
+    # carrying the parsed status, the per-name header bag, the
+    # chunked / SSE flags, the body bytes already read past the head
+    # (leftover -- handed to the streamer so no bytes are lost), and
+    # an ok flag (false on timeout / EOF before the head completed).
+    def self.read_upstream_head(fd)
+      out = Tep::Proxy::UpstreamHead.new
+      buf = ""
+      while true
+        ready = Tep::Scheduler.io_wait(fd, Tep::Scheduler::READ, 60)
+        if ready == 0
+          return out          # timeout -- ok stays false
+        end
+        chunk = Sock.sphttp_recv_some(fd, 4096)
+        if chunk.length == 0
+          return out          # EOF before head completed
+        end
+        buf = buf + chunk
+        eoh = Tep.str_find(buf, "\r\n\r\n", 0)
+        if eoh >= 0
+          header_blob = buf[0, eoh]
+          out.leftover = buf[eoh + 4, buf.length - eoh - 4]
+          out.fill_from(header_blob)
+          out.ok = true
+          return out
+        end
+        if buf.length > 65535
+          return out          # head too large -- bail
+        end
+      end
+      out
     end
 
     # RFC 7230 §6.1 hop-by-hop headers: meaningful only for a single
@@ -173,6 +453,143 @@ module Tep
 
       def set_header(k, v)
         @headers[k] = v
+      end
+    end
+
+    # Parsed upstream response head, produced by read_upstream_head.
+    # `fill_from` parses a header blob ("Status-Line\r\nH: v\r\n...",
+    # no trailing blank line) into status + the downcased-name header
+    # bag + the chunked / SSE transport flags.
+    class UpstreamHead
+      attr_accessor :status, :headers, :is_chunked, :is_sse, :leftover, :ok
+
+      def initialize
+        @status     = 0
+        @headers    = Tep.str_hash
+        @is_chunked = false
+        @is_sse     = false
+        @leftover   = ""
+        @ok         = false
+      end
+
+      def fill_from(blob)
+        eol = Tep.str_find(blob, "\r\n", 0)
+        if eol < 0
+          return 0
+        end
+        line = blob[0, eol]
+        sp1 = Tep.str_find(line, " ", 0)
+        if sp1 >= 0
+          rest = line[sp1 + 1, line.length - sp1 - 1]
+          sp2 = Tep.str_find(rest, " ", 0)
+          if sp2 >= 0
+            @status = rest[0, sp2].to_i
+          else
+            @status = rest.to_i
+          end
+        end
+        # Header lines.
+        pos = eol + 2
+        while pos < blob.length
+          neol = Tep.str_find(blob, "\r\n", pos)
+          stop = neol
+          if stop < 0
+            stop = blob.length
+          end
+          line2 = blob[pos, stop - pos]
+          ci = Tep.str_find(line2, ":", 0)
+          if ci > 0
+            name = line2[0, ci].downcase
+            vpos = ci + 1
+            # skip one leading space
+            if vpos < line2.length && line2[vpos, 1] == " "
+              vpos += 1
+            end
+            val = line2[vpos, line2.length - vpos]
+            @headers[name] = val
+            if name == "transfer-encoding" && Tep.str_find(val.downcase, "chunked", 0) >= 0
+              @is_chunked = true
+            end
+            if name == "content-type" && val.downcase.start_with?("text/event-stream")
+              @is_sse = true
+            end
+          end
+          if neol < 0
+            return 0
+          end
+          pos = neol + 2
+        end
+        0
+      end
+    end
+
+    # One unit handed to on_stream_chunk: a dechunked HTTP chunk or a
+    # complete SSE event record. Read the bytes via `chunk_text`.
+    #
+    # Two spinel constraints shape this:
+    #  * The hook param is poly-boxed (it flows through the poly
+    #    on_stream_chunk dispatch), so a bare String would arrive poly
+    #    and block String methods. Wrapping in an object lets the hook
+    #    recover a concrete String via the accessor.
+    #  * The accessor is named `chunk_text`, not `text`: a poly value's
+    #    method call resolves by name across ALL classes, and `text`
+    #    collides with Tep::WebSocket::Driver#text (returns int). A
+    #    name with exactly one definition resolves cleanly to a String.
+    #    See [[spinel-widening-dispatch]].
+    class StreamChunk
+      attr_accessor :chunk_text
+
+      def initialize(chunk_text)
+        @chunk_text = chunk_text
+      end
+    end
+
+    # Per-stream telemetry, carried across every on_stream_chunk call
+    # and into on_stream_end. The framework maintains byte_count /
+    # chunk_count (input bytes dispatched, chunk/event count) and
+    # errored (set when the upstream stalls past the io_wait timeout
+    # or closes mid-frame). Accumulate custom counters (tokens, etc.)
+    # in the `meta_bag` bag -- a typed object rather than the doc's
+    # stats[:sym] hash because spinel hashes are single-value-typed
+    # (same reason Tep::Llm::StreamState is a class).
+    #
+    # Field names are deliberately collision-free: spinel unifies
+    # field/accessor types by NAME file-wide. `bytes` collides with
+    # String#bytes (int-array) and `data` collides with WebSocket
+    # Event#data (String) -- either would mis-type these fields. Hence
+    # byte_count / chunk_count / meta_bag. See [[spinel-widening-dispatch]].
+    class StreamStats
+      attr_accessor :byte_count, :chunk_count, :errored, :meta_bag
+
+      def initialize
+        @byte_count  = 0
+        @chunk_count = 0
+        @errored     = false
+        @meta_bag    = Tep.str_hash
+      end
+    end
+
+    # Thin Streamer shim. Holds the held-open upstream fd + state and
+    # delegates the actual pump to @proxy.run_stream. The work lives
+    # on Tep::Proxy (not here) so the per-chunk / end hooks dispatch
+    # through `self` -- a polymorphic-self call inside a base-Proxy
+    # method reaches subclass overrides, whereas a call through this
+    # object's @proxy slot (statically base-typed) would only ever hit
+    # the base hooks. See run_stream's comment + [[spinel-widening-dispatch]].
+    class ProxyStreamer < Tep::Streamer
+      attr_accessor :proxy, :fd, :leftover, :is_chunked, :is_sse, :req
+
+      def initialize
+        @proxy      = Tep::Proxy.new("")
+        @fd         = -1
+        @leftover   = ""
+        @is_chunked = false
+        @is_sse     = false
+        @req        = Tep::Request.new
+      end
+
+      def pump(out)
+        @proxy.run_stream(out, @fd, @leftover, @is_chunked, @is_sse, @req)
       end
     end
   end

--- a/test/test_proxy_streaming.rb
+++ b/test/test_proxy_streaming.rb
@@ -1,0 +1,146 @@
+require_relative "helper"
+
+# Tep::Proxy streaming (chunk 6.2, #81). Self-calling scheduled-server
+# shape like test_http.rb / test_proxy.rb: the app boots an SSE
+# upstream producer (/sse_upstream) and proxy routes that forward to
+# 127.0.0.1:<own-port> with stream_request? => true, exercising
+# on_stream_chunk per event + on_stream_end once at the end.
+#
+# Requires the scheduled server (proxy streaming parks on io_wait,
+# same constraint as WebSocket). workers=1 so the upstream-producer
+# fiber and the proxy-consumer fiber cooperate on one worker.
+class TestProxyStreaming < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # ---- upstream: emits three SSE events then closes ----
+    class SseTicks < Tep::Streamer
+      def pump(out)
+        out.write("data: a\\n\\n")
+        out.write("data: b\\n\\n")
+        out.write("data: c\\n\\n")
+      end
+    end
+
+    get '/sse_upstream' do
+      res.headers["Content-Type"] = "text/event-stream"
+      stream SseTicks.new
+    end
+
+    # ---- proxy subclasses (streaming hooks) ----
+
+    # Plain pass-through.
+    class PassProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/sse_upstream"
+      end
+      def stream_request?(req)
+        true
+      end
+    end
+
+    # Finalizer: emit a closing event carrying the framework's
+    # chunk_count, proving on_stream_end fires once with live stats.
+    class FinalizeProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/sse_upstream"
+      end
+      def stream_request?(req)
+        true
+      end
+      def on_stream_end(req, out, stats)
+        out.write("data: count=" + stats.chunk_count.to_s + "\\n\\n")
+        0
+      end
+    end
+
+    # Transform: prefix every event, proving on_stream_chunk can
+    # rewrite bytes on the way through.
+    class PrefixProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/sse_upstream"
+      end
+      def stream_request?(req)
+        true
+      end
+      def on_stream_chunk(chunk, out, stats)
+        out.write("x-" + chunk.chunk_text)
+        0
+      end
+    end
+
+    # Drop: forward only events whose payload contains "b".
+    class DropProxy < Tep::Proxy
+      def rewrite_path(path)
+        "/sse_upstream"
+      end
+      def stream_request?(req)
+        true
+      end
+      def on_stream_chunk(chunk, out, stats)
+        if chunk.chunk_text.include?("b")
+          out.write(chunk.chunk_text)
+        end
+        0
+      end
+    end
+
+    # ---- mount routes (build proxy with runtime port) ----
+
+    get '/p/pass/:port' do
+      PassProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/finalize/:port' do
+      FinalizeProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/prefix/:port' do
+      PrefixProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/drop/:port' do
+      DropProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    # Control: the upstream itself, fetched directly.
+    get '/direct/:port' do
+      r = Tep::Http.get("http://127.0.0.1:" + params[:port] + "/sse_upstream")
+      "status=" + r.status.to_s
+    end
+  RB
+
+  def test_streams_all_events_through
+    res = get("/p/pass/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "chunked", res["transfer-encoding"]
+    assert_equal "data: a\n\ndata: b\n\ndata: c\n\n", res.body
+  end
+
+  def test_on_stream_end_fires_once_with_stats
+    res = get("/p/finalize/#{@port}")
+    assert_equal "200", res.code
+    # Three upstream events, then exactly one finalizer event carrying
+    # the chunk count.
+    assert_equal "data: a\n\ndata: b\n\ndata: c\n\ndata: count=3\n\n", res.body
+  end
+
+  def test_on_stream_chunk_can_transform
+    res = get("/p/prefix/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "x-data: a\n\nx-data: b\n\nx-data: c\n\n", res.body
+  end
+
+  def test_on_stream_chunk_can_drop
+    res = get("/p/drop/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "data: b\n\n", res.body
+  end
+end


### PR DESCRIPTION
## Summary

Chunk 6.2 of the proxy battery ([`docs/PROXY-BATTERY.md`](docs/PROXY-BATTERY.md)). When a handler opts a request into streaming, `Tep::Proxy` forwards over a held-open connection and pumps the upstream body to the client, dispatching each chunk/SSE-event through `on_stream_chunk` and firing `on_stream_end` exactly once at end-of-stream.

```ruby
class LlmGateway < Tep::Proxy
  def stream_request?(req)
    Tep::Json.get_bool(req.raw_body, "stream")   # client opts in
  end
  def on_stream_chunk(chunk, out, stats)
    out.write(chunk.chunk_text)                  # transform / count / drop
    0
  end
  def on_stream_end(req, out, stats)
    EVENTS.write(req_id: req.headers["x-request-id"],
                 chunks: stats.chunk_count, bytes: stats.byte_count)
    0
  end
end
```

## How it works

- `start_streaming_forward` connects, writes the request, reads just the response head (`read_upstream_head` → `UpstreamHead`: status + headers + chunked/SSE flags + leftover bytes), then hands the open fd to a `ProxyStreamer` via `res.start_stream`.
- `ProxyStreamer#pump` delegates to `Tep::Proxy#run_stream`, which recv-loops the upstream (dechunking chunked transfer, splitting SSE event records), dispatches each unit via `on_stream_chunk`, and fires `on_stream_end`. Cooperative (`io_wait`) → **requires the scheduled server** (now that `res.streaming` works there, #90).
- `StreamStats` carries `byte_count` / `chunk_count` / `errored` + a `meta_bag` for custom counters.

## Design decisions

- **Request-side opt-in** (`stream_request?`) rather than response-Content-Type sniffing: keeps the non-streaming path on the unchanged buffered `send_req`, and matches how clients signal intent (`"stream": true`). Consequence: `after_forward` does not run for streamed responses — `on_stream_end` is its streaming counterpart (per the doc).
- **`on_stream_chunk` receives a `StreamChunk` object** (`chunk.chunk_text`), not a bare String. A primitive arg boxes to poly through the poly-receiver hook dispatch, blocking String methods (`.include?`, `+`) in overrides; an object survives as a typed pointer (same reason `Tep::WebSocket` passes `evt` with `evt.data`).
- **`run_stream` lives on `Tep::Proxy`**, not the streamer, so the hooks dispatch via implicit `self` (polymorphic → reaches subclass overrides) rather than a base-typed slot (base-only).

These plus the field/accessor naming (`chunk_text` not `text`; `byte_count`/`chunk_count`/`meta_bag` not `bytes`/`chunks`/`data`) work around spinel's file-wide by-name type unification — documented inline.

## Test plan

- [x] `test/test_proxy_streaming.rb` — 4 tests (pass-through, `on_stream_end` once + live stats, `on_stream_chunk` transform, `on_stream_chunk` drop), self-calling scheduled-server shape.
- [x] Full `make test` — **411 runs, 0 failures, 0 errors** (52 skips), against fresh spinel master.

## Discovered + fixed en route

#90 (PR #91, merged): the scheduled server silently dropped `res.streaming` responses (`Content-Length: 0`, empty body) — a latent bug also breaking the chatbot's OpenAI-compat SSE endpoint. That was the hard prerequisite for this chunk.

## Out of scope

Block-form DSL (#88), https:// upstreams, and the OpenAI-server `serve!(events_jsonl:)` emitter (#80 — a separate origin-server battery; this is the proxy/gateway-side analog).

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)