### PR TITLE
feat(openai-server): emit toy/v1 events (run_start + per-request inference) (#110)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -597,6 +597,10 @@ module Tep
   # (a global side effect); its types self-pin from its body.
   _tep_seed_oai_backend = Tep::Llm::OpenAI::Backend.new
   Tep::APP.set_openai_backend(_tep_seed_oai_backend)
+  # 7.1c openai_events slot. Re-uses _tep_seed_events (already declared
+  # above as the Tep::Events seed). Pins APP.openai_events so the route
+  # handlers' `Tep::APP.openai_events.inference(...)` dispatch resolves.
+  Tep::APP.set_openai_events(_tep_seed_events)
   Tep::Llm::OpenAI::Server.use(_tep_seed_oai_backend)
   _tep_seed_oai_backend.list_models
   _tep_seed_oai_backend.supports_chat?

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -57,6 +57,10 @@ module Tep
     # openai_server.rb loads -- not in initialize, since the class
     # isn't defined yet there), same pattern as broadcast_pg_conn.
     attr_accessor :openai_backend
+    # Tep::Events emitter for the openai-server (7.1c). Configured by
+    # Server.serve!(events_jsonl); empty path => zero-overhead disabled.
+    # Late-seeded for the same reason as openai_backend.
+    attr_accessor :openai_events
     attr_accessor :asset_bodies, :asset_mimes
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
@@ -158,6 +162,7 @@ module Tep
     def set_presence_pg_worker_id(s); @presence_pg_worker_id = s; end
     def set_presence_pg_conn(c);      @presence_pg_conn      = c; end
     def set_openai_backend(b);        @openai_backend        = b; end
+    def set_openai_events(e);         @openai_events         = e; end
     def set_not_found(h);         @nf_handler = h; end
 
     def dispatch(req, res)

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -77,10 +77,27 @@ module Tep
           0
         end
 
-        # Mount the standard OpenAI routes. 7.1a: GET /v1/models.
-        # 7.1b: POST /v1/completions. Later chunks add events, the
-        # chat route (501-gated on supports_chat?), and embeddings.
-        def self.serve!
+        # Mount the standard OpenAI routes + (optionally) start the
+        # toy/v1 events stream. `events_jsonl` is a JSONL path the
+        # per-request inference event + the run_start at boot append
+        # to; an empty path (the default) disables emission with zero
+        # overhead. Backwards-compatible with the 7.1a/b no-arg form.
+        def self.serve!(events_jsonl = "")
+          events = Tep::Events.new(events_jsonl)
+          Tep::APP.set_openai_events(events)
+          host = ENV["HOSTNAME"]
+          if host.length == 0
+            host = "tep"
+          end
+          # backend.device_kind => the run_start's `backend.kind`; reads
+          # the backend via APP.openai_backend so a `use`d subclass's
+          # override answers (e.g. ToyBackend returning "cuda").
+          backend_kind = Tep::APP.openai_backend.device_kind
+          config_json = "{" +
+            Tep::Json.encode_pair_str("server", "tep-llm-openai") + "," +
+            Tep::Json.encode_pair_str("events_jsonl", events_jsonl) +
+          "}"
+          events.run_start(host, backend_kind, "", "", config_json)
           Tep.get("/v1/models",       Tep::Llm::OpenAI::ModelsHandler.new)
           Tep.post("/v1/completions", Tep::Llm::OpenAI::CompletionsHandler.new)
           0
@@ -150,8 +167,29 @@ module Tep
           sampling  = Tep::Llm::OpenAI::Sampling.new
           sampling.max_tokens = Tep::Json.get_int(body, "max_tokens")
 
+          # Stamp t0 for the inference event's wall_us. Time.now exposes
+          # only integer epoch seconds under spinel, so wall_us is at
+          # second-resolution (latency * 1_000_000) -- coarse, but LLM
+          # serving is seconds-scale, fine for the run-level analytics.
+          # A µs clock helper lands later; until then this is the right
+          # placeholder shape so consumers see populated wall_us.
+          t0 = Time.now.to_i
+
           comp = Tep::APP.openai_backend.generate_from_tokens(model, token_ids, sampling)
           total = comp.prompt_tokens + comp.completion_tokens
+
+          # Emit one inference event per request. Skipped when events
+          # are disabled via path-length short-circuit inside #inference.
+          # request_id matches the JSON response's id; principal_id is
+          # the auth-filter populated identity (anonymous if none).
+          wall_us = (Time.now.to_i - t0) * 1_000_000
+          extra = "{" +
+            Tep::Json.encode_pair_str("request_id", "cmpl-tep") + "," +
+            Tep::Json.encode_pair_str("principal_id", req.identity.subject) +
+          "}"
+          Tep::APP.openai_events.inference(
+            model, comp.prompt_tokens, comp.completion_tokens, wall_us, extra
+          )
 
           "{" +
             Tep::Json.encode_pair_str("id", "cmpl-tep") + "," +

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -66,3 +66,80 @@ class TestOpenAIServer < TepTest
     assert_equal 8, body["usage"]["total_tokens"]
   end
 end
+
+# Tep::Llm::OpenAI::Server events emission (chunk 7.1c): with a
+# non-empty events_jsonl path, serve! emits one run_start at boot and
+# CompletionsHandler emits one inference per /v1/completions request.
+# Disabled (empty path) leaves zero footprint -- exercised by the
+# TestOpenAIServer class above, which doesn't pass an events arg.
+class TestOpenAIServerEvents < TepTest
+  EVENTS_PATH = "/tmp/tep_test_openai_events.jsonl"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    class EchoBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["echo-1"]
+      end
+      def device_kind
+        "cpu"
+      end
+      def generate_from_tokens(model, token_ids, sampling)
+        c = Tep::Llm::OpenAI::Completion.new
+        c.text              = "echoed " + token_ids.length.to_s + " tokens"
+        c.prompt_tokens     = token_ids.length
+        c.completion_tokens = sampling.max_tokens
+        c
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EchoBackend.new)
+    Tep::Llm::OpenAI::Server.serve!("#{EVENTS_PATH}")
+  RB
+
+  # Wipe the events file ONCE, before the lazy boot. boot! is memoised
+  # so serve!'s run_start only emits on the first setup call; deleting
+  # the file after boot would lose the run_start the test asserts on.
+  # A leftover file from a previous `make test` run would otherwise
+  # poison the inference-count assertion.
+  @@events_path_cleaned = false
+  def setup
+    unless @@events_path_cleaned
+      File.delete(EVENTS_PATH) if File.exist?(EVENTS_PATH)
+      @@events_path_cleaned = true
+    end
+    super
+  end
+
+  def test_events_jsonl_populated
+    # serve! ran during binary boot -> a run_start should already be on
+    # disk before we make any request. (The test harness boots the
+    # compiled binary before this method runs.)
+    assert File.exist?(EVENTS_PATH), "events file not created at serve!"
+    lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
+    rs = lines.find { |e| e["kind"] == "run_start" }
+    refute_nil rs, "no run_start emitted"
+    assert_equal "toy/v1", rs["schema"]
+    assert_equal "cpu",    rs["backend"]["kind"]
+
+    # POST /v1/completions -> exactly one inference event appended.
+    res = post("/v1/completions",
+               "{\"model\":\"echo-1\",\"prompt\":[1,2,3,4],\"max_tokens\":7}")
+    assert_equal "200", res.code
+
+    lines2 = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
+    inferences = lines2.select { |e| e["kind"] == "inference" }
+    assert_equal 1, inferences.length, "expected exactly one inference event"
+    inf = inferences[0]
+    assert_equal "serve",  inf["phase"]
+    assert_equal "echo-1", inf["model"]
+    assert_equal 4,        inf["prompt_tokens"]
+    assert_equal 7,        inf["completion_tokens"]
+    assert_kind_of Integer, inf["wall_us"]
+    assert inf["wall_us"] >= 0
+    extra = inf["extra"]
+    assert_equal "cmpl-tep", extra["request_id"]
+    assert_match(/\Auser:/, extra["principal_id"])
+  end
+end


### PR DESCRIPTION
Battery 7 chunk 7.1c: wires the existing `Tep::Events` JSONL emitter
into `Tep::Llm::OpenAI::Server`. Non-streaming half of #80; streaming
inference (post-`[DONE]`) lands with 7.2, `run_end` waits on a clean
shutdown hook (deferred).

## What

- `Server.serve!(events_jsonl = "")` — positional default keeps 7.1a/b
  callers unbroken. Builds `Tep::Events`, stashes on APP, emits
  `run_start` (host, backend.kind from `device_kind`, server +
  events path in `config`).
- `APP.openai_events` accessor + `set_openai_events` setter; slot
  pinned in lib/tep.rb against the existing `_tep_seed_events`.
- `CompletionsHandler.handle`: stamps `t0` before backend call,
  emits one `inference` event after — model, token counts,
  `wall_us = (Time.now - t0)*1e6`, `extra{request_id, principal_id}`.
  Coarse second-resolution latency (spinel `Time.now` is epoch-int
  only); LLM is seconds-scale, populated `wall_us` is enough signal.
- Disabled (`""`) stays zero-overhead — `Tep::Events` path-length
  short-circuits before any File I/O.

## Test

New `TestOpenAIServerEvents`: asserts `run_start` (boot) +
exactly one `inference` event with the right fields after a
`POST /v1/completions`. Existing `TestOpenAIServer` keeps the no-arg
`serve!` — covers the disabled path implicitly.

## Suite

Full parallel: **429 runs, 963 assertions, 0 failures, 52 skips**
(was 428, +1 from the new test).

Refs #80