### PR TITLE
feat(proxy): block-form DSL translator lowering (closes #88)

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -71,6 +71,10 @@ def translate(input_path)
   live_views    = []
   mcp_tools     = []
   mcp_resources = []
+  proxies       = []   # Tep::Proxy block-DSL (#88): one entry per
+                       # `var = Tep::Proxy.new(...)` + its .before/.after/
+                       # .on_stream_chunk/.on_stream_end/.stream_request?
+                       # block calls, lowered to a generated subclass.
   filters       = { "before" => [], "after" => [] }
   not_founds    = []
   startup_block = nil
@@ -100,6 +104,62 @@ def translate(input_path)
        node.receiver.name == :Tep
       handle_tep_live(node, live_views, warnings)
       return
+    end
+
+    # Proxy block-DSL (#88), part 1: `var = Tep::Proxy.new(...)`.
+    # Record the proxy var + rewrite the assignment to instantiate
+    # the generated subclass (TepProxy_<idx>), which carries the
+    # before/after/stream hooks collected below. The base
+    # `Tep::Proxy.new` would forward with no customization; the
+    # subclass is only emitted when at least one hook block is seen,
+    # but we always rewrite so the var name stays consistent.
+    if node.is_a?(Prism::LocalVariableWriteNode) && proxy_new_call?(node.value)
+      idx    = proxies.length
+      up_src = proxy_upstream_src(node.value, warnings)
+      proxies << { var: node.name.to_s, idx: idx, upstream: up_src, hooks: {} }
+      # Assign to a CONSTANT, not the original local. A Tep::Proxy
+      # subclass instance flowing through a *local* into Tep.<verb>
+      # widens rewrite_path's virtual `path` param to poly (poisoning
+      # Tep::App.guess_mime's `path` file-wide); the same instance via
+      # a constant compiles clean. Mounts are rewritten to the
+      # constant below.
+      passthrough << "TEPPROXY_#{idx} = TepProxy_#{idx}.new(#{up_src})"
+      return
+    end
+
+    # Proxy block-DSL (#88), part 2: `proxyvar.before do ... end`
+    # (and .after / .on_stream_chunk / .on_stream_end /
+    # .stream_request?). Collect the block onto the proxy entry +
+    # suppress from passthrough (a receiver-method call with a block
+    # can't lower -- spinel has no PtrArray<Block>; the block becomes
+    # an imeth on the generated subclass instead).
+    if call?(node) && node.receiver.is_a?(Prism::LocalVariableReadNode) &&
+       PROXY_HOOK_IMETH.key?(node.name.to_s) && node.block.is_a?(Prism::BlockNode)
+      pv = proxies.find { |p| p[:var] == node.receiver.name.to_s }
+      if pv
+        pv[:hooks][node.name.to_s] = {
+          params: block_param_list(node.block),
+          src:    block_source(node.block),
+        }
+        return
+      end
+    end
+
+    # Proxy block-DSL (#88), part 3: rewrite a mount of a proxy var --
+    # `Tep.<verb> "path", proxyvar` or bare `<verb> "path", proxyvar`
+    # (no block) -- to reference the generated constant instead of the
+    # (dropped) local. Reconstructed structurally so the handler arg
+    # becomes TEPPROXY_<idx>.
+    if call?(node) && PROXY_MOUNT_VERBS.include?(node.name.to_s) && node.block.nil?
+      margs = node.arguments&.arguments || []
+      if margs.length == 2 && margs[1].is_a?(Prism::LocalVariableReadNode)
+        pv = proxies.find { |p| p[:var] == margs[1].name.to_s }
+        if pv
+          recv = node.receiver ? "#{node.receiver.location.slice}." : ""
+          passthrough << "#{recv}#{node.name}(#{margs[0].location.slice}, TEPPROXY_#{pv[:idx]})"
+          return
+        end
+      end
     end
 
     # Only bare top-level method calls (no receiver) are candidates
@@ -163,6 +223,32 @@ def translate(input_path)
   # Top-level non-DSL statements (constants, classes, defs, ...).
   # Emitted verbatim before any DSL registrations so handler bodies
   # can refer to them.
+  # Proxy block-DSL subclasses (#88). Emitted BEFORE passthrough so
+  # the rewritten `var = TepProxy_<idx>.new(...)` assignment (which
+  # stays in passthrough, in its original position so its upstream
+  # argument can reference earlier top-level code) finds the class
+  # defined. Each subclass's imeths are the user's `.before` /
+  # `.after` / `.on_stream_chunk` / `.on_stream_end` /
+  # `.stream_request?` block bodies, lowered verbatim with the user's
+  # param names -- a thin 1:1 sugar over the subclass-override form.
+  # Method bodies run at request time, so referencing user constants
+  # defined later in passthrough is fine. A hookless proxy still gets
+  # a (trivial) subclass so its assignment resolves.
+  unless proxies.empty?
+    out << "# --- proxy block-DSL subclasses (#88) ---"
+    proxies.each do |p|
+      out << "class TepProxy_#{p[:idx]} < Tep::Proxy"
+      p[:hooks].each do |dsl_name, info|
+        imeth = PROXY_HOOK_IMETH[dsl_name]
+        out << "  def #{imeth}(#{info[:params]})"
+        out << indent(rewrite_block(info[:src], force_string: false), 4)
+        out << "  end"
+      end
+      out << "end"
+    end
+    out << ""
+  end
+
   unless passthrough.empty?
     out << "# --- top-level passthrough from #{File.basename(input_path)} ---"
     passthrough.each { |s| out << s }
@@ -1247,6 +1333,68 @@ def block_source(block_node)
   return "" if body.nil?
   src = body.location.slice
   src
+end
+
+# ---- Tep::Proxy block-DSL lowering (#88) ----
+
+# Maps a proxy block-DSL method name to the Tep::Proxy imeth the
+# generated subclass overrides. `before`/`after` rename to
+# `before_forward`/`after_forward` (the runtime hook names -- bare
+# before/after collide with Filter/Security/Auth under spinel's
+# same-name dispatch); the rest map 1:1.
+PROXY_HOOK_IMETH = {
+  "before"          => "before_forward",
+  "after"           => "after_forward",
+  "on_stream_chunk" => "on_stream_chunk",
+  "on_stream_end"   => "on_stream_end",
+  "stream_request?" => "stream_request?",
+}.freeze
+
+# Route verbs a proxy var can be mounted on (`Tep.<verb> "p", api`).
+PROXY_MOUNT_VERBS = %w[get post put patch delete head].freeze
+
+# True for a `Tep::Proxy.new(...)` / `Proxy.new(...)` call node.
+def proxy_new_call?(node)
+  return false unless node.is_a?(Prism::CallNode) && node.name == :new
+  recv = node.receiver
+  return false if recv.nil?
+  slice = recv.location.slice
+  slice == "Tep::Proxy" || slice == "Proxy"
+end
+
+# Extract the upstream argument source from a `Tep::Proxy.new(...)`
+# call, normalising the doc's keyword form (`upstream: "..."`) to the
+# positional arg the runtime initialize(upstream) takes. Returns the
+# raw source slice of the value expression.
+def proxy_upstream_src(node, warnings)
+  args = node.arguments&.arguments || []
+  if args.empty?
+    warnings << "Tep::Proxy.new needs an upstream argument; emitting empty"
+    return '""'
+  end
+  first = args.first
+  if first.is_a?(Prism::KeywordHashNode)
+    first.elements.each do |el|
+      next unless el.is_a?(Prism::AssocNode)
+      k = el.key
+      kn = k.is_a?(Prism::SymbolNode) ? k.unescaped : nil
+      return el.value.location.slice if kn == "upstream"
+    end
+    warnings << "Tep::Proxy.new: no `upstream:` key found; emitting empty"
+    return '""'
+  end
+  first.location.slice
+end
+
+# Comma-joined block parameter names ("req, res, ureq"). The generated
+# imeth uses the user's chosen names verbatim, so their block body
+# references resolve. Empty string for a paramless block.
+def block_param_list(block_node)
+  bp = block_node.parameters
+  return "" unless bp.is_a?(Prism::BlockParametersNode)
+  pp = bp.parameters
+  return "" unless pp.is_a?(Prism::ParametersNode)
+  pp.requireds.map { |r| r.is_a?(Prism::RequiredParameterNode) ? r.name.to_s : nil }.compact.join(", ")
 end
 
 def literal_string(node)

--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -6,20 +6,16 @@ gateways, observability layers, key-swap proxies, multi-upstream
 routing, mirror-to-staging, fan-out, LLM proxies. Whatever sits
 between a client and a real upstream HTTP server.
 
-> Status: **chunks 6.1 + 6.2 shipped** (`lib/tep/proxy.rb`). 6.1:
-> non-streaming forward + `before_forward` / `after_forward`. 6.2:
-> streaming forward (chunked + SSE) via `stream_request?` opt-in,
-> `on_stream_chunk(chunk, out, stats)` (chunk is a `StreamChunk` —
-> read `chunk.chunk_text`), `on_stream_end(req, out, stats)`, carried
-> `StreamStats` (byte_count / chunk_count / errored / meta_bag).
-> Streaming requires the scheduled server. The block-form DSL (#88)
-> and https:// upstreams are still draft. (Older one-shot note below.)
->
-> Old status line follows for context:
-> **chunk 6.1 shipped** (`lib/tep/proxy.rb` — non-streaming
-> forward + `before_forward` / `after_forward` hooks via subclass-
-> override; see "Filter shape" note below). Streaming (6.2) and the
-> block-form DSL are still draft. Sister doc:
+> Status: **chunks 6.1 + 6.2 + block-DSL (#88) shipped**
+> (`lib/tep/proxy.rb` + bin/tep). 6.1: non-streaming forward +
+> `before_forward` / `after_forward`. 6.2: streaming forward (chunked
+> + SSE) via `stream_request?` opt-in, `on_stream_chunk(chunk, out,
+> stats)` (chunk is a `StreamChunk` — read `chunk.chunk_text`),
+> `on_stream_end(req, out, stats)`, carried `StreamStats` (byte_count
+> / chunk_count / errored / meta_bag). #88: the `api.before do … end`
+> block DSL lowers to a generated subclass (see "Filter shape").
+> Streaming requires the scheduled server. https:// upstreams are
+> still draft. Sister doc:
 > [`OPENAI-SERVER-BATTERY.md`](OPENAI-SERVER-BATTERY.md) covers
 > the *origin-server* case (no upstream — tep is the source of
 > truth). The two batteries are independent; an OpenAI gateway
@@ -70,17 +66,34 @@ Tep.get  "/v1/models",           api
 
 ## Filter shape
 
-> **Shipped form (chunk 6.1): subclass + override.** The block DSL
-> below (`api.before do … end`) is the *target* API, but it needs a
-> bin/tep translator pass that doesn't exist yet (#88) — a
-> receiver-method call with a block can't lower to spinel without it
-> (`PtrArray<Block>` isn't representable). So 6.1 ships the lowering
-> target directly: subclass `Tep::Proxy` and override the hooks. The
-> imeths are named `before_forward` / `after_forward` (not bare
-> `before` / `after`) to avoid colliding with the 2-arg `before` /
-> `after` on `Tep::Filter` / `Security` / `Auth` under spinel's
-> same-name virtual dispatch. Same staging `Tep::LiveView` used
-> before its `Tep.live` auto-wire helper.
+> **Two equivalent forms now ship.** As of #88 the block DSL below
+> (`api.before do … end`) works — the bin/tep translator lowers it
+> into a generated `Tep::Proxy` subclass (the block bodies become
+> `before_forward` / `after_forward` / `on_stream_chunk` /
+> `on_stream_end` / `stream_request?` imeths, with `before`/`after`
+> renamed to `*_forward` to dodge spinel's same-name dispatch
+> collision with `Filter`/`Security`/`Auth`). The subclass-override
+> form (below the block example) is the direct equivalent — both
+> compile to the same thing; use whichever reads better.
+>
+> Block-DSL specifics: `chunk` in `on_stream_chunk` is a
+> `StreamChunk` (read `chunk.chunk_text`); the proxy var is mounted
+> via `Tep.<verb> "path", api` (the translator rewrites it to a
+> generated constant — passing a Proxy subclass through a *local* into
+> `Tep.<verb>` trips a spinel inference bug, a constant doesn't). Use
+> the proxy var only for mounts.
+>
+> ```ruby
+> api = Tep::Proxy.new("http://api.internal:8080")
+> api.before do |req, res, ureq|
+>   ureq.set_header("Authorization", "Bearer " + ENV["OPENAI_KEY"])
+>   false                                  # true short-circuits
+> end
+> api.after { |req, ures, res| Tep::Logger.info("up " + ures.status.to_s); 0 }
+> Tep.post "/v1/chat/completions", api
+> ```
+>
+> Subclass-override equivalent:
 >
 > ```ruby
 > class OpenAIProxy < Tep::Proxy
@@ -371,7 +384,7 @@ discovery on top of a proxy, they declare it explicitly
 | Chunk | Scope |
 |---|---|
 | **6.1** ✅ | `Tep::Proxy.new(upstream)` base; `before_forward` + `after_forward` overridable hooks; non-streaming bodies; hop-by-hop header stripping; connect-failure → 502; mount as `Tep::Handler` at any verb/path. Block-form DSL deferred to #88. |
-| **6.2** ✅ | Streaming proxy — `stream_request?` opt-in, chunked + SSE-aware `on_stream_chunk(chunk, out, stats)` (chunk = `StreamChunk`, read `chunk.chunk_text`), **`on_stream_end(req, out, stats)` finalizer** + carried `StreamStats`. Requires the scheduled server. Block-form DSL deferred to #88. |
+| **6.2** ✅ | Streaming proxy — `stream_request?` opt-in, chunked + SSE-aware `on_stream_chunk(chunk, out, stats)` (chunk = `StreamChunk`, read `chunk.chunk_text`), **`on_stream_end(req, out, stats)` finalizer** + carried `StreamStats`. Requires the scheduled server. |
 | **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + per-request `inference` event emission via `on_stream_end`). |
 | **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |
 

--- a/test/test_proxy_dsl.rb
+++ b/test/test_proxy_dsl.rb
@@ -1,0 +1,91 @@
+require_relative "helper"
+
+# Tep::Proxy block-form DSL (#88). The bin/tep translator lowers
+#   api = Tep::Proxy.new("...")
+#   api.before do |req, res, ureq| ... end
+#   Tep.get "/path", api
+# into a generated TepProxy_<n> < Tep::Proxy subclass (before ->
+# before_forward, etc.) instantiated by the rewritten assignment.
+#
+# Behavior is validated via the short-circuit path (before returns
+# true -> no upstream call) + dead-port (-> 502), so no live upstream
+# is needed -- the actual forwarding is the subclass-override form
+# (test_proxy.rb) this lowers to. The streaming hooks
+# (on_stream_chunk/on_stream_end/stream_request?) are exercised for
+# *compilation* (the app builds with all five hook kinds lowered).
+class TestProxyDsl < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    # Short-circuit proxy: before returns true, never reaches upstream.
+    guard = Tep::Proxy.new("http://127.0.0.1:1")
+    guard.before do |req, res, ureq|
+      res.set_status(403)
+      res.set_body("blocked by dsl")
+      true
+    end
+    Tep.get "/guard", guard
+
+    # before short-circuits + after runs on the short-circuit path
+    # (audit sees rejected requests). after stamps a header.
+    audited = Tep::Proxy.new("http://127.0.0.1:1")
+    audited.before do |req, res, ureq|
+      res.set_status(403)
+      res.set_body("denied")
+      true
+    end
+    audited.after do |req, ures, res|
+      res.headers["X-Audited"] = "yes"
+      0
+    end
+    Tep.get "/audited", audited
+
+    # No hooks: forwards to a dead upstream -> 502.
+    dead = Tep::Proxy.new("http://127.0.0.1:1")
+    Tep.get "/dead", dead
+
+    # All five hook kinds, to exercise the translator lowering of the
+    # streaming blocks. stream_request? returns false so GET takes the
+    # buffered path (dead upstream -> 502); the on_stream_* blocks are
+    # lowered + compiled but not invoked here.
+    full = Tep::Proxy.new("http://127.0.0.1:1")
+    full.stream_request? do |req|
+      false
+    end
+    full.on_stream_chunk do |chunk, out, stats|
+      out.write(chunk.chunk_text)
+      0
+    end
+    full.on_stream_end do |req, out, stats|
+      out.write("data: done\\n\\n")
+      0
+    end
+    Tep.get "/full", full
+  RB
+
+  def test_before_block_short_circuits
+    res = get("/guard")
+    assert_equal "403", res.code
+    assert_equal "blocked by dsl", res.body
+  end
+
+  def test_after_block_runs_on_short_circuit
+    res = get("/audited")
+    assert_equal "403", res.code
+    assert_equal "denied", res.body
+    assert_equal "yes", res["X-Audited"]
+  end
+
+  def test_no_hooks_forwards_dead_upstream_502
+    res = get("/dead")
+    assert_equal "502", res.code
+  end
+
+  def test_full_hookset_buffered_path
+    # stream_request? => false, so GET /full takes the buffered path
+    # to the dead upstream -> 502 (proves the lowered stream_request?
+    # block runs + returns false; the on_stream_* blocks compiled).
+    res = get("/full")
+    assert_equal "502", res.code
+  end
+end


### PR DESCRIPTION
## Summary

Lowers the documented proxy **block DSL** into the shipped subclass-override runtime, so both forms now work:

```ruby
api = Tep::Proxy.new("http://api.internal:8080")
api.before do |req, res, ureq|
  ureq.set_header("Authorization", "Bearer " + ENV["OPENAI_KEY"])
  false                                  # true short-circuits
end
api.after            { |req, ures, res| Tep::Logger.info("up " + ures.status.to_s); 0 }
api.stream_request?  { |req| Tep::Json.get_bool(req.raw_body, "stream") }
api.on_stream_chunk  { |chunk, out, stats| out.write(chunk.chunk_text); 0 }
api.on_stream_end    { |req, out, stats| EVENTS.write(chunks: stats.chunk_count); 0 }
Tep.post "/v1/chat/completions", api
```

## What the translator does (bin/tep, top-level statement walk)

- Records `var = Tep::Proxy.new(ARG)` (normalising the doc's `upstream:` keyword to the positional arg the runtime takes).
- Collects `var.before/after/on_stream_chunk/on_stream_end/stream_request? do…end` blocks onto that proxy + suppresses them from passthrough (a receiver-method-with-block can't lower — spinel has no `PtrArray<Block>`).
- Emits one `TepProxy_<idx> < Tep::Proxy` subclass per proxy, block bodies as imeths (`before`/`after` → `before_forward`/`after_forward` to dodge the `Filter`/`Security`/`Auth` same-name dispatch collision; the rest 1:1), params + bodies verbatim — a thin sugar over the subclass-override form.
- Rewrites the assignment + `Tep.<verb> "path", var` mounts to a generated **constant** `TEPPROXY_<idx>`, not the local.

## Why a constant (not the local)

A `Tep::Proxy` subclass instance flowing through a **local** into `Tep.<verb>` widens `rewrite_path`'s virtual `path` param to poly, which — via spinel's file-wide name unification — poisons `Tep::App.guess_mime`'s `path` (`const char* = mrb_int` build error). The same instance via a **constant** compiles clean. Subclasses emit before passthrough (class-before-use); the constant assignment stays at its original position so its upstream arg can reference earlier top-level code.

## Test plan

- [x] `test/test_proxy_dsl.rb` — 4 tests: `before` short-circuit (403), `after` runs on the short-circuit path (audit header), no-hooks dead-upstream → 502, full five-hook set compiles + `stream_request?` gates.
- [x] Full `make test` — **421 runs, 0 failures, 0 errors** (52 skips), against fresh spinel master. Confirms the new statement-walk branches don't misfire on non-proxy apps.

## Notes

- The subclass-override form (6.1/6.2) is unchanged and still valid — the block DSL compiles to it.
- Use the proxy var only for mounts (the translator drops the local; it doesn't track other references).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)