### PR TITLE
feat(events): Tep::Events — toy/v1 JSONL emitter (#80, closes #79)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -62,6 +62,7 @@ require_relative "tep/scheduler"
 require_relative "tep/shell"
 require_relative "tep/http"
 require_relative "tep/proxy"
+require_relative "tep/events"
 require_relative "tep/llm"
 require_relative "tep/websocket"
 require_relative "tep/parallel"
@@ -575,6 +576,19 @@ module Tep
   _tep_seed_pstreamer = Tep::Proxy::ProxyStreamer.new
   _tep_seed_pstreamer.proxy = _tep_seed_proxy
   _tep_seed_proxy_res.start_stream(_tep_seed_pstreamer)
+
+  # Tep::Events seed (toy/v1 emitter). Seeded with a disabled ("")
+  # path so the guards short-circuit before any File I/O at boot;
+  # the JSON-building bodies + sphttp_iso8601_utc call still compile
+  # statically, and the call args pin every param type.
+  _tep_seed_events = Tep::Events.new("")
+  _tep_seed_events.enabled?
+  _tep_seed_events.run_start("host", "cpu", "model", "/path", "{}")
+  _tep_seed_events.inference("model", 0, 0, 0, "{}")
+  _tep_seed_events.record_error
+  _tep_seed_events.run_end("ok")
+  _tep_seed_events.rel_t
+  Sock.sphttp_iso8601_utc(0)
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -1,0 +1,162 @@
+# Tep::Events -- toy/v1 event-stream emitter.
+#
+# Appends newline-delimited JSON (JSONL) in the toy/v1 envelope
+# (`docs/events-schema.md` in the toy project): one `run_start` at
+# boot, one `inference` per served request, one `run_end` at
+# shutdown. The serving stream is structurally indistinguishable
+# from a training stream, so a single downstream ingest (the
+# research-lab orchestrator) consumes both.
+#
+# Standalone on purpose: any tep handler can emit (the chatbot's
+# existing OpenAI-compat endpoint, a future Tep::Llm::OpenAI::Server,
+# a Tep::Proxy gateway via on_stream_end). The full server battery
+# (Battery 7) builds on this rather than reimplementing it.
+#
+#   EVENTS = Tep::Events.new(ENV["EVENTS_JSONL"])   # "" => disabled
+#   EVENTS.run_start("gx10", "cpu", "smollm2-135m",
+#                    "/srv/models/smollm2-135m.gguf",
+#                    "{\"server\":\"tep\",\"cap\":\"infer\"}")
+#   # ... per request, after generation completes:
+#   EVENTS.inference("smollm2-135m", 12, 8, 87000,
+#     "{\"request_id\":\"cmpl-abc\",\"principal_id\":\"user:42\"," +
+#     "\"sampling\":{\"temperature\":0.7,\"max_tokens\":256}}")
+#   # ... at shutdown:
+#   EVENTS.run_end("ok")
+#
+# Schema choice (was #79): per-request telemetry is `kind:"inference",
+# phase:"serve"` -- a distinct kind, NOT an overload of toy/v1's
+# `eval` (reserved for held-out training evaluation: loss/ppl/
+# samples). tao's recommendation; a served completion shares none of
+# eval's defining fields, and overloading `eval` would break tao's
+# ingest (which keys the "final eval" on `kind` alone).
+#
+# Float-free by design (spinel has no Float + tep ships zero floats):
+#   * `t` is integer seconds since run_start (a JSON number; consumers
+#     reading it as float get N.0). Sub-second ordering isn't needed
+#     for serving telemetry -- per-request latency rides in wall_us.
+#   * `wall_us` (microsecond latency) is caller-measured + passed in.
+#   * Floats that the schema does carry (sampling.temperature) live in
+#     the caller-built `extra` JSON string, which tep emits verbatim.
+#
+# `started_at` / `ended_at` are ISO-8601 UTC via Sock.sphttp_iso8601_utc
+# (spinel's Time.now exposes only integer epoch seconds).
+module Tep
+  class Events
+    def initialize(path)
+      @path        = path   # "" disables emission (zero I/O, zero alloc)
+      @run_started = 0       # epoch seconds at run_start; basis for relative t
+      @req_count   = 0
+      @err_count   = 0
+      @tok_out     = 0
+    end
+
+    # True when a non-empty path was configured. Apps that build the
+    # emitter unconditionally can cheaply skip work when disabled.
+    def enabled?
+      @path.length > 0
+    end
+
+    # Emit `run_start` once, before any request. Establishes the
+    # relative-t origin even when emission is disabled (so a later
+    # enable mid-run wouldn't be needed; cheap either way). host /
+    # backend_kind / model_name / model_path are plain strings;
+    # config_json is a caller-built JSON object emitted verbatim.
+    def run_start(host, backend_kind, model_name, model_path, config_json)
+      @run_started = Time.now.to_i
+      if @path.length == 0
+        return 0
+      end
+      started = Sock.sphttp_iso8601_utc(@run_started)
+      line = "{" +
+        Json.encode_pair_str("kind", "run_start") + "," +
+        Json.encode_pair_str("schema", "toy/v1") + "," +
+        Json.encode_pair_int("t", 0) + "," +
+        Json.encode_pair_str("started_at", started) + "," +
+        Json.encode_pair_str("host", host) + "," +
+        "\"backend\":{" + Json.encode_pair_str("kind", backend_kind) + "}," +
+        "\"model\":{" +
+          Json.encode_pair_str("name", model_name) + "," +
+          Json.encode_pair_str("path", model_path) +
+        "}," +
+        "\"config\":" + config_json +
+      "}"
+      append_line(line)
+    end
+
+    # Emit one `inference` event. Token counts + wall_us (microsecond
+    # latency) are ints the caller measured. extra_json is a caller-
+    # built JSON object ("{}" if none) carrying sampling / request_id /
+    # principal_id -- emitted verbatim, so floats (temperature) live
+    # there, out of tep's float-free core.
+    def inference(model, prompt_tokens, completion_tokens, wall_us, extra_json)
+      @req_count = @req_count + 1
+      @tok_out   = @tok_out + completion_tokens
+      if @path.length == 0
+        return 0
+      end
+      line = "{" +
+        Json.encode_pair_str("kind", "inference") + "," +
+        Json.encode_pair_str("phase", "serve") + "," +
+        Json.encode_pair_int("t", rel_t) + "," +
+        Json.encode_pair_str("model", model) + "," +
+        Json.encode_pair_int("prompt_tokens", prompt_tokens) + "," +
+        Json.encode_pair_int("completion_tokens", completion_tokens) + "," +
+        Json.encode_pair_int("wall_us", wall_us) + "," +
+        "\"extra\":" + extra_json +
+      "}"
+      append_line(line)
+    end
+
+    # Count one server-side error (surfaced in run_end.stats.errors).
+    # Separate from emission so the counter advances even when
+    # emission is disabled.
+    def record_error
+      @err_count = @err_count + 1
+      0
+    end
+
+    # Emit `run_end` once at shutdown. reason is "ok" (clean) or
+    # "errored" (uncaught failure) -- per toy/v1, quality verdicts on
+    # the run are downstream decisions, not encoded here.
+    def run_end(reason)
+      if @path.length == 0
+        return 0
+      end
+      ended = Sock.sphttp_iso8601_utc(Time.now.to_i)
+      line = "{" +
+        Json.encode_pair_str("kind", "run_end") + "," +
+        Json.encode_pair_int("t", rel_t) + "," +
+        Json.encode_pair_str("ended_at", ended) + "," +
+        Json.encode_pair_str("reason", reason) + "," +
+        "\"stats\":{" +
+          Json.encode_pair_int("requests", @req_count) + "," +
+          Json.encode_pair_int("errors", @err_count) + "," +
+          Json.encode_pair_int("tokens_out", @tok_out) +
+        "}" +
+      "}"
+      append_line(line)
+    end
+
+    # Seconds since run_start, clamped at 0 (a clock that goes
+    # backwards, or events before run_start, read as t=0).
+    def rel_t
+      d = Time.now.to_i - @run_started
+      if d < 0
+        d = 0
+      end
+      d
+    end
+
+    # Append one JSON line. Best-effort, append mode -- mirrors
+    # Tep::Logger's file sink. Telemetry must never fail a request, so
+    # a malformed/unwritable path degrades to a dropped line rather
+    # than a raised error reaching the handler. Callers gate on a
+    # non-empty @path before reaching here.
+    def append_line(line)
+      File.open(@path, "a") do |f|
+        f.puts(line)
+      end
+      0
+    end
+  end
+end

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -30,6 +30,11 @@ module Sock
   ffi_func :sphttp_recv_frame_buf, [],              :str
   ffi_func :sphttp_recv_frame_len, [],              :int
 
+  # ISO-8601 UTC timestamp for an epoch-seconds value. Used by
+  # Tep::Events (toy/v1 envelope) for run_start/run_end wall-clock
+  # fields -- spinel's Time.now is integer-epoch only.
+  ffi_func :sphttp_iso8601_utc,   [:int],           :str
+
   ffi_func :sphttp_sendfile,      [:int, :str],     :int
   ffi_func :sphttp_filesize,      [:str],           :int
   ffi_func :sphttp_close,         [:int],           :int

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -469,4 +469,21 @@ const char *sphttp_shell_capture(const char *cmd, int max_bytes) {
     return sphttp_shell_buf;
 }
 
+/* ISO-8601 UTC timestamp ("2026-05-27T13:40:01Z") for the given
+ * Unix epoch seconds. Used by Tep::Events for the run_start /
+ * run_end wall-clock fields -- spinel's Time.now only exposes
+ * integer epoch seconds, and hand-rolling the calendar math (leap
+ * years, etc.) in Ruby isn't worth it. gmtime_r + strftime do it
+ * in one line. Returns a pointer to a static buffer (single-
+ * threaded server model; copy on the Ruby side if retained). */
+static char sphttp_iso8601_buf[32];
+const char *sphttp_iso8601_utc(int epoch_secs) {
+    time_t t = (time_t)epoch_secs;
+    struct tm tmv;
+    gmtime_r(&t, &tmv);
+    strftime(sphttp_iso8601_buf, sizeof(sphttp_iso8601_buf),
+             "%Y-%m-%dT%H:%M:%SZ", &tmv);
+    return sphttp_iso8601_buf;
+}
+
 /* File read/write moved to spinel's built-in File.read / File.write */

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,0 +1,103 @@
+require_relative "helper"
+require "json"
+
+# Tep::Events -- toy/v1 JSONL emitter. The app emits a full
+# run_start -> inference x2 -> run_end scenario into a file and dumps
+# it back over HTTP, so the test can parse + assert the envelope.
+class TestEvents < TepTest
+  EV_PATH = "/tmp/tep_events_test.jsonl"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    PATH = "#{EV_PATH}"
+
+    # One self-contained scenario: reset the file, emit the full
+    # event sequence, return the raw JSONL.
+    get '/scenario' do
+      File.write(PATH, "")
+      ev = Tep::Events.new(PATH)
+      ev.run_start("testhost", "cpu", "smollm2-135m", "/m.gguf",
+                   "{\\"server\\":\\"tep\\",\\"cap\\":\\"infer\\"}")
+      ev.inference("smollm2-135m", 12, 8, 87000,
+                   "{\\"request_id\\":\\"cmpl-abc\\",\\"principal_id\\":\\"user:42\\"}")
+      ev.inference("smollm2-135m", 5, 3, 40000,
+                   "{\\"request_id\\":\\"cmpl-def\\"}")
+      ev.run_end("ok")
+      File.read(PATH)
+    end
+
+    # Disabled emitter ("" path): enabled? false + no file written.
+    get '/disabled' do
+      File.write(PATH, "SENTINEL")
+      d = Tep::Events.new("")
+      d.run_start("h", "cpu", "m", "/p", "{}")
+      d.inference("m", 1, 1, 1, "{}")
+      d.run_end("ok")
+      # File must still hold the sentinel (disabled wrote nothing).
+      "enabled=" + d.enabled?.to_s + " file=" + File.read(PATH)
+    end
+
+    # ISO-8601 helper directly.
+    get '/iso' do
+      Sock.sphttp_iso8601_utc(0)
+    end
+  RB
+
+  def scenario_lines
+    body = get("/scenario").body
+    body.split("\n").reject(&:empty?).map { |l| JSON.parse(l) }
+  end
+
+  def test_emits_four_events_in_order
+    lines = scenario_lines
+    assert_equal 4, lines.length
+    assert_equal "run_start", lines[0]["kind"]
+    assert_equal "inference", lines[1]["kind"]
+    assert_equal "inference", lines[2]["kind"]
+    assert_equal "run_end",   lines[3]["kind"]
+  end
+
+  def test_run_start_envelope
+    rs = scenario_lines[0]
+    assert_equal "toy/v1", rs["schema"]
+    assert_equal 0, rs["t"]
+    assert_equal "testhost", rs["host"]
+    assert_equal "cpu", rs["backend"]["kind"]
+    assert_equal "smollm2-135m", rs["model"]["name"]
+    assert_equal "/m.gguf", rs["model"]["path"]
+    assert_equal "infer", rs["config"]["cap"]
+    assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/, rs["started_at"])
+  end
+
+  def test_inference_event_fields
+    ev = scenario_lines[1]
+    assert_equal "inference", ev["kind"]
+    assert_equal "serve", ev["phase"]
+    assert_equal "smollm2-135m", ev["model"]
+    assert_equal 12, ev["prompt_tokens"]
+    assert_equal 8, ev["completion_tokens"]
+    assert_equal 87000, ev["wall_us"]
+    assert_equal "cmpl-abc", ev["extra"]["request_id"]
+    assert_equal "user:42", ev["extra"]["principal_id"]
+    assert_kind_of Integer, ev["t"]
+  end
+
+  def test_run_end_stats_accumulate
+    re = scenario_lines[3]
+    assert_equal "ok", re["reason"]
+    assert_equal 2, re["stats"]["requests"]      # two inference calls
+    assert_equal 11, re["stats"]["tokens_out"]   # 8 + 3
+    assert_equal 0, re["stats"]["errors"]
+    assert_match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\z/, re["ended_at"])
+  end
+
+  def test_disabled_emitter_writes_nothing
+    res = get("/disabled")
+    assert_equal "enabled=false file=SENTINEL", res.body
+  end
+
+  def test_iso8601_epoch_zero
+    assert_equal "1970-01-01T00:00:00Z", get("/iso").body
+  end
+end


### PR DESCRIPTION
## Summary

A standalone emitter for the **toy/v1 event-stream envelope** — one `run_start` at boot, one `inference` per served request, one `run_end` at shutdown, appended as JSONL. Any tep handler can emit, so it **unblocks toy now**: toy wires it into its existing `openai_api_*.rb` demos and the research-lab orchestrator ingests a serving stream structurally identical to a training stream. The forthcoming `Tep::Llm::OpenAI::Server` (Battery 7) builds on this rather than reimplementing it.

```ruby
EVENTS = Tep::Events.new(ENV["EVENTS_JSONL"])      # "" => disabled (zero I/O)
EVENTS.run_start("gx10", "cpu", "smollm2-135m", "/srv/models/smollm2-135m.gguf",
                 "{\"server\":\"tep\",\"cap\":\"infer\"}")
# ... after a request's generation completes:
EVENTS.inference("smollm2-135m", 12, 8, 87000,
  "{\"request_id\":\"cmpl-abc\",\"principal_id\":\"user:42\"," +
  "\"sampling\":{\"temperature\":0.7,\"max_tokens\":256}}")
# ... at shutdown:
EVENTS.run_end("ok")
```

## Schema decision (closes #79)

Per-request telemetry is **`kind:"inference"`, `phase:"serve"`** — a distinct kind, not an overload of toy/v1's `eval` (reserved for held-out training evaluation). tao's recommendation; a served completion shares none of `eval`'s fields, and overloading it would break tao's ingest (which keys the "final eval" on `kind` alone). The doc already encoded this; this PR commits it in code.

## Design notes

- **Float-free** (spinel has no Float, tep ships zero): `t` is integer seconds since `run_start` (still a JSON number); per-request latency precision rides in `wall_us` (caller-measured int); schema floats like `sampling.temperature` live in the caller-built `extra` JSON string, emitted verbatim.
- **`started_at`/`ended_at`** are ISO-8601 UTC via a new `sphttp_iso8601_utc` C primitive (`Time.now` exposes only integer epoch seconds; `gmtime_r` + `strftime` beat hand-rolling calendar math).
- **`events_jsonl` unset (`""`)** disables the whole path — zero I/O, zero alloc. Append failures degrade to a dropped line, never a raised error reaching the handler.

## Test plan

- [x] `test/test_events.rb` — 6 tests (event ordering; `run_start`/`inference`/`run_end` envelopes; stats accumulation; disabled no-op; ISO-8601 format), parsing the emitted JSONL with Ruby's `JSON`.
- [x] Full `make test` — **417 runs, 0 failures, 0 errors** (52 skips), against fresh spinel master.

## Scope

This is the **standalone-emitter** half of #80. The `serve!`-route-handler wiring (emit fires from the OpenAI-server route) lands with Battery 7 chunk 7.1, which calls this same emitter. #80 stays open for that.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)