### PR TITLE
feat(examples): api_gateway — capability-gated buffered proxy (#102)

### DIFF
--- a/docs/PROXY-BATTERY.md
+++ b/docs/PROXY-BATTERY.md
@@ -385,7 +385,7 @@ discovery on top of a proxy, they declare it explicitly
 |---|---|
 | **6.1** ✅ | `Tep::Proxy.new(upstream)` base; `before_forward` + `after_forward` overridable hooks; non-streaming bodies; hop-by-hop header stripping; connect-failure → 502; mount as `Tep::Handler` at any verb/path. Block-form DSL deferred to #88. |
 | **6.2** ✅ | Streaming proxy — `stream_request?` opt-in, chunked + SSE-aware `on_stream_chunk(chunk, out, stats)` (chunk = `StreamChunk`, read `chunk.chunk_text`), **`on_stream_end(req, out, stats)` finalizer** + carried `StreamStats`. Requires the scheduled server. |
-| **6.3** | `examples/api_gateway` (auth-attach + observability composition) + `examples/llm_gateway` (proxy a remote OpenAI with token-counting filter + per-request `inference` event emission via `on_stream_end`). |
+| **6.3** ✅ | `examples/api_gateway` (capability gate + auth-attach + observability, buffered path) + `examples/llm_gateway` (streaming proxy + per-request `inference` event via `on_stream_end` + `Tep::Events`). |
 | **6.4+** | Multi-upstream router helper, request-body buffering limits, automatic retries with exponential backoff (opt-in), upstream connection pooling. |
 
 ## Spinel-related risks

--- a/examples/api_gateway/README.md
+++ b/examples/api_gateway/README.md
@@ -1,0 +1,49 @@
+# api_gateway — a capability-gated API gateway on `Tep::Proxy`
+
+The non-streaming sibling of [`examples/llm_gateway`](../llm_gateway).
+Fronts an upstream HTTP API on the buffered (6.1) proxy path and adds
+the three jobs of a gateway in ~30 lines:
+
+1. **Authorization** — `before` short-circuits with `403` unless
+   `req.identity.may?(:call_upstream)`. The upstream is never hit for
+   a denied request.
+2. **Credential swap** — for an authorized request, strip the
+   client's key and attach the server-side one (`ureq.set_header`).
+3. **Observability** — `after` logs the call and stamps
+   `X-Proxy-Status` / `X-Proxy-Upstream` on the response — **including
+   for rejected requests** (`after` runs on the short-circuit path
+   too, so the audit log sees denials).
+
+Uses the **block-form proxy DSL** (`api.before do … end`), which
+`bin/tep` lowers to a `Tep::Proxy` subclass.
+
+## Run
+
+```sh
+UPSTREAM=https://api.example.com \
+UPSTREAM_KEY=secret \
+GATEWAY_KEY=let-me-in \
+  bin/tep build examples/api_gateway/app.rb -o /tmp/ag && /tmp/ag -p 4567
+
+curl -i localhost:4567/v1/data                          # 403, missing capability
+curl -i localhost:4567/v1/data -H 'x-api-key: let-me-in'  # forwarded with upstream key
+```
+
+Both responses carry `X-Proxy-Status` / `X-Proxy-Upstream`.
+
+## Notes
+
+- The `before do … end` filter granting `:call_upstream` on the
+  gateway key is a **stand-in** for the Auth battery — a real app
+  installs `Tep::Auth` (bearer JWT / session / OAuth2), which
+  populates `req.identity` the same way, so the `may?` gate is
+  unchanged.
+- One `Tep::Proxy` instance serves many routes; mount whatever paths
+  you proxy.
+- Non-streaming (buffered) — for SSE/streaming upstreams + per-request
+  telemetry, see `examples/llm_gateway`.
+
+## See also
+
+- [`docs/PROXY-BATTERY.md`](../../docs/PROXY-BATTERY.md) — the battery.
+- [`examples/llm_gateway`](../llm_gateway) — the streaming half of 6.3.

--- a/examples/api_gateway/app.rb
+++ b/examples/api_gateway/app.rb
@@ -1,0 +1,66 @@
+# examples/api_gateway -- a capability-gated API gateway on Tep::Proxy.
+#
+# The non-streaming sibling of examples/llm_gateway. Fronts an upstream
+# HTTP API and adds the three things a gateway exists for, on the
+# buffered (6.1) proxy path:
+#
+#   1. Authorization  -- gate on req.identity.may?(:call_upstream);
+#                        reject (403) before the upstream is ever hit.
+#   2. Credential swap -- strip the client's key, attach the server's.
+#   3. Observability   -- log + stamp X-Proxy-* headers on the way out,
+#                         including for rejected requests (audit).
+#
+# Run:
+#   UPSTREAM=https://api.example.com UPSTREAM_KEY=secret \
+#   GATEWAY_KEY=let-me-in \
+#     bin/tep build examples/api_gateway/app.rb -o /tmp/ag && /tmp/ag -p 4567
+#
+#   curl -i localhost:4567/v1/data                       # 403 (no key)
+#   curl -i localhost:4567/v1/data -H 'x-api-key: let-me-in'   # forwarded
+require 'sinatra'
+
+UPSTREAM     = ENV["UPSTREAM"]     || "http://127.0.0.1:8080"
+UPSTREAM_KEY = ENV["UPSTREAM_KEY"] || ""
+GATEWAY_KEY  = ENV["GATEWAY_KEY"]  || "let-me-in"
+LOGGER       = Tep::Logger.new   # stderr; .to_file(path) to redirect
+
+# Stand-in for the Auth battery: grant :call_upstream to callers
+# presenting the gateway key. A real app installs Tep::Auth (bearer
+# JWT / session / OAuth2), which populates req.identity the same way.
+before do
+  if req.req_headers["x-api-key"] == GATEWAY_KEY
+    req.identity = Tep::Identity.new("client:demo", nil, [:call_upstream])
+  end
+end
+
+api = Tep::Proxy.new(UPSTREAM)
+
+# Capability gate + credential swap. Returning true short-circuits --
+# the upstream is never called; res (set here) goes straight back.
+api.before do |req, res, ureq|
+  if !req.identity.may?(:call_upstream)
+    res.set_status(403)
+    res.set_body("{\"error\":\"missing capability: call_upstream\"}")
+    true
+  else
+    if UPSTREAM_KEY.length > 0
+      ureq.set_header("Authorization", "Bearer " + UPSTREAM_KEY)
+    end
+    false
+  end
+end
+
+# Observability. Runs on the forwarded path AND the short-circuit path
+# (ures.status is 0 when before_forward rejected) -- so the audit log
+# sees denied requests too.
+api.after do |req, ures, res|
+  res.headers["X-Proxy-Status"]   = ures.status.to_s
+  res.headers["X-Proxy-Upstream"] = UPSTREAM
+  LOGGER.info("[api_gateway] " + req.verb + " " + req.raw_path +
+              " -> " + ures.status.to_s)
+  0
+end
+
+# Mount whatever paths you proxy (one instance serves many).
+Tep.get  "/v1/data",   api
+Tep.post "/v1/submit", api

--- a/test/test_api_gateway.rb
+++ b/test/test_api_gateway.rb
@@ -1,0 +1,76 @@
+require_relative "helper"
+
+# examples/api_gateway integration: a non-streaming Tep::Proxy that
+# gates on a capability (before_forward short-circuit), swaps the
+# upstream credential, and stamps observability headers in
+# after_forward -- which must run on BOTH the forwarded and the
+# short-circuited (denied) paths.
+#
+# Self-call shape (scheduled + workers=1, like test_http/test_proxy):
+# the upstream echoes the Authorization header it received, so the
+# test can confirm the credential swap; the gateway is the
+# subclass-override form, built per-request with the runtime port
+# (the example app uses the block DSL).
+class TestApiGateway < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # Upstream: echo the Authorization header the gateway attached.
+    get '/up/echo' do
+      "auth=" + req.req_headers["authorization"]
+    end
+
+    # Grant :call_upstream when the request carries ?auth=ok (stands in
+    # for the Auth battery populating req.identity).
+    before do
+      if params[:auth] == "ok"
+        req.identity = Tep::Identity.new("client:test", nil, [:call_upstream])
+      end
+    end
+
+    class ApiGw < Tep::Proxy
+      def rewrite_path(path)
+        "/up/echo"
+      end
+      def before_forward(req, res, ureq)
+        if !req.identity.may?(:call_upstream)
+          res.set_status(403)
+          res.set_body("denied")
+          true
+        else
+          ureq.set_header("Authorization", "Bearer upstream-secret")
+          false
+        end
+      end
+      def after_forward(req, ures, res)
+        res.headers["X-Proxy-Status"] = ures.status.to_s
+        0
+      end
+    end
+
+    get '/gw/:port' do
+      ApiGw.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+  RB
+
+  def test_forwards_with_credential_when_capable
+    res = get("/gw/#{@port}?auth=ok")
+    assert_equal "200", res.code
+    # Upstream saw the gateway's attached credential, not the client's.
+    assert_equal "auth=Bearer upstream-secret", res.body
+    # after_forward stamped the real upstream status.
+    assert_equal "200", res["X-Proxy-Status"]
+  end
+
+  def test_rejects_without_capability
+    res = get("/gw/#{@port}")           # no ?auth=ok -> no capability
+    assert_equal "403", res.code
+    assert_equal "denied", res.body
+    # after_forward ran on the short-circuit path too (ures.status 0).
+    assert_equal "0", res["X-Proxy-Status"]
+  end
+end


### PR DESCRIPTION
Completes proxy **chunk 6.3** (non-streaming sibling of llm_gateway). Block-DSL `Tep::Proxy` on the buffered path: `before` capability-gates (403 short-circuit unless `may?(:call_upstream)`) + swaps the upstream credential; `after` stamps `X-Proxy-Status`/`X-Proxy-Upstream` on both paths (audit sees denials). + README + self-call smoke test (credential swap, 403 without cap, after on both paths). Full `make test`: **425 runs, 0 failures**. Marks 6.3 ✅.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)