### PR TITLE
feat(openai-server): POST /v1/completions + generate_from_tokens (7.1b, #106)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -604,6 +604,14 @@ module Tep
   _tep_seed_oai_backend.supports_embeddings?
   _tep_seed_oai_models = Tep::Llm::OpenAI::ModelsHandler.new
   _tep_seed_oai_models.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
+  # 7.1b /v1/completions surface.
+  Tep::Json.get_int_array("{}", "prompt")
+  _tep_seed_oai_sampling = Tep::Llm::OpenAI::Sampling.new
+  _tep_seed_oai_sampling.max_tokens = 0
+  _tep_seed_oai_comp = Tep::Llm::OpenAI::Completion.new
+  _tep_seed_oai_backend.generate_from_tokens("m", Tep::Json.get_int_array("{}", "prompt"), _tep_seed_oai_sampling)
+  _tep_seed_oai_completions = Tep::Llm::OpenAI::CompletionsHandler.new
+  _tep_seed_oai_completions.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/json.rb
+++ b/lib/tep/json.rb
@@ -208,6 +208,50 @@ module Tep
       Json.find_value_start(s, key) >= 0
     end
 
+    # Decode a flat JSON array of integers at `key` -> Array[Integer].
+    # The `prompt` of /v1/completions is a token-id array
+    # (`[464, 6193, ...]`). A missing or non-array value yields []
+    # (the tep typed-empty-array idiom); non-int elements are skipped.
+    def self.get_int_array(s, key)
+      out = [0]
+      out.delete_at(0)
+      pos = Json.find_value_start(s, key)
+      if pos < 0
+        return out
+      end
+      pos = Json.skip_ws(s, pos)
+      if pos >= s.length || s[pos] != "["
+        return out
+      end
+      pos += 1
+      while pos < s.length
+        pos = Json.skip_ws(s, pos)
+        if pos >= s.length
+          return out
+        end
+        c = s[pos]
+        if c == "]"
+          return out
+        elsif c == ","
+          pos += 1
+        elsif (c >= "0" && c <= "9") || c == "-"
+          out.push(Json.parse_int_value(s, pos))
+          # Advance past the number parse_int_value just consumed
+          # (optional '-' then digits).
+          if s[pos] == "-"
+            pos += 1
+          end
+          while pos < s.length && s[pos] >= "0" && s[pos] <= "9"
+            pos += 1
+          end
+        else
+          # Non-int element (string / object / etc.): skip it.
+          pos = Json.skip_value(s, pos)
+        end
+      end
+      out
+    end
+
     # ---- Internal helpers ----
 
     # Skip whitespace starting at `pos`, return the new position.

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -34,6 +34,18 @@ module Tep
           empty
         end
 
+        # PRIMARY shape: token-level generation (maps to
+        # /v1/completions). `token_ids` is the encoded prompt
+        # (Array[Integer]); `sampling` is a Tep::Llm::OpenAI::Sampling.
+        # Returns a Tep::Llm::OpenAI::Completion (text + usage). This
+        # 7.1b form is non-streaming -- it returns the full result;
+        # the per-token block-yield variant for SSE lands in 7.2. The
+        # base returns an empty completion so a bare backend compiles;
+        # real backends override.
+        def generate_from_tokens(model, token_ids, sampling)
+          Tep::Llm::OpenAI::Completion.new
+        end
+
         # Does this backend implement message-level (chat) generation?
         # When false, /v1/chat/completions returns 501. (The chat
         # template is per-model + an ML concern; tep doesn't ship one.)
@@ -66,11 +78,36 @@ module Tep
         end
 
         # Mount the standard OpenAI routes. 7.1a: GET /v1/models.
-        # Later chunks add /v1/completions (+ events) and the
-        # chat/embeddings routes.
+        # 7.1b: POST /v1/completions. Later chunks add events, the
+        # chat route (501-gated on supports_chat?), and embeddings.
         def self.serve!
-          Tep.get("/v1/models", Tep::Llm::OpenAI::ModelsHandler.new)
+          Tep.get("/v1/models",       Tep::Llm::OpenAI::ModelsHandler.new)
+          Tep.post("/v1/completions", Tep::Llm::OpenAI::CompletionsHandler.new)
           0
+        end
+      end
+
+      # Sampling parameters handed to the backend. v1 carries max_tokens
+      # (the int tep needs to bound generation); temperature / top_p are
+      # JSON-number floats, which tep can't represent natively (no
+      # Float) -- a float-capable chunk adds them. A backend that needs
+      # them today reads the raw request body itself.
+      class Sampling
+        attr_accessor :max_tokens
+
+        def initialize
+          @max_tokens = 0
+        end
+      end
+
+      # A backend's generation result: the decoded text + token usage.
+      class Completion
+        attr_accessor :text, :prompt_tokens, :completion_tokens
+
+        def initialize
+          @text              = ""
+          @prompt_tokens     = 0
+          @completion_tokens = 0
         end
       end
 
@@ -96,6 +133,42 @@ module Tep
           end
           out = out + "]}"
           out
+        end
+      end
+
+      # POST /v1/completions -- token-level OpenAI shape (the primary
+      # completion route). Parses model / prompt (token ids) /
+      # max_tokens, calls backend.generate_from_tokens, and formats the
+      # standard text_completion response. Dispatches through
+      # APP.openai_backend (the app's subclass override answers).
+      class CompletionsHandler < Tep::Handler
+        def handle(req, res)
+          res.headers["Content-Type"] = "application/json"
+          body      = req.raw_body
+          model     = Tep::Json.get_str(body, "model")
+          token_ids = Tep::Json.get_int_array(body, "prompt")
+          sampling  = Tep::Llm::OpenAI::Sampling.new
+          sampling.max_tokens = Tep::Json.get_int(body, "max_tokens")
+
+          comp = Tep::APP.openai_backend.generate_from_tokens(model, token_ids, sampling)
+          total = comp.prompt_tokens + comp.completion_tokens
+
+          "{" +
+            Tep::Json.encode_pair_str("id", "cmpl-tep") + "," +
+            Tep::Json.encode_pair_str("object", "text_completion") + "," +
+            Tep::Json.encode_pair_int("created", Time.now.to_i) + "," +
+            Tep::Json.encode_pair_str("model", model) + "," +
+            "\"choices\":[{" +
+              Tep::Json.encode_pair_int("index", 0) + "," +
+              Tep::Json.encode_pair_str("text", comp.text) + "," +
+              Tep::Json.encode_pair_str("finish_reason", "stop") +
+            "}]," +
+            "\"usage\":{" +
+              Tep::Json.encode_pair_int("prompt_tokens", comp.prompt_tokens) + "," +
+              Tep::Json.encode_pair_int("completion_tokens", comp.completion_tokens) + "," +
+              Tep::Json.encode_pair_int("total_tokens", total) +
+            "}" +
+          "}"
         end
       end
     end

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -17,6 +17,13 @@ class TestOpenAIServer < TepTest
       def device_kind
         "cpu"
       end
+      def generate_from_tokens(model, token_ids, sampling)
+        c = Tep::Llm::OpenAI::Completion.new
+        c.text              = "echoed " + token_ids.length.to_s + " tokens"
+        c.prompt_tokens     = token_ids.length
+        c.completion_tokens = sampling.max_tokens
+        c
+      end
     end
 
     Tep::Llm::OpenAI::Server.use(EchoBackend.new)
@@ -42,5 +49,20 @@ class TestOpenAIServer < TepTest
     ids = JSON.parse(get("/v1/models").body)["data"].map { |m| m["id"] }
     refute_empty ids, "route hit the base Backend (empty), not the override"
     assert_includes ids, "echo-1"
+  end
+
+  def test_completions_returns_text_completion
+    res = post("/v1/completions",
+               "{\"model\":\"echo-1\",\"prompt\":[10,20,30],\"max_tokens\":5}")
+    assert_equal "200", res.code
+    body = JSON.parse(res.body)
+    assert_equal "text_completion", body["object"]
+    assert_equal "echo-1", body["model"]
+    # generate_from_tokens saw the 3-token prompt + max_tokens=5.
+    assert_equal "echoed 3 tokens", body["choices"][0]["text"]
+    assert_equal "stop", body["choices"][0]["finish_reason"]
+    assert_equal 3, body["usage"]["prompt_tokens"]
+    assert_equal 5, body["usage"]["completion_tokens"]
+    assert_equal 8, body["usage"]["total_tokens"]
   end
 end


### PR DESCRIPTION
Token-level completion path. Adds `Tep::Json.get_int_array` (prompt is a token-id array), `Sampling`/`Completion`, `Backend#generate_from_tokens`, and `POST /v1/completions` (OpenAI text_completion response). Float-free (max_tokens int; temperature deferred). Test: EchoBackend -> correct text_completion + usage. Full `make test`: **428 runs, 0 failures**. Next: 7.1c (events, closes #80).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)