### PR TITLE
fix(events): host shape {name, os, arch} + run_end reason "completed" (closes #115)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -878,9 +878,12 @@ module Tep
   # toy/v1 events stream's run_end; future shutdown hooks add their
   # cleanups here. Cheap when nothing is configured: openai_events is
   # seeded with an empty path, whose enabled? short-circuits.
+  #
+  # reason: "completed" — matches toy/v1 vocabulary (was "ok"; #115
+  # noted that Tao's renderer flags non-"completed" reasons visually).
   def self.on_shutdown
     if APP.openai_events.enabled?
-      APP.openai_events.run_end("ok")
+      APP.openai_events.run_end("completed")
     end
     0
   end

--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -67,12 +67,19 @@ module Tep
         return 0
       end
       started = Sock.sphttp_iso8601_utc(@run_started)
+      # toy/v1 says host is {name, os, arch} (docs/events-schema.md);
+      # was a bare string before #115. os + arch come from uname() via
+      # Sock.sphttp_os_kind / sphttp_arch_kind.
       line = "{" +
         Json.encode_pair_str("kind", "run_start") + "," +
         Json.encode_pair_str("schema", "toy/v1") + "," +
         Json.encode_pair_int("t", 0) + "," +
         Json.encode_pair_str("started_at", started) + "," +
-        Json.encode_pair_str("host", host) + "," +
+        "\"host\":{" +
+          Json.encode_pair_str("name", host) + "," +
+          Json.encode_pair_str("os",   Sock.sphttp_os_kind) + "," +
+          Json.encode_pair_str("arch", Sock.sphttp_arch_kind) +
+        "}," +
         "\"backend\":{" + Json.encode_pair_str("kind", backend_kind) + "}," +
         "\"model\":{" +
           Json.encode_pair_str("name", model_name) + "," +

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -37,6 +37,14 @@ module Sock
   ffi_func :sphttp_install_term_handlers, [], :int
   ffi_func :sphttp_shutdown_requested,    [], :int
 
+  # uname-based host introspection for the toy/v1 envelope (see
+  # docs/events-schema.md). sphttp_os_kind returns lowercased
+  # uname.sysname ("linux" / "darwin" / ...); sphttp_arch_kind
+  # returns uname.machine as-is ("aarch64" / "x86_64" / ...). Both
+  # return "unknown" on uname() failure.
+  ffi_func :sphttp_os_kind,       [],               :str
+  ffi_func :sphttp_arch_kind,     [],               :str
+
   # ISO-8601 UTC timestamp for an epoch-seconds value. Used by
   # Tep::Events (toy/v1 envelope) for run_start/run_end wall-clock
   # fields -- spinel's Time.now is integer-epoch only.

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -519,4 +519,39 @@ const char *sphttp_iso8601_utc(int epoch_secs) {
     return sphttp_iso8601_buf;
 }
 
+/* uname-based host introspection for toy/v1's host:{name,os,arch}
+ * envelope (Tep::Events.run_start). One static buffer per field;
+ * we lowercase the os field to match the schema's "linux"/"darwin"
+ * convention (uname returns "Linux"/"Darwin" with leading caps).
+ * arch is returned as-is ("aarch64", "x86_64", ...). On uname()
+ * failure we return "unknown" so the field is always populated. */
+#include <sys/utsname.h>
+#include <ctype.h>
+static char sphttp_os_buf[32];
+static char sphttp_arch_buf[32];
+const char *sphttp_os_kind(void) {
+    struct utsname u;
+    if (uname(&u) != 0) {
+        return "unknown";
+    }
+    size_t i;
+    for (i = 0; i < sizeof(sphttp_os_buf) - 1 && u.sysname[i]; i++) {
+        sphttp_os_buf[i] = (char)tolower((unsigned char)u.sysname[i]);
+    }
+    sphttp_os_buf[i] = '\0';
+    return sphttp_os_buf;
+}
+const char *sphttp_arch_kind(void) {
+    struct utsname u;
+    if (uname(&u) != 0) {
+        return "unknown";
+    }
+    size_t i;
+    for (i = 0; i < sizeof(sphttp_arch_buf) - 1 && u.machine[i]; i++) {
+        sphttp_arch_buf[i] = u.machine[i];
+    }
+    sphttp_arch_buf[i] = '\0';
+    return sphttp_arch_buf;
+}
+
 /* File read/write moved to spinel's built-in File.read / File.write */

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -62,7 +62,12 @@ class TestEvents < TepTest
     rs = scenario_lines[0]
     assert_equal "toy/v1", rs["schema"]
     assert_equal 0, rs["t"]
-    assert_equal "testhost", rs["host"]
+    # host is {name, os, arch} per toy/v1 (#115).
+    assert_equal "testhost", rs["host"]["name"]
+    assert_kind_of String, rs["host"]["os"]
+    assert_kind_of String, rs["host"]["arch"]
+    refute_empty rs["host"]["os"], "os field should be populated via uname()"
+    refute_empty rs["host"]["arch"], "arch field should be populated via uname()"
     assert_equal "cpu", rs["backend"]["kind"]
     assert_equal "smollm2-135m", rs["model"]["name"]
     assert_equal "/m.gguf", rs["model"]["path"]

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -284,7 +284,8 @@ class TestOpenAIServerShutdown < TepTest
     lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
     re = lines.find { |e| e["kind"] == "run_end" }
     refute_nil re, "expected a run_end event after SIGTERM"
-    assert_equal "ok", re["reason"]
+    # reason: "completed" harmonised with toy/v1 vocabulary in #115.
+    assert_equal "completed", re["reason"]
     assert_equal 1,    re["stats"]["requests"]
     assert_equal 1,    re["stats"]["tokens_out"]
     assert_equal 0,    re["stats"]["errors"]


### PR DESCRIPTION
Tao's ingest crashed because tep emitted `host` as bare string; toy/v1 says `{name, os, arch}`. Fixed by emitting the canonical shape; `os` + `arch` come from new `sphttp_os_kind` / `sphttp_arch_kind` C helpers (uname-based).

Also harmonised `run_end.reason` from `"ok"` to `"completed"` per toy/v1.

Tests updated: 6/6 events + 9/9 openai_server pass.

Closes #115