### PR TITLE
feat(examples): llm_gateway — streaming proxy + per-request inference event (#100)

### DIFF
--- a/examples/llm_gateway/README.md
+++ b/examples/llm_gateway/README.md
@@ -1,0 +1,73 @@
+# llm_gateway — an LLM API gateway on `Tep::Proxy`
+
+Fronts a remote OpenAI-compatible upstream and adds, in ~40 lines of
+Ruby, the three things a gateway exists for:
+
+1. **Credential swap** — strips the client's `Authorization`, attaches
+   the server-side key (`before`). The upstream only ever sees the
+   gateway's key.
+2. **Transparent streaming** — `stream: true` requests are forwarded
+   over a held-open connection and the SSE events pass straight back
+   to the client, unbuffered (`stream_request?` + `on_stream_chunk`).
+3. **Per-request telemetry** — exactly one toy/v1 `inference` event
+   per request, emitted at end-of-stream (`on_stream_end` +
+   `Tep::Events`) — the right cardinality (one per request, not per
+   chunk), with token counts + latency.
+
+This is the showcase for proxy battery chunk 6.2 (streaming +
+`on_stream_end`) composed with `Tep::Events`. It uses the **block-form
+proxy DSL** (`gw.before do … end`), which `bin/tep` lowers to a
+`Tep::Proxy` subclass.
+
+## Run
+
+```sh
+UPSTREAM=https://api.openai.com \
+OPENAI_KEY=sk-... \
+EVENTS_JSONL=/tmp/gateway.events.jsonl \
+  bin/tep build examples/llm_gateway/app.rb -o /tmp/gw && /tmp/gw -p 4567
+```
+
+(Points at any OpenAI-compatible server — a local `ollama`, vLLM,
+llama.cpp's server, or the real OpenAI API. `EVENTS_JSONL` unset
+disables emission with zero overhead.)
+
+```sh
+# streaming chat completion — SSE passthrough + one inference event
+curl -s localhost:4567/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"gpt-4o-mini","stream":true,
+       "messages":[{"role":"user","content":"hi"}]}'
+
+tail -1 /tmp/gateway.events.jsonl
+# {"kind":"inference","phase":"serve","t":3,"model":"gpt-4o-mini",
+#  "prompt_tokens":0,"completion_tokens":42,"wall_us":3000000,
+#  "extra":{"request_id":"...","principal_id":"anonymous"}}
+```
+
+The events stream is the toy/v1 envelope, so a research-lab
+orchestrator (or any consumer of training/serving events) ingests it
+the same way it ingests a training run.
+
+## Notes / limits
+
+- **Streaming requires the scheduled server** (`set :scheduler,
+  :scheduled`) — the pump parks on `io_wait`, same as WebSocket.
+- **Token counts are approximate at the proxy:** `completion_tokens`
+  is the SSE-event count (no tokenizer here); `prompt_tokens` is left
+  0. A real gateway parses `delta.content` / the request `messages`.
+  The origin-server battery (`Tep::Llm::OpenAI::Server`) reports exact
+  counts from the backend.
+- **`wall_us` is second-resolution** (`Time.now` exposes only integer
+  epoch seconds; LLM requests are seconds-scale, so latency is still
+  meaningful). Sub-second timing would need a µs-clock primitive.
+- **Auth/capabilities** flow through `req.identity` like any tep
+  route — gate the gateway with `req.identity.may?(:call_upstream)` in
+  `before` if you want per-principal access control.
+
+## See also
+
+- [`docs/PROXY-BATTERY.md`](../../docs/PROXY-BATTERY.md) — the battery.
+- `lib/tep/events.rb` — the toy/v1 emitter.
+- `examples/api_gateway` — the non-streaming sibling (auth-attach +
+  observability), 6.3's other half.

--- a/examples/llm_gateway/app.rb
+++ b/examples/llm_gateway/app.rb
@@ -1,0 +1,89 @@
+# examples/llm_gateway -- an LLM API gateway built on Tep::Proxy.
+#
+# Fronts a remote OpenAI-compatible upstream: swaps the client's
+# credential for the server-side key, streams the SSE response back
+# unchanged, and emits ONE toy/v1 `inference` telemetry event per
+# request at end-of-stream (via Tep::Events). This is the payoff of
+# the proxy streaming battery (chunk 6.2) + the events emitter --
+# token-count + latency telemetry with the right cardinality (one
+# event per request, not per chunk), using on_stream_end as the
+# one-shot finalizer.
+#
+# Run:
+#   UPSTREAM=https://api.openai.com OPENAI_KEY=sk-... \
+#   EVENTS_JSONL=/tmp/gateway.events.jsonl \
+#     bin/tep build examples/llm_gateway/app.rb -o /tmp/gw && /tmp/gw -p 4567
+#
+#   # streaming chat completion -> SSE passthrough + one inference event
+#   curl -s localhost:4567/v1/chat/completions -H 'content-type: application/json' \
+#     -d '{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"hi"}]}'
+#   tail -1 /tmp/gateway.events.jsonl
+#   # {"kind":"inference","phase":"serve","t":3,"model":"gpt-4o-mini",
+#   #  "prompt_tokens":0,"completion_tokens":42,"wall_us":3000000,"extra":{...}}
+require 'sinatra'
+
+# Streaming proxying needs the cooperative server (the pump parks on
+# io_wait); same constraint as WebSocket.
+set :scheduler, :scheduled
+set :workers, 1
+
+UPSTREAM     = ENV["UPSTREAM"]   || "http://127.0.0.1:11434"   # e.g. a local ollama
+OPENAI_KEY   = ENV["OPENAI_KEY"] || ""
+EVENTS       = Tep::Events.new(ENV["EVENTS_JSONL"] || "")      # "" disables emission
+
+on_start do
+  EVENTS.run_start("gateway", "proxy", "upstream", UPSTREAM,
+                   "{\"server\":\"tep-llm-gateway\"}")
+end
+
+# Block-form proxy DSL (lowered to a Tep::Proxy subclass by bin/tep).
+gw = Tep::Proxy.new(UPSTREAM)
+
+# Swap the credential: strip whatever the client sent, attach the
+# server-side key. Also stamp a coarse start time for the latency
+# measurement in on_stream_end (req.ivars is per-request state).
+gw.before do |req, res, ureq|
+  if OPENAI_KEY.length > 0
+    ureq.set_header("Authorization", "Bearer " + OPENAI_KEY)
+  end
+  req.ivars["t0"] = Time.now.to_i.to_s
+  false
+end
+
+# Stream when the client asked for it. OpenAI signals streaming with
+# `"stream": true` in the JSON body; Tep::Json has no bool getter, so
+# we match the literal (with or without the space).
+gw.stream_request? do |req|
+  b = req.raw_body
+  b.include?("\"stream\":true") || b.include?("\"stream\": true")
+end
+
+# Pass each SSE event straight through. The framework's StreamStats
+# tracks chunk_count / byte_count for us (chunk_count ~ completion
+# tokens for this demo; a real gateway would parse delta.content).
+gw.on_stream_chunk do |chunk, out, stats|
+  out.write(chunk.chunk_text)
+  0
+end
+
+# One inference event at end-of-stream -- the right cardinality.
+gw.on_stream_end do |req, out, stats|
+  model = Tep::Json.get_str(req.raw_body, "model")
+  t0    = req.ivars["t0"].to_i
+  wall  = Time.now.to_i - t0
+  if wall < 0
+    wall = 0
+  end
+  extra = "{" +
+    Tep::Json.encode_pair_str("request_id", req.req_headers["x-request-id"]) + "," +
+    Tep::Json.encode_pair_str("principal_id", req.identity.principal_id) +
+  "}"
+  # prompt_tokens unknown at the proxy (no tokenizer); completion_tokens
+  # approximated by the SSE event count. wall_us is second-resolution
+  # (no µs clock) -- fine for seconds-scale LLM latency.
+  EVENTS.inference(model, 0, stats.chunk_count, wall * 1000000, extra)
+  0
+end
+
+Tep.get  "/v1/models",           gw
+Tep.post "/v1/chat/completions", gw

--- a/test/test_llm_gateway.rb
+++ b/test/test_llm_gateway.rb
@@ -1,0 +1,92 @@
+require_relative "helper"
+require "json"
+
+# examples/llm_gateway integration: a Tep::Proxy that streams an SSE
+# upstream through to the client AND emits one toy/v1 inference event
+# at end-of-stream via Tep::Events. Self-contained (self-call SSE
+# upstream, like test_proxy_streaming): proves proxy streaming +
+# Tep::Events compose -- the chunk-6.3 payoff.
+#
+# The example app itself uses the block DSL; here the gateway is the
+# subclass-override form so it can be built per-request with the
+# harness's runtime port (block-DSL proxies construct at load time,
+# before the port is known -- same reason test_proxy_streaming uses
+# in-handler construction).
+class TestLlmGateway < TepTest
+  EV_PATH = "/tmp/tep_gateway_test.jsonl"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    PATH = "#{EV_PATH}"
+    EVENTS = Tep::Events.new(PATH)
+
+    # Upstream: an OpenAI-shaped streaming chat completion.
+    class ChatSse < Tep::Streamer
+      def pump(out)
+        out.write("data: {\\"choices\\":[{\\"delta\\":{\\"content\\":\\"He\\"}}]}\\n\\n")
+        out.write("data: {\\"choices\\":[{\\"delta\\":{\\"content\\":\\"llo\\"}}]}\\n\\n")
+        out.write("data: [DONE]\\n\\n")
+      end
+    end
+
+    post '/v1/upstream' do
+      res.headers["Content-Type"] = "text/event-stream"
+      stream ChatSse.new
+    end
+
+    # The gateway: stream through + emit one inference event at end.
+    class Gateway < Tep::Proxy
+      def rewrite_path(path)
+        "/v1/upstream"
+      end
+      def stream_request?(req)
+        true
+      end
+      def on_stream_chunk(chunk, out, stats)
+        out.write(chunk.chunk_text)
+        0
+      end
+      def on_stream_end(req, out, stats)
+        model = Tep::Json.get_str(req.raw_body, "model")
+        extra = "{" + Tep::Json.encode_pair_str("request_id", "req-1") + "}"
+        EVENTS.inference(model, 0, stats.chunk_count, 1000000, extra)
+        0
+      end
+    end
+
+    post '/gw/:port' do
+      File.write(PATH, "")
+      Gateway.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/events' do
+      File.read(PATH)
+    end
+  RB
+
+  def test_streams_upstream_through_gateway
+    res = post("/gw/#{@port}", "{\"model\":\"demo-llm\",\"stream\":true}")
+    assert_equal "200", res.code
+    # The three upstream SSE events pass through unchanged.
+    assert_equal "data: {\"choices\":[{\"delta\":{\"content\":\"He\"}}]}\n\n" \
+                 "data: {\"choices\":[{\"delta\":{\"content\":\"llo\"}}]}\n\n" \
+                 "data: [DONE]\n\n", res.body
+  end
+
+  def test_emits_one_inference_event
+    post("/gw/#{@port}", "{\"model\":\"demo-llm\",\"stream\":true}")
+    lines = get("/events").body.split("\n").reject(&:empty?)
+    assert_equal 1, lines.length, "expected exactly one inference event"
+    ev = JSON.parse(lines[0])
+    assert_equal "inference", ev["kind"]
+    assert_equal "serve", ev["phase"]
+    assert_equal "demo-llm", ev["model"]
+    assert_equal 3, ev["completion_tokens"]   # 3 SSE events dispatched
+    assert_equal "req-1", ev["extra"]["request_id"]
+  end
+end


### PR DESCRIPTION
## Summary

Proxy battery **chunk 6.3** headline example — composes the just-shipped 6.2 streaming hooks with `Tep::Events`. A block-DSL `Tep::Proxy` fronting a remote OpenAI-compatible upstream:

- **before** — swap the client credential for the server-side `OPENAI_KEY`; stamp a per-request start time (`req.ivars`).
- **stream_request?** — opt into streaming on `"stream": true`.
- **on_stream_chunk** — pass each SSE event through (`StreamStats` counts).
- **on_stream_end** — emit **one** toy/v1 `inference` event via `Tep::Events` (model, `completion_tokens` ≈ chunk_count, `wall_us`, request/principal id). The right cardinality (one per request) — the #81 "why this is the seam" payoff.

Mounts `/v1/chat/completions` + `/v1/models`; ENV-configured (`UPSTREAM`/`OPENAI_KEY`/`EVENTS_JSONL`). README covers run + the emitted event + the honest approximations (proxy-side token counts, second-resolution `wall_us`).

## Test plan

- [x] `test/test_llm_gateway.rb` — self-contained smoke (self-call SSE upstream): stream passes through unchanged AND exactly one `inference` event is appended with the right fields (`completion_tokens=3`, model, request_id).
- [x] Full `make test`: **423 runs, 0 failures, 0 errors** (52 skips).

## Notes

- Streaming needs the scheduled server (the pump parks on `io_wait`).
- The example uses the **block-form proxy DSL** (#94) — the test uses the subclass-override form (in-handler construction for the harness's runtime port).
- `examples/api_gateway` (6.3's non-streaming half: auth-attach + observability) is the next follow-up.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)