### PR TITLE
feat(openai-server): streaming /v1/completions (SSE + per-token + inference-on-[DONE]) (closes #80)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -616,6 +616,30 @@ module Tep
   _tep_seed_oai_backend.generate_from_tokens("m", Tep::Json.get_int_array("{}", "prompt"), _tep_seed_oai_sampling)
   _tep_seed_oai_completions = Tep::Llm::OpenAI::CompletionsHandler.new
   _tep_seed_oai_completions.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
+  # 7.2 streaming completions: pin StreamSink + CompletionsStreamer
+  # slots + exercise the backend's generate_stream_from_tokens(sink)
+  # arity so the param type resolves. emit_token is called against a
+  # fd=-1 Stream -- the seed never runs the actual write (the streamer
+  # pump is never invoked at boot), it just gives spinel the surface.
+  _tep_seed_oai_stream = Tep::Stream.new(-1)
+  _tep_seed_oai_sink = Tep::Llm::OpenAI::StreamSink.new
+  _tep_seed_oai_sink.out   = _tep_seed_oai_stream
+  _tep_seed_oai_sink.model = "m"
+  _tep_seed_oai_sink.completion_count
+  # emit_token call site pins the `piece` parameter to String. fd=-1
+  # makes the underlying sphttp_write_chunk a harmless EBADF at boot.
+  _tep_seed_oai_sink.emit_token("seed")
+  _tep_seed_oai_backend.generate_stream_from_tokens(
+    "m", Tep::Json.get_int_array("{}", "prompt"), _tep_seed_oai_sampling, _tep_seed_oai_sink)
+  _tep_seed_oai_cstreamer = Tep::Llm::OpenAI::CompletionsStreamer.new
+  _tep_seed_oai_cstreamer.model         = "m"
+  _tep_seed_oai_cstreamer.token_ids     = Tep::Json.get_int_array("{}", "prompt")
+  _tep_seed_oai_cstreamer.sampling      = _tep_seed_oai_sampling
+  _tep_seed_oai_cstreamer.prompt_tokens = 0
+  _tep_seed_oai_cstreamer.t0            = 0
+  _tep_seed_oai_cstreamer.request_id    = ""
+  _tep_seed_oai_cstreamer.principal_id  = ""
+  _tep_seed_proxy_res.start_stream(_tep_seed_oai_cstreamer)
 
   # Tep::Shell.write seed.
   Tep::Shell.write("/dev/null", "")

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -35,15 +35,27 @@ module Tep
         end
 
         # PRIMARY shape: token-level generation (maps to
-        # /v1/completions). `token_ids` is the encoded prompt
-        # (Array[Integer]); `sampling` is a Tep::Llm::OpenAI::Sampling.
-        # Returns a Tep::Llm::OpenAI::Completion (text + usage). This
-        # 7.1b form is non-streaming -- it returns the full result;
-        # the per-token block-yield variant for SSE lands in 7.2. The
-        # base returns an empty completion so a bare backend compiles;
-        # real backends override.
+        # /v1/completions, non-streaming). `token_ids` is the encoded
+        # prompt (Array[Integer]); `sampling` is a
+        # Tep::Llm::OpenAI::Sampling. Returns a
+        # Tep::Llm::OpenAI::Completion (text + usage). The base returns
+        # an empty completion so a bare backend compiles; real backends
+        # override.
         def generate_from_tokens(model, token_ids, sampling)
           Tep::Llm::OpenAI::Completion.new
+        end
+
+        # STREAMING shape (7.2): the per-token variant for SSE
+        # /v1/completions when the request carries "stream": true.
+        # The backend writes each token to `sink` via
+        # sink.emit_token(piece); the sink (Tep::Llm::OpenAI::StreamSink)
+        # formats it as an OpenAI SSE frame and writes to the
+        # outbound chunked stream. Blocks/yields don't lower across the
+        # spinel boundary, so a typed sink replaces the block --
+        # backends never see SSE wire format or the client fd.
+        # Base no-op (subclasses override).
+        def generate_stream_from_tokens(model, token_ids, sampling, sink)
+          0
         end
 
         # Does this backend implement message-level (chat) generation?
@@ -128,6 +140,87 @@ module Tep
         end
       end
 
+      # The per-token write surface a streaming backend uses (7.2). One
+      # method: `emit_token(piece)`. The sink formats `piece` as an
+      # OpenAI text-completion SSE frame and writes one chunked frame
+      # to the outbound stream. Counts emitted tokens for the
+      # inference event's completion_tokens.
+      #
+      # Why a sink object instead of a block: spinel can't lower a
+      # block parameter across the backend call boundary; a typed
+      # object with one method does the same job through ordinary
+      # virtual dispatch.
+      class StreamSink
+        attr_accessor :out, :model, :completion_count
+
+        def initialize
+          @model            = ""
+          @completion_count = 0
+        end
+
+        # Write one SSE event carrying a single text delta. Matches
+        # OpenAI's text_completion streaming shape: one choices[].text
+        # per event, finish_reason: null until the streamer sends
+        # [DONE]. created uses Time.now.to_i (epoch seconds).
+        def emit_token(piece)
+          @completion_count = @completion_count + 1
+          frame = "{" +
+            Tep::Json.encode_pair_str("id", "cmpl-tep") + "," +
+            Tep::Json.encode_pair_str("object", "text_completion") + "," +
+            Tep::Json.encode_pair_int("created", Time.now.to_i) + "," +
+            Tep::Json.encode_pair_str("model", @model) + "," +
+            "\"choices\":[{" +
+              Tep::Json.encode_pair_int("index", 0) + "," +
+              Tep::Json.encode_pair_str("text", piece) + "," +
+              "\"finish_reason\":null" +
+            "}]" +
+          "}"
+          @out.write("data: " + frame + "\n\n")
+          0
+        end
+      end
+
+      # Runs one streaming completion. Subclass of Tep::Streamer so the
+      # server pumps `pump(out)` cooperatively; we own the SSE shape
+      # end-to-end: drive the backend through StreamSink, write the
+      # terminating data:[DONE], then emit the toy/v1 inference event.
+      class CompletionsStreamer < Tep::Streamer
+        attr_accessor :model, :token_ids, :sampling
+        attr_accessor :prompt_tokens, :t0, :request_id, :principal_id
+
+        def initialize
+          @model         = ""
+          @token_ids     = [0]
+          @token_ids.delete_at(0)
+          @sampling      = Tep::Llm::OpenAI::Sampling.new
+          @prompt_tokens = 0
+          @t0            = 0
+          @request_id    = ""
+          @principal_id  = ""
+        end
+
+        def pump(out)
+          sink = Tep::Llm::OpenAI::StreamSink.new
+          sink.out   = out
+          sink.model = @model
+          Tep::APP.openai_backend.generate_stream_from_tokens(
+            @model, @token_ids, @sampling, sink)
+          # Terminating sentinel + inference event. wall_us is
+          # second-resolution for the same reason as the non-streaming
+          # path (spinel Time.now exposes epoch-int only); LLM is
+          # seconds-scale, populated wall_us is enough signal.
+          out.write("data: [DONE]\n\n")
+          wall_us = (Time.now.to_i - @t0) * 1_000_000
+          extra = "{" +
+            Tep::Json.encode_pair_str("request_id", @request_id) + "," +
+            Tep::Json.encode_pair_str("principal_id", @principal_id) +
+          "}"
+          Tep::APP.openai_events.inference(
+            @model, @prompt_tokens, sink.completion_count, wall_us, extra)
+          0
+        end
+      end
+
       # GET /v1/models -- the standard OpenAI list envelope, built from
       # backend.list_models. Dispatches through APP.openai_backend so
       # the app's subclass override is what answers.
@@ -160,12 +253,36 @@ module Tep
       # APP.openai_backend (the app's subclass override answers).
       class CompletionsHandler < Tep::Handler
         def handle(req, res)
-          res.headers["Content-Type"] = "application/json"
           body      = req.raw_body
           model     = Tep::Json.get_str(body, "model")
           token_ids = Tep::Json.get_int_array(body, "prompt")
           sampling  = Tep::Llm::OpenAI::Sampling.new
           sampling.max_tokens = Tep::Json.get_int(body, "max_tokens")
+
+          # OpenAI signals streaming with "stream": true in the JSON
+          # body; Tep::Json has no bool getter, so we sniff the literal
+          # (same shape as examples/llm_gateway/app.rb). When set, the
+          # response is SSE: a CompletionsStreamer pumps per-token
+          # frames + the [DONE] sentinel, then emits the inference
+          # event with sink.completion_count.
+          wants_stream = Tep.str_find(body, "\"stream\":true", 0) >= 0 ||
+                         Tep.str_find(body, "\"stream\": true", 0) >= 0
+          if wants_stream
+            res.headers["Content-Type"]  = "text/event-stream"
+            res.headers["Cache-Control"] = "no-cache"
+            streamer = Tep::Llm::OpenAI::CompletionsStreamer.new
+            streamer.model         = model
+            streamer.token_ids     = token_ids
+            streamer.sampling      = sampling
+            streamer.prompt_tokens = token_ids.length
+            streamer.t0            = Time.now.to_i
+            streamer.request_id    = "cmpl-tep"
+            streamer.principal_id  = req.identity.subject
+            res.start_stream(streamer)
+            return ""
+          end
+
+          res.headers["Content-Type"] = "application/json"
 
           # Stamp t0 for the inference event's wall_us. Time.now exposes
           # only integer epoch seconds under spinel, so wall_us is at

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -143,3 +143,76 @@ class TestOpenAIServerEvents < TepTest
     assert_match(/\Auser:/, extra["principal_id"])
   end
 end
+
+# Tep::Llm::OpenAI::Server streaming completions (chunk 7.2): with
+# "stream": true in the body, /v1/completions responds SSE-style. The
+# backend writes tokens through a Tep::Llm::OpenAI::StreamSink (no
+# block-yield -- spinel can't lower one across the backend boundary);
+# the CompletionsStreamer terminates the stream with data: [DONE] and
+# emits the toy/v1 inference event with sink.completion_count.
+class TestOpenAIServerStreaming < TepTest
+  EVENTS_PATH = "/tmp/tep_test_openai_stream_events.jsonl"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    class EchoStreamBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["echo-stream"]
+      end
+      def device_kind
+        "cpu"
+      end
+      def generate_stream_from_tokens(model, token_ids, sampling, sink)
+        # Emit one delta per prompt token -- simplest deterministic
+        # shape the test can assert on.
+        i = 0
+        while i < token_ids.length
+          sink.emit_token("t" + token_ids[i].to_s + " ")
+          i += 1
+        end
+        0
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EchoStreamBackend.new)
+    Tep::Llm::OpenAI::Server.serve!("#{EVENTS_PATH}")
+  RB
+
+  @@events_path_cleaned = false
+  def setup
+    unless @@events_path_cleaned
+      File.delete(EVENTS_PATH) if File.exist?(EVENTS_PATH)
+      @@events_path_cleaned = true
+    end
+    super
+  end
+
+  def test_streaming_emits_sse_with_done_and_inference_event
+    body = "{\"model\":\"echo-stream\",\"prompt\":[7,8,9],\"max_tokens\":5,\"stream\":true}"
+    res  = post("/v1/completions", body)
+    assert_equal "200", res.code
+    assert_match(%r{text/event-stream}, res["content-type"])
+
+    # Three token deltas + [DONE] sentinel.
+    data_lines = res.body.scan(/^data: (.+)$/).flatten
+    assert_equal 4, data_lines.length, "expected 3 token frames + 1 [DONE]"
+    assert_equal "[DONE]", data_lines.last
+    frames = data_lines[0..-2].map { |l| JSON.parse(l) }
+    assert_equal ["t7 ", "t8 ", "t9 "], frames.map { |f| f["choices"][0]["text"] }
+    assert_equal [nil, nil, nil],        frames.map { |f| f["choices"][0]["finish_reason"] }
+    assert_equal ["echo-stream", "echo-stream", "echo-stream"],
+                 frames.map { |f| f["model"] }
+
+    # And the inference event landed in the JSONL with the right
+    # completion_count (= 3, the number of emit_token calls).
+    lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
+    inferences = lines.select { |e| e["kind"] == "inference" }
+    assert_equal 1, inferences.length
+    inf = inferences[0]
+    assert_equal "echo-stream", inf["model"]
+    assert_equal 3,             inf["prompt_tokens"]
+    assert_equal 3,             inf["completion_tokens"]
+    assert_equal "cmpl-tep",    inf["extra"]["request_id"]
+  end
+end


### PR DESCRIPTION
Battery 7 chunk 7.2: streaming /v1/completions via SSE, with the toy/v1 inference event emitted on `[DONE]`. Closes #80 in full.

## Design (sink shape, not yield)

Spinel can't pass blocks across the backend boundary, so the backend writes tokens through a typed sink object instead of yielding. The backend calls `sink.emit_token(piece)` per token; the sink builds the SSE frame, writes it via the outbound Stream, and counts tokens. Backends never see SSE wire format or the client fd.

## Surface

- `Backend#generate_stream_from_tokens(model, token_ids, sampling, sink)` — base no-op.
- `Tep::Llm::OpenAI::StreamSink` — `out`/`model`/`completion_count` + `emit_token(piece)`. Formats an OpenAI text_completion SSE frame (`choices[0].text = piece`, `finish_reason: null`) and writes one chunked frame.
- `Tep::Llm::OpenAI::CompletionsStreamer < Tep::Streamer` — drives the backend, writes terminating `data:[DONE]`, then emits one `inference` event with `sink.completion_count`.
- `CompletionsHandler.handle` — sniffs `"stream":true` (with/without whitespace, same shape as `examples/llm_gateway`); if set, sets SSE headers + `res.start_stream(streamer)`; else current non-streaming path (unchanged).

## Test

`TestOpenAIServerStreaming`: EchoStreamBackend emits one token per prompt id; asserts `text/event-stream`, 3 `data:` frames with the right text + `finish_reason: null`, terminating `data: [DONE]`, and the events JSONL accumulates one `inference` event with `completion_tokens=3`.

## Suite

Full parallel: **430 runs, 976 assertions, 0 failures, 52 skips** (was 429; +1 from the streaming test).

Closes #80, Refs #112
