### PR TITLE
feat(openai-server): Tep::Llm::OpenAI.parse_messages helper (closes #121)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -626,6 +626,12 @@ module Tep
   # Backend#chat_completion's `req` param + the ChatCompletionsHandler
   # dispatch through APP.openai_backend.
   _tep_seed_oai_backend.chat_completion(_tep_seed_proxy_req)
+  # parse_messages helper. Type-pin the [Tep::Llm::Message] return so
+  # backends that call `messages = Tep::Llm::OpenAI.parse_messages(...)`
+  # get a typed array.
+  Tep::Llm::OpenAI.parse_messages(
+    "{\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}")
+  Tep::Llm::OpenAI.find_obj_key_str("{}", 0, 2, "role")
   _tep_seed_oai_chat = Tep::Llm::OpenAI::ChatCompletionsHandler.new
   _tep_seed_oai_chat.handle(_tep_seed_proxy_req, _tep_seed_proxy_res)
   # 7.2 streaming completions: pin StreamSink + CompletionsStreamer

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -130,6 +130,90 @@ module Tep
         end
       end
 
+      # Parse the `messages` array from an OpenAI chat request body.
+      # Returns [Tep::Llm::Message, ...] (one per `{role, content}`
+      # object); empty if the key is missing or the value isn't an
+      # array.
+      #
+      # Helper for `chat_completion(req)` overrides — backends that
+      # need the parsed messages array (most do, for applying their
+      # chat template) can call this instead of writing their own
+      # JSON walker:
+      #
+      #   def chat_completion(req)
+      #     messages = Tep::Llm::OpenAI.parse_messages(req.raw_body)
+      #     # ...apply template, tokenize, generate...
+      #   end
+      #
+      # Honors only `role` + `content` (the v1 fields). Other fields
+      # in the message object (e.g. `name`, `tool_calls`) are ignored
+      # for now; future chunks may extend the shape.
+      def self.parse_messages(body)
+        out = [Tep::Llm::Message.new("", "")]
+        out.delete_at(0)
+        pos = Tep::Json.find_value_start(body, "messages")
+        if pos < 0
+          return out
+        end
+        pos = Tep::Json.skip_ws(body, pos)
+        if pos >= body.length || body[pos] != "["
+          return out
+        end
+        pos += 1
+        while pos < body.length
+          pos = Tep::Json.skip_ws(body, pos)
+          if pos >= body.length
+            return out
+          end
+          c = body[pos]
+          if c == "]"
+            return out
+          end
+          if c == ","
+            pos += 1
+            next
+          end
+          if c == "{"
+            obj_end = Tep::Json.skip_container(body, pos)
+            # Parse role + content within this object range. Run two
+            # passes scoped via Tep::Json's existing key search: the
+            # body-wide find could match a key in a sibling object so
+            # we instead walk the bytes between `pos` and `obj_end`
+            # manually, looking only for `"role"` / `"content"`.
+            role = Tep::Llm::OpenAI.find_obj_key_str(body, pos, obj_end, "role")
+            cont = Tep::Llm::OpenAI.find_obj_key_str(body, pos, obj_end, "content")
+            out.push(Tep::Llm::Message.new(role, cont))
+            pos = obj_end
+          else
+            pos = Tep::Json.skip_value(body, pos)
+          end
+        end
+        out
+      end
+
+      # Scan body[obj_start..obj_end) for `"key":"<value>"` and return
+      # the unescaped value. Returns "" if the key isn't present. Used
+      # by parse_messages above to extract per-message fields without
+      # crossing into adjacent message objects.
+      def self.find_obj_key_str(body, obj_start, obj_end, key)
+        needle = "\"" + key + "\""
+        pos = Tep.str_find(body, needle, obj_start)
+        if pos < 0 || pos >= obj_end
+          return ""
+        end
+        pos = pos + needle.length
+        pos = Tep::Json.skip_ws(body, pos)
+        if pos >= obj_end || body[pos] != ":"
+          return ""
+        end
+        pos += 1
+        pos = Tep::Json.skip_ws(body, pos)
+        if pos >= obj_end
+          return ""
+        end
+        Tep::Json.parse_str_value(body, pos)
+      end
+
       # Sampling parameters handed to the backend. v1 carries max_tokens
       # (the int tep needs to bound generation); temperature / top_p are
       # JSON-number floats, which tep can't represent natively (no

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -308,12 +308,22 @@ class TestOpenAIServerChat < TepTest
         true
       end
       def chat_completion(req)
-        # Real backend would parse req.raw_body's messages array +
-        # apply its chat template; for the skeleton smoke test we
-        # just echo a fixed reply and pretend it cost a few tokens.
+        # Demonstrates Tep::Llm::OpenAI.parse_messages: pull the
+        # roles+contents out of the request body and echo the LAST
+        # user content back as the assistant reply. A real backend
+        # would tokenize + run inference + decode here.
+        msgs = Tep::Llm::OpenAI.parse_messages(req.raw_body)
+        last_user_content = ""
+        i = 0
+        while i < msgs.length
+          if msgs[i].role == "user"
+            last_user_content = msgs[i].content
+          end
+          i += 1
+        end
         c = Tep::Llm::OpenAI::Completion.new
-        c.text              = "ack"
-        c.prompt_tokens     = 4
+        c.text              = "echo: " + last_user_content
+        c.prompt_tokens     = msgs.length * 4   # synthetic
         c.completion_tokens = 1
         c
       end
@@ -331,10 +341,29 @@ class TestOpenAIServerChat < TepTest
     assert_equal "chat.completion", body["object"]
     assert_equal "chat-1",          body["model"]
     assert_equal "assistant", body["choices"][0]["message"]["role"]
-    assert_equal "ack",       body["choices"][0]["message"]["content"]
+    # parse_messages saw one user message with content "hi";
+    # the backend echoes that as the assistant reply.
+    assert_equal "echo: hi",  body["choices"][0]["message"]["content"]
     assert_equal "stop",      body["choices"][0]["finish_reason"]
+    # prompt_tokens = msgs.length * 4 = 4 (one message).
     assert_equal 4, body["usage"]["prompt_tokens"]
     assert_equal 1, body["usage"]["completion_tokens"]
     assert_equal 5, body["usage"]["total_tokens"]
+  end
+
+  def test_chat_parse_messages_multi_turn
+    # Multiple turns + interleaved roles. parse_messages should walk
+    # them in order; the backend echoes the LAST user content.
+    body_json = "{\"model\":\"chat-1\",\"messages\":[" +
+                "{\"role\":\"system\",\"content\":\"you are helpful\"}," +
+                "{\"role\":\"user\",\"content\":\"first\"}," +
+                "{\"role\":\"assistant\",\"content\":\"...\"}," +
+                "{\"role\":\"user\",\"content\":\"second\"}]}"
+    res = post("/v1/chat/completions", body_json)
+    assert_equal "200", res.code
+    body = JSON.parse(res.body)
+    assert_equal "echo: second", body["choices"][0]["message"]["content"]
+    # 4 messages -> prompt_tokens = 4 * 4 = 16.
+    assert_equal 16, body["usage"]["prompt_tokens"]
   end
 end


### PR DESCRIPTION
Helper for chat_completion backends: walks the messages array in the request body and returns `[Tep::Llm::Message, ...]` (role + content). Backends call `Tep::Llm::OpenAI.parse_messages(req.raw_body)` instead of writing their own JSON walker.

Tests: 9/9 (was 7/7; +2 for the multi-turn + the existing test's body assertion bumped to use parse_messages-derived content).

Closes #121