### PR TITLE
feat: post-#80 follow-ups — request.body.read bridge, chat skeleton, run_end on SIGTERM

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -1550,6 +1550,16 @@ def rewrite_block(src, force_string: true)
   # `params['x']` / `params["x"]` and bare `params`
   s = s.gsub(/(?<![\w.])params(?=[\[\.]|$|\s)/, "req.params")
 
+  # `request.body.read` -> `req.body` (a Sinatra app's request.body
+  # is an IO and apps commonly call `.read` on it; tep's req.body
+  # is already a String, so `.read` is a no-op). Run BEFORE the bare
+  # `request -> req` rewrite so we can pin the `.body.read` suffix
+  # exactly and not have to deal with the intermediate `req.body.read`
+  # state. The bare `request.body` form (no `.read`) is handled by
+  # the next rewrite, which leaves it as `req.body` -- already a
+  # String via Tep::Request#body's alias to @raw_body.
+  s = s.gsub(/(?<![\w.])request\.body\.read\b/, "req.body")
+
   # `request` -> req,  `response` -> res, when used as bare identifiers
   s = s.gsub(/(?<![\w.])request(?=[\.\[\s,)]|$)/, "req")
   s = s.gsub(/(?<![\w.])response(?=[\.\[\s,)]|$)/, "res")

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -616,6 +616,15 @@ module Tep
   _tep_seed_oai_backend.generate_from_tokens("m", Tep::Json.get_int_array("{}", "prompt"), _tep_seed_oai_sampling)
   _tep_seed_oai_completions = Tep::Llm::OpenAI::CompletionsHandler.new
   _tep_seed_oai_completions.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
+  # Chat completions skeleton (POST /v1/chat/completions). Default
+  # backend.supports_chat? is false -> ChatCompletionsHandler returns
+  # 501; the override path (supports_chat? = true, chat_completion
+  # overridden) dispatches to the backend's chat_completion. Pin
+  # Backend#chat_completion's `req` param + the ChatCompletionsHandler
+  # dispatch through APP.openai_backend.
+  _tep_seed_oai_backend.chat_completion(_tep_seed_proxy_req)
+  _tep_seed_oai_chat = Tep::Llm::OpenAI::ChatCompletionsHandler.new
+  _tep_seed_oai_chat.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
   # 7.2 streaming completions: pin StreamSink + CompletionsStreamer
   # slots + exercise the backend's generate_stream_from_tokens(sink)
   # arity so the param type resolves. emit_token is called against a
@@ -853,5 +862,17 @@ module Tep
     else
       Server.new(APP).run(port, workers, quiet)
     end
+  end
+
+  # Called by server accept loops when SIGTERM/SIGINT is observed
+  # (via sphttp's term flag). Right now this flushes the openai-server
+  # toy/v1 events stream's run_end; future shutdown hooks add their
+  # cleanups here. Cheap when nothing is configured: openai_events is
+  # seeded with an empty path, whose enabled? short-circuits.
+  def self.on_shutdown
+    if APP.openai_events.enabled?
+      APP.openai_events.run_end("ok")
+    end
+    0
   end
 end

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -30,6 +30,13 @@ module Sock
   ffi_func :sphttp_recv_frame_buf, [],              :str
   ffi_func :sphttp_recv_frame_len, [],              :int
 
+  # Shutdown-on-signal plumbing. Install once at server start;
+  # sphttp_shutdown_requested polls the flag (sigaction sets it on
+  # SIGTERM/SIGINT). The server's accept loop checks the flag after
+  # sphttp_accept returns -1 and runs Tep.on_shutdown before exit.
+  ffi_func :sphttp_install_term_handlers, [], :int
+  ffi_func :sphttp_shutdown_requested,    [], :int
+
   # ISO-8601 UTC timestamp for an epoch-seconds value. Used by
   # Tep::Events (toy/v1 envelope) for run_start/run_end wall-clock
   # fields -- spinel's Time.now is integer-epoch only.

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -65,6 +65,19 @@ module Tep
           false
         end
 
+        # Message-level (chat) generation. Mirrors generate_from_tokens
+        # but receives the raw req so the backend can parse the
+        # messages array itself + apply its own chat template. Tep
+        # doesn't pre-build a Message[] because templating + role
+        # ordering is per-model; the JSON tools live in Tep::Json. The
+        # return is reused from the token path (text becomes the
+        # assistant message's content). Base no-op; subclasses override.
+        # Only reached when supports_chat? returns true -- the handler
+        # gates with a 501 otherwise.
+        def chat_completion(req)
+          Tep::Llm::OpenAI::Completion.new
+        end
+
         # Backend's device, surfaced into the run_start event's
         # backend.kind at serve! time. Defaults to cpu.
         def device_kind
@@ -110,8 +123,9 @@ module Tep
             Tep::Json.encode_pair_str("events_jsonl", events_jsonl) +
           "}"
           events.run_start(host, backend_kind, "", "", config_json)
-          Tep.get("/v1/models",       Tep::Llm::OpenAI::ModelsHandler.new)
-          Tep.post("/v1/completions", Tep::Llm::OpenAI::CompletionsHandler.new)
+          Tep.get("/v1/models",            Tep::Llm::OpenAI::ModelsHandler.new)
+          Tep.post("/v1/completions",      Tep::Llm::OpenAI::CompletionsHandler.new)
+          Tep.post("/v1/chat/completions", Tep::Llm::OpenAI::ChatCompletionsHandler.new)
           0
         end
       end
@@ -316,6 +330,53 @@ module Tep
             "\"choices\":[{" +
               Tep::Json.encode_pair_int("index", 0) + "," +
               Tep::Json.encode_pair_str("text", comp.text) + "," +
+              Tep::Json.encode_pair_str("finish_reason", "stop") +
+            "}]," +
+            "\"usage\":{" +
+              Tep::Json.encode_pair_int("prompt_tokens", comp.prompt_tokens) + "," +
+              Tep::Json.encode_pair_int("completion_tokens", comp.completion_tokens) + "," +
+              Tep::Json.encode_pair_int("total_tokens", total) +
+            "}" +
+          "}"
+        end
+      end
+
+      # POST /v1/chat/completions -- message-level OpenAI shape. Skeleton
+      # for now: gated 501 when backend.supports_chat? is false (the
+      # default; chat templating is per-model + an ML concern tep
+      # doesn't ship). When a backend opts in (overrides supports_chat?
+      # to true + chat_completion), this dispatches to it and formats
+      # the standard chat.completion envelope around the returned
+      # Completion (the text field becomes the assistant message's
+      # content). Streaming chat lands later.
+      class ChatCompletionsHandler < Tep::Handler
+        def handle(req, res)
+          res.headers["Content-Type"] = "application/json"
+          if !Tep::APP.openai_backend.supports_chat?
+            res.set_status(501)
+            return "{" +
+              "\"error\":{" +
+                Tep::Json.encode_pair_str("message",
+                  "chat completions not supported by this backend") + "," +
+                Tep::Json.encode_pair_str("type", "not_implemented") +
+              "}" +
+            "}"
+          end
+          body  = req.raw_body
+          model = Tep::Json.get_str(body, "model")
+          comp  = Tep::APP.openai_backend.chat_completion(req)
+          total = comp.prompt_tokens + comp.completion_tokens
+          "{" +
+            Tep::Json.encode_pair_str("id", "chatcmpl-tep") + "," +
+            Tep::Json.encode_pair_str("object", "chat.completion") + "," +
+            Tep::Json.encode_pair_int("created", Time.now.to_i) + "," +
+            Tep::Json.encode_pair_str("model", model) + "," +
+            "\"choices\":[{" +
+              Tep::Json.encode_pair_int("index", 0) + "," +
+              "\"message\":{" +
+                Tep::Json.encode_pair_str("role", "assistant") + "," +
+                Tep::Json.encode_pair_str("content", comp.text) +
+              "}," +
               Tep::Json.encode_pair_str("finish_reason", "stop") +
             "}]," +
             "\"usage\":{" +

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -30,6 +30,11 @@ module Tep
              " (workers=" + workers.to_s + ")"
       end
 
+      # Install SIGTERM/SIGINT handlers BEFORE fork so children inherit
+      # them; on signal, sphttp_accept returns -1 and the worker loop
+      # runs Tep.on_shutdown (flushes events.run_end + future hooks).
+      Sock.sphttp_install_term_handlers
+
       if workers <= 1
         sfd = Sock.sphttp_listen(port, 0)
         if sfd < 0
@@ -69,6 +74,14 @@ module Tep
       loop do
         client = Sock.sphttp_accept(sfd)
         if client < 0
+          # accept returns -1 with the term flag set after the first
+          # SIGTERM/SIGINT (sphttp_accept retries past unrelated
+          # signals). Run shutdown hooks once, then exit so the parent
+          # reap loop can move on.
+          if Sock.sphttp_shutdown_requested != 0
+            Tep.on_shutdown
+            break
+          end
           next
         end
         handle_connection(client)

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -56,6 +56,11 @@ module Tep
         Tep::APP.pending_listen_fd = sfd
         Tep::APP.pending_quiet = quiet
 
+        # Install SIGTERM/SIGINT handlers BEFORE fork so children
+        # inherit them; accept_loop checks the term flag once per
+        # second and runs Tep.on_shutdown (run_end + future hooks).
+        Sock.sphttp_install_term_handlers
+
         if workers > 1
           i = 0
           while i < workers
@@ -99,7 +104,17 @@ module Tep
       def self.accept_loop
         sfd = Tep::APP.pending_listen_fd
         while true
-          ready = Tep::Scheduler.io_wait(sfd, Tep::Scheduler::READ, -1)
+          # SIGTERM/SIGINT: sphttp's term flag is set by the signal
+          # handler; check before parking on io_wait so we don't sleep
+          # past a shutdown request. The 1s io_wait timeout below
+          # bounds the sleep-side latency.
+          if Sock.sphttp_shutdown_requested != 0
+            Tep.on_shutdown
+            break
+          end
+          # Bounded wait so the flag check above runs once per second
+          # even when traffic is idle (was -1 = wait forever).
+          ready = Tep::Scheduler.io_wait(sfd, Tep::Scheduler::READ, 1)
           if ready == 0
             next
           end

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -31,6 +31,31 @@
 static char sphttp_req_buf[SPHTTP_BUFSIZE];
 static int  sphttp_req_len = 0;
 
+/* Shutdown-on-signal plumbing. SIGTERM/SIGINT set the flag; the
+ * server's accept loop checks it after accept() returns from EINTR
+ * and breaks out cleanly so Ruby-level run_end hooks can fire before
+ * the process exits. SA_RESETHAND restores the default handler after
+ * the first delivery so a second signal kills the process immediately
+ * if shutdown stalls (a non-cooperative second Ctrl-C). */
+static volatile sig_atomic_t sphttp_term_flag = 0;
+static void sphttp_term_signal(int sig) {
+    (void)sig;
+    sphttp_term_flag = 1;
+}
+int sphttp_install_term_handlers(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sphttp_term_signal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = SA_RESETHAND;       /* second signal -> default action */
+    sigaction(SIGTERM, &sa, NULL);
+    sigaction(SIGINT,  &sa, NULL);
+    return 0;
+}
+int sphttp_shutdown_requested(void) {
+    return (int)sphttp_term_flag;
+}
+
 /* Bind & listen on 0.0.0.0:port. If `reuseport` != 0 we set
  * SO_REUSEPORT so multiple worker processes can listen on the same
  * port and the kernel will load-balance accept() across them. */
@@ -72,10 +97,18 @@ int sphttp_accept(int sfd) {
     struct sockaddr_in caddr;
     socklen_t clen = sizeof(caddr);
     int fd;
-    do {
+    for (;;) {
         fd = accept(sfd, (struct sockaddr *)&caddr, &clen);
-    } while (fd < 0 && errno == EINTR);
-    return fd;
+        if (fd >= 0) return fd;
+        if (errno == EINTR) {
+            /* SIGTERM/SIGINT raises sphttp_term_flag; surface as a -1
+             * return so the Ruby accept loop can run shutdown hooks
+             * and exit. Unrelated signals (SIGCHLD, ...) just retry. */
+            if (sphttp_term_flag) return -1;
+            continue;
+        }
+        return -1;
+    }
 }
 
 /* Non-blocking accept. Returns the new fd on success, -1 with errno

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -56,8 +56,37 @@ module TepHarness
     log  = File.join(tmp, "app.log")
     pid  = Process.spawn(bin, "-p", port.to_s, out: log, err: [:child, :out])
     wait_for_port(port, tmp: tmp, pid: pid)
-    @running << { pid: pid, tmp: tmp, log: log }
+    @running << { pid: pid, tmp: tmp, log: log, port: port }
     port
+  end
+
+  # Find the spawned record for a given bound port (used by tests
+  # that need to send signals to the process they booted, e.g.
+  # shutdown-hook tests asserting on run_end emission).
+  def self.find_by_port(port)
+    @running.find { |s| s[:port] == port }
+  end
+
+  # SIGTERM the process bound to `port` + wait for exit. Removes the
+  # entry from @running so kill_all's at_exit doesn't double-reap.
+  def self.terminate(port, timeout: 5.0)
+    s = find_by_port(port)
+    return unless s
+    begin
+      Process.kill("TERM", s[:pid])
+    rescue Errno::ESRCH
+    end
+    deadline = Time.now + timeout
+    until Time.now > deadline
+      begin
+        pid, _ = Process.waitpid2(s[:pid], Process::WNOHANG)
+        break if pid
+      rescue Errno::ECHILD
+        break
+      end
+      sleep 0.05
+    end
+    @running.delete(s)
   end
 
   def self.kill_all
@@ -100,6 +129,17 @@ module TepHarness
   end
 end
 
+# TODO: kill_all runs BEFORE tests in Ruby's LIFO at_exit chain
+# (require "minitest/autorun" registers the test-runner at_exit
+# FIRST; this one registers SECOND, so it fires FIRST). @running is
+# empty at this point so it's a no-op; tests then spawn apps that
+# leak as orphans to docker PID 1 when ruby exits. The parallel
+# runner masks the leak via per-file unique port ranges; serial
+# `make test` is one process so intra-process leak doesn't matter;
+# but manually chaining `ruby A.rb; ruby B.rb` with overlapping
+# default ports DOES surface the leak. Fix is to use
+# `Minitest.after_run { TepHarness.kill_all }` instead, which fires
+# AFTER tests run + @running is populated.
 at_exit { TepHarness.kill_all }
 
 # Kill any zombie tep test processes leaking from previous runs.

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -51,6 +51,21 @@ class TestOpenAIServer < TepTest
     assert_includes ids, "echo-1"
   end
 
+  def test_chat_completions_returns_501_when_unsupported
+    # Default backend.supports_chat? is false (EchoBackend doesn't
+    # override it) -> the route returns 501 with an OpenAI-shape
+    # error JSON, not a 200 / not a 404. Closes the gap that
+    # /v1/chat/completions doesn't exist as a route until a backend
+    # opts in.
+    res = post("/v1/chat/completions",
+               "{\"model\":\"echo-1\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+    assert_equal "501", res.code
+    assert_match(%r{application/json}, res["content-type"])
+    body = JSON.parse(res.body)
+    assert_equal "not_implemented", body["error"]["type"]
+    assert_match(/chat completions not supported/, body["error"]["message"])
+  end
+
   def test_completions_returns_text_completion
     res = post("/v1/completions",
                "{\"model\":\"echo-1\",\"prompt\":[10,20,30],\"max_tokens\":5}")
@@ -214,5 +229,112 @@ class TestOpenAIServerStreaming < TepTest
     assert_equal 3,             inf["prompt_tokens"]
     assert_equal 3,             inf["completion_tokens"]
     assert_equal "cmpl-tep",    inf["extra"]["request_id"]
+  end
+end
+
+# Tep::Llm::OpenAI::Server shutdown hook (SIGTERM/SIGINT -> run_end).
+# Boots the binary normally, hits one /v1/completions to advance the
+# stats, then SIGTERMs the spawned pid and asserts the events JSONL
+# acquired a `run_end` line with the expected stats.
+class TestOpenAIServerShutdown < TepTest
+  EVENTS_PATH = "/tmp/tep_test_openai_shutdown.jsonl"
+
+  app_source <<~RB
+    require 'sinatra'
+
+    class EchoBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["echo-1"]
+      end
+      def device_kind
+        "cpu"
+      end
+      def generate_from_tokens(model, token_ids, sampling)
+        c = Tep::Llm::OpenAI::Completion.new
+        c.text              = "ok"
+        c.prompt_tokens     = token_ids.length
+        c.completion_tokens = 1
+        c
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EchoBackend.new)
+    Tep::Llm::OpenAI::Server.serve!("#{EVENTS_PATH}")
+  RB
+
+  @@events_path_cleaned = false
+  def setup
+    unless @@events_path_cleaned
+      File.delete(EVENTS_PATH) if File.exist?(EVENTS_PATH)
+      @@events_path_cleaned = true
+    end
+    super
+  end
+
+  def test_sigterm_emits_run_end
+    # One request bumps requests=1, tokens_out=1.
+    res = post("/v1/completions",
+               "{\"model\":\"echo-1\",\"prompt\":[10,20,30],\"max_tokens\":1}")
+    assert_equal "200", res.code
+
+    # SIGTERM the server. accept(2) returns -1 with the term flag set;
+    # the worker loop runs Tep.on_shutdown -> Tep::Events#run_end.
+    TepHarness.terminate(@port)
+
+    lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
+    re = lines.find { |e| e["kind"] == "run_end" }
+    refute_nil re, "expected a run_end event after SIGTERM"
+    assert_equal "ok", re["reason"]
+    assert_equal 1,    re["stats"]["requests"]
+    assert_equal 1,    re["stats"]["tokens_out"]
+    assert_equal 0,    re["stats"]["errors"]
+  end
+end
+
+# Tep::Llm::OpenAI::Server chat completions when a backend opts in.
+# Default backend.supports_chat? is false (TestOpenAIServer covers the
+# 501 gate); here ChatBackend overrides supports_chat? + chat_completion
+# to prove the 200 path -- chat.completion envelope around the
+# assistant message.
+class TestOpenAIServerChat < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    class ChatBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["chat-1"]
+      end
+      def supports_chat?
+        true
+      end
+      def chat_completion(req)
+        # Real backend would parse req.raw_body's messages array +
+        # apply its chat template; for the skeleton smoke test we
+        # just echo a fixed reply and pretend it cost a few tokens.
+        c = Tep::Llm::OpenAI::Completion.new
+        c.text              = "ack"
+        c.prompt_tokens     = 4
+        c.completion_tokens = 1
+        c
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(ChatBackend.new)
+    Tep::Llm::OpenAI::Server.serve!
+  RB
+
+  def test_chat_completion_envelope_when_supported
+    res = post("/v1/chat/completions",
+               "{\"model\":\"chat-1\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+    assert_equal "200", res.code
+    body = JSON.parse(res.body)
+    assert_equal "chat.completion", body["object"]
+    assert_equal "chat-1",          body["model"]
+    assert_equal "assistant", body["choices"][0]["message"]["role"]
+    assert_equal "ack",       body["choices"][0]["message"]["content"]
+    assert_equal "stop",      body["choices"][0]["finish_reason"]
+    assert_equal 4, body["usage"]["prompt_tokens"]
+    assert_equal 1, body["usage"]["completion_tokens"]
+    assert_equal 5, body["usage"]["total_tokens"]
   end
 end

--- a/test/test_request_methods.rb
+++ b/test/test_request_methods.rb
@@ -63,3 +63,40 @@ class TestRequestMethods < TepTest
     assert_match(/accept=application\/json/, res2.body)
   end
 end
+
+# `request.body.read` -- Sinatra apps commonly treat request.body as
+# IO and call .read on it; tep's req.body is already a String, so the
+# bin/tep translator rewrites `request.body.read` -> `req.body` so the
+# Sinatra-style handler compiles + serves unchanged.
+class TestRequestBodyRead < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    post '/echo' do
+      content_type 'text/plain'
+      request.body.read
+    end
+
+    post '/echo-twice' do
+      # Hit .read twice -- a Sinatra IO would return "" on the second
+      # call (cursor at EOF); for tep's no-op .read it just returns
+      # the same String again. The expected behaviour here is "tep
+      # gives you the body each time"; apps that rely on the IO
+      # cursor semantics need to rewrite to a single .read + store.
+      content_type 'text/plain'
+      request.body.read + "|" + request.body.read
+    end
+  RB
+
+  def test_request_body_read_returns_raw_body
+    res = post("/echo", "hello world")
+    assert_equal "200", res.code
+    assert_equal "hello world", res.body
+  end
+
+  def test_request_body_read_idempotent
+    res = post("/echo-twice", "abc")
+    assert_equal "200", res.code
+    assert_equal "abc|abc", res.body
+  end
+end


### PR DESCRIPTION
Three orthogonal follow-ups queued after #80 closed:

## 1. `request.body.read` translator bridge

Last open post-WS follow-up. Sinatra apps treat `request.body` as IO and call `.read` on it; tep's `req.body` is already a String. The bin/tep translator now rewrites `request.body.read` → `req.body` alongside the existing `params` / `request` / `response` substitutions.

Test: `TestRequestBodyRead` (added to `test/test_request_methods.rb`). A Sinatra-style `post '/echo' do request.body.read end` handler compiles + serves correctly. Idempotency check passes too — multiple `.read` calls return the body each time (different from Sinatra's IO cursor semantics; documented in the test comment).

## 2. Chat completions skeleton (`POST /v1/chat/completions`)

Battery 7 chunk. New route + `Backend#chat_completion(req)` (default no-op). When `backend.supports_chat?` is false (the default), returns **501** with OpenAI-shape error JSON. When a backend opts in (overrides `supports_chat?` + `chat_completion`), the handler dispatches to it and formats a `chat.completion` envelope around the returned `Completion` (text becomes the assistant message's content). No chat template ships in tep — per-model templating is an ML concern that lives app-side.

Tests: `TestOpenAIServer` (501 gate) + new `TestOpenAIServerChat` class (200 path with `ChatBackend` override).

## 3. `run_end`-at-shutdown signal hook

Last loose end of #80. SIGTERM/SIGINT now install a `sphttp_term_handler` (sigaction + SA_RESETHAND — second signal kills immediately for non-cooperative shutdowns). `sphttp_accept` surfaces -1 on signal when the flag is set; the prefork `worker_loop` + scheduled `accept_loop` both check the flag after accept returns. `Tep.on_shutdown` calls `APP.openai_events.run_end("ok")` when events are configured; cheap when not (path-length short-circuit).

Test: `TestOpenAIServerShutdown` spawns the server with an `events_jsonl`, hits `/v1/completions` once, sends SIGTERM via the new `TepHarness.terminate` helper, then asserts the JSONL ended with `run_end` (`reason: "ok"`, `stats.requests: 1`, `stats.tokens_out: 1`).

Wire smoke verified end-to-end with the blog example: `kill -TERM` → exit in 204ms (vs default "terminate" which was instant; the +200ms covers our flag-check + run_end emission).

## Pre-existing latent bug (not caused by this PR)

While validating the SIGTERM path I found that `test/helper.rb` registers `at_exit { TepHarness.kill_all }` AFTER `require "minitest/autorun"`. Under Ruby's LIFO at_exit semantics, kill_all fires BEFORE tests run with `@running` empty (no-op), then tests spawn apps that leak as orphans to docker PID 1 when ruby exits.

The parallel runner masks it via per-file unique port ranges; serial `make test` runs everything in one process so intra-process leak doesn't matter; manually chaining `ruby A.rb; ruby B.rb` with overlapping default ports DOES surface the leak (4900 stays bound by A). Filed as a TODO in `test/helper.rb` — the fix is to switch to `Minitest.after_run { TepHarness.kill_all }` (fires AFTER tests, with `@running` populated).

## Smoke results

Each of the three changes passes in isolation:
- `test_request_methods.rb`: 8/8 (was 6/6, +2 for body.read).
- `test_openai_server.rb`: 9/9 (was 5/5, +1 chat-501 + +1 chat-200 + +1 shutdown — though the chat-501 is a method within the existing TestOpenAIServer class so the test count goes +3, run count +2).
- Blog (`test_real_world#test_blog_homepage_lists_posts`): 1/1, 15s.

Full parallel suite not re-run here due to extreme host load this session (5-min timeouts hit on single test files); will run on the next quieter run.
