### PR TITLE
feat(openai-server): Backend + use/serve! + /v1/models (7.1a, #104)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -64,6 +64,7 @@ require_relative "tep/http"
 require_relative "tep/proxy"
 require_relative "tep/events"
 require_relative "tep/llm"
+require_relative "tep/openai_server"
 require_relative "tep/websocket"
 require_relative "tep/parallel"
 require_relative "tep/job"
@@ -589,6 +590,20 @@ module Tep
   _tep_seed_events.run_end("ok")
   _tep_seed_events.rel_t
   Sock.sphttp_iso8601_utc(0)
+
+  # Tep::Llm::OpenAI::Server seed (Battery 7, chunk 7.1a). Pin the
+  # Backend slot + interface + the ModelsHandler dispatch through
+  # APP.openai_backend. serve! is NOT called here -- it mounts a route
+  # (a global side effect); its types self-pin from its body.
+  _tep_seed_oai_backend = Tep::Llm::OpenAI::Backend.new
+  Tep::APP.set_openai_backend(_tep_seed_oai_backend)
+  Tep::Llm::OpenAI::Server.use(_tep_seed_oai_backend)
+  _tep_seed_oai_backend.list_models
+  _tep_seed_oai_backend.supports_chat?
+  _tep_seed_oai_backend.device_kind
+  _tep_seed_oai_backend.supports_embeddings?
+  _tep_seed_oai_models = Tep::Llm::OpenAI::ModelsHandler.new
+  _tep_seed_oai_models.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -51,6 +51,12 @@ module Tep
     attr_accessor :broadcast_pg_enabled
     attr_accessor :broadcast_pg_channel
     attr_accessor :broadcast_pg_conn
+    # Tep::Llm::OpenAI::Server backend (Battery 7). Set by
+    # Server.use(backend) at boot; the route handlers dispatch through
+    # it per request. Seeded with a base Backend in lib/tep.rb (after
+    # openai_server.rb loads -- not in initialize, since the class
+    # isn't defined yet there), same pattern as broadcast_pg_conn.
+    attr_accessor :openai_backend
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -151,6 +157,7 @@ module Tep
     def set_presence_pg_enabled(v);   @presence_pg_enabled   = v; end
     def set_presence_pg_worker_id(s); @presence_pg_worker_id = s; end
     def set_presence_pg_conn(c);      @presence_pg_conn      = c; end
+    def set_openai_backend(b);        @openai_backend        = b; end
     def set_not_found(h);         @nf_handler = h; end
 
     def dispatch(req, res)

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -1,0 +1,103 @@
+# Tep::Llm::OpenAI::Server -- serve OpenAI-compatible HTTP from local
+# compute (Battery 7). Unlike Tep::Proxy there's no upstream: the route
+# + events shell is tep, the actual inference is a pluggable Backend an
+# app supplies. See docs/OPENAI-SERVER-BATTERY.md.
+#
+# Chunk 7.1a (this file): the Backend interface apps subclass, the
+# Server.use / .serve! DSL, and GET /v1/models. Token-level completions
+# (/v1/completions), events emission, and streaming land in later
+# chunks (7.1b / 7.2).
+#
+#   class ToyBackend < Tep::Llm::OpenAI::Backend
+#     def list_models; ["smollm2-135m"]; end
+#     # generate_from_tokens / device_kind / ... overridden as needed
+#   end
+#   Tep::Llm::OpenAI::Server.use(ToyBackend.new)
+#   Tep::Llm::OpenAI::Server.serve!
+#
+# Why subclass-and-override + `use(ConcreteBackend.new)`: the concrete
+# instance flows into the APP.openai_backend slot from the user's
+# `.new`, so spinel's observed-class set includes it and the route's
+# `APP.openai_backend.list_models` dispatches to the override (verified
+# spike). Same shape Tep::LiveView uses for its view instances.
+module Tep
+  class Llm
+    module OpenAI
+      # The interface an app's backend implements. Defaults make a
+      # bare backend safe to compile + serve (empty model list, chat
+      # unsupported, cpu device). Subclasses override what they offer.
+      class Backend
+        # Available model names -> [String]. /v1/models wraps these.
+        def list_models
+          empty = [""]
+          empty.delete_at(0)
+          empty
+        end
+
+        # Does this backend implement message-level (chat) generation?
+        # When false, /v1/chat/completions returns 501. (The chat
+        # template is per-model + an ML concern; tep doesn't ship one.)
+        def supports_chat?
+          false
+        end
+
+        # Backend's device, surfaced into the run_start event's
+        # backend.kind at serve! time. Defaults to cpu.
+        def device_kind
+          "cpu"
+        end
+
+        # Backends that can embed override this -> true (gates
+        # /v1/embeddings, chunk 7.3).
+        def supports_embeddings?
+          false
+        end
+      end
+
+      # The mountable server. Class methods because an app wires one
+      # backend per process at boot (`use`) then mounts the standard
+      # routes (`serve!`).
+      class Server
+        # Register the app's backend. Pass a concrete Backend subclass
+        # instance; it's stored on Tep::APP and dispatched per request.
+        def self.use(backend)
+          Tep::APP.set_openai_backend(backend)
+          0
+        end
+
+        # Mount the standard OpenAI routes. 7.1a: GET /v1/models.
+        # Later chunks add /v1/completions (+ events) and the
+        # chat/embeddings routes.
+        def self.serve!
+          Tep.get("/v1/models", Tep::Llm::OpenAI::ModelsHandler.new)
+          0
+        end
+      end
+
+      # GET /v1/models -- the standard OpenAI list envelope, built from
+      # backend.list_models. Dispatches through APP.openai_backend so
+      # the app's subclass override is what answers.
+      class ModelsHandler < Tep::Handler
+        def handle(req, res)
+          res.headers["Content-Type"] = "application/json"
+          models = Tep::APP.openai_backend.list_models
+          out = "{\"object\":\"list\",\"data\":["
+          i = 0
+          while i < models.length
+            if i > 0
+              out = out + ","
+            end
+            out = out + "{" +
+              Tep::Json.encode_pair_str("id", models[i]) + "," +
+              Tep::Json.encode_pair_str("object", "model") + "," +
+              Tep::Json.encode_pair_str("owned_by", "tep") +
+            "}"
+            i += 1
+          end
+          out = out + "]}"
+          out
+        end
+      end
+    end
+  end
+end

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -1,0 +1,46 @@
+require_relative "helper"
+require "json"
+
+# Tep::Llm::OpenAI::Server skeleton (chunk 7.1a): a Backend subclass
+# wired via Server.use, served via Server.serve!, answering GET
+# /v1/models. Proves the use/serve! DSL + that the route dispatches to
+# the app's Backend *override* (APP.openai_backend slot, concrete
+# instance flowed in via use -- the spiked dispatch path).
+class TestOpenAIServer < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    class EchoBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["echo-1", "echo-2"]
+      end
+      def device_kind
+        "cpu"
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EchoBackend.new)
+    Tep::Llm::OpenAI::Server.serve!
+  RB
+
+  def test_models_lists_backend_models
+    res = get("/v1/models")
+    assert_equal "200", res.code
+    assert_match(%r{application/json}, res["content-type"])
+    body = JSON.parse(res.body)
+    assert_equal "list", body["object"]
+    ids = body["data"].map { |m| m["id"] }
+    assert_equal ["echo-1", "echo-2"], ids
+    assert_equal "model", body["data"][0]["object"]
+    assert_equal "tep",   body["data"][0]["owned_by"]
+  end
+
+  def test_models_dispatches_to_subclass_override
+    # The base Backend#list_models returns []; getting echo-1/echo-2
+    # back proves the EchoBackend override is what answered (backend
+    # dispatch through the APP slot reaches the subclass).
+    ids = JSON.parse(get("/v1/models").body)["data"].map { |m| m["id"] }
+    refute_empty ids, "route hit the base Backend (empty), not the override"
+    assert_includes ids, "echo-1"
+  end
+end


### PR DESCRIPTION
First chunk of Battery 7 — the skeleton. `Tep::Llm::OpenAI::Backend` (interface apps subclass) + `Server.use`/`.serve!` + `GET /v1/models`. Backend dispatch through the `APP.openai_backend` slot reaches the subclass override (spiked — concrete `.new` flows in, #513 observed-class narrowing); 3-level namespace verified. Test: EchoBackend override -> /v1/models lists its models. Full `make test`: **427 runs, 0 failures**. Next: 7.1b (/v1/completions + generate_from_tokens + events).

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)