### PR TITLE
fix(events): parent-only run_end with cross-worker aggregated stats (closes #128)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -591,6 +591,11 @@ module Tep
   _tep_seed_events.inference("model", 0, 0, 0, "{}")
   _tep_seed_events.record_error
   _tep_seed_events.run_end("ok")
+  # #128: aggregated run_end (parent reads JSONL + sums). The seed
+  # path is "" so the call short-circuits before any File I/O at
+  # boot; this exists to pin the method's surface area so spinel's
+  # codegen emits it.
+  _tep_seed_events.run_end_aggregated("completed")
   _tep_seed_events.rel_t
   Sock.sphttp_iso8601_utc(0)
 
@@ -873,17 +878,19 @@ module Tep
     end
   end
 
-  # Called by server accept loops when SIGTERM/SIGINT is observed
-  # (via sphttp's term flag). Right now this flushes the openai-server
-  # toy/v1 events stream's run_end; future shutdown hooks add their
-  # cleanups here. Cheap when nothing is configured: openai_events is
-  # seeded with an empty path, whose enabled? short-circuits.
+  # Called by the SERVER PARENT (workers>1) or the single process
+  # (workers=1) at SIGTERM/SIGINT, AFTER the worker children have
+  # exited. Children no longer emit run_end themselves -- #128 moved
+  # the emission here so a multi-worker deployment writes exactly ONE
+  # run_end with aggregated stats from the events.jsonl, not N per
+  # worker.
   #
-  # reason: "completed" — matches toy/v1 vocabulary (was "ok"; #115
-  # noted that Tao's renderer flags non-"completed" reasons visually).
+  # reason: "completed" -- matches toy/v1 vocabulary (was "ok"; #115).
+  # Cheap when nothing is configured: openai_events is seeded with an
+  # empty path, whose enabled? short-circuits.
   def self.on_shutdown
     if APP.openai_events.enabled?
-      APP.openai_events.run_end("completed")
+      APP.openai_events.run_end_aggregated("completed")
     end
     0
   end

--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -122,9 +122,12 @@ module Tep
       0
     end
 
-    # Emit `run_end` once at shutdown. reason is "ok" (clean) or
-    # "errored" (uncaught failure) -- per toy/v1, quality verdicts on
-    # the run are downstream decisions, not encoded here.
+    # Emit `run_end` once at shutdown using LOCAL counters. reason is
+    # "completed" (clean) or "errored" (uncaught failure) -- per
+    # toy/v1, quality verdicts on the run are downstream decisions,
+    # not encoded here. Used for single-process / workers=1 deployments
+    # where the writer is the same process that handled the inferences.
+    # For workers>1, see run_end_aggregated below.
     def run_end(reason)
       if @path.length == 0
         return 0
@@ -142,6 +145,49 @@ module Tep
         "}" +
       "}"
       append_line(line)
+    end
+
+    # Cross-worker run_end: re-read the JSONL + sum inference events
+    # so the emitted stats cover every worker's contribution, then
+    # emit ONE run_end with aggregated counters. Used by Tep.on_shutdown
+    # in the prefork parent (workers>1) -- worker children stop calling
+    # run_end at all; only the parent emits, after all workers have
+    # exited. Avoids cross-worker IPC entirely.
+    def run_end_aggregated(reason)
+      if @path.length == 0
+        return 0
+      end
+      reqs = 0
+      toks = 0
+      # errors aren't yet event-encoded (record_error only bumps a
+      # local counter), so cross-worker errors aren't visible here.
+      # If a future chunk emits "error" events, sum them too. For
+      # now: 0 in aggregated mode.
+      errs = 0
+      content = File.read(@path)
+      lines = content.split("\n")
+      i = 0
+      while i < lines.length
+        line_s = lines[i]
+        if Tep.str_find(line_s, "\"kind\":\"inference\"", 0) >= 0
+          reqs += 1
+          toks += Json.get_int(line_s, "completion_tokens")
+        end
+        i += 1
+      end
+      ended = Sock.sphttp_iso8601_utc(Time.now.to_i)
+      out = "{" +
+        Json.encode_pair_str("kind", "run_end") + "," +
+        Json.encode_pair_int("t", rel_t) + "," +
+        Json.encode_pair_str("ended_at", ended) + "," +
+        Json.encode_pair_str("reason", reason) + "," +
+        "\"stats\":{" +
+          Json.encode_pair_int("requests", reqs) + "," +
+          Json.encode_pair_int("errors", errs) + "," +
+          Json.encode_pair_int("tokens_out", toks) +
+        "}" +
+      "}"
+      append_line(out)
     end
 
     # Seconds since run_start, clamped at 0 (a clock that goes

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -42,6 +42,10 @@ module Tep
           exit(1)
         end
         worker_loop(sfd)
+        # Single-process is its own "parent" -- emit run_end here.
+        if Sock.sphttp_shutdown_requested != 0
+          Tep.on_shutdown
+        end
         return
       end
 
@@ -61,12 +65,19 @@ module Tep
         end
         i += 1
       end
-      # Parent: reap forever.
+      # Parent: reap children until none remain (wait returns -1).
+      # On SIGTERM-to-the-pgroup, children break their accept loops and
+      # exit; parent's wait_any reaps them in order. Once all workers
+      # are gone, emit the single aggregated run_end (re-reading the
+      # JSONL for cross-worker stats; see Tep::Events#run_end_aggregated).
       loop do
         gone = Sock.sphttp_wait_any
         if gone < 0
           break
         end
+      end
+      if Sock.sphttp_shutdown_requested != 0
+        Tep.on_shutdown
       end
     end
 
@@ -76,10 +87,11 @@ module Tep
         if client < 0
           # accept returns -1 with the term flag set after the first
           # SIGTERM/SIGINT (sphttp_accept retries past unrelated
-          # signals). Run shutdown hooks once, then exit so the parent
-          # reap loop can move on.
+          # signals). Break here; the parent (or this same process for
+          # workers=1) emits the aggregated run_end. Workers used to
+          # call Tep.on_shutdown here too, which emitted N run_ends
+          # in the JSONL for an N-worker deployment (#128).
           if Sock.sphttp_shutdown_requested != 0
-            Tep.on_shutdown
             break
           end
           next

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -71,14 +71,24 @@ module Tep
             end
             i += 1
           end
+          # Reap children until none remain. After all workers exit,
+          # emit the single aggregated run_end (see #128 / Tep::Events
+          # #run_end_aggregated).
           loop do
             gone = Sock.sphttp_wait_any
             if gone < 0
               break
             end
           end
+          if Sock.sphttp_shutdown_requested != 0
+            Tep.on_shutdown
+          end
         else
           Tep::Server::Scheduled.run_worker
+          # Single-process: this IS the parent; emit run_end here.
+          if Sock.sphttp_shutdown_requested != 0
+            Tep.on_shutdown
+          end
         end
         0
       end
@@ -107,9 +117,10 @@ module Tep
           # SIGTERM/SIGINT: sphttp's term flag is set by the signal
           # handler; check before parking on io_wait so we don't sleep
           # past a shutdown request. The 1s io_wait timeout below
-          # bounds the sleep-side latency.
+          # bounds the sleep-side latency. The parent (or this same
+          # process for workers=1) emits the aggregated run_end after
+          # all workers exit (#128).
           if Sock.sphttp_shutdown_requested != 0
-            Tep.on_shutdown
             break
           end
           # Bounded wait so the flag check above runs once per second

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -36,8 +36,11 @@ module TepHarness
     p
   end
 
-  # Compile `source` (Sinatra-classic by default) and return the bound port.
-  def self.spawn_app(source, mode: :sinatra)
+  # Compile `source` (Sinatra-classic by default) and return the bound
+  # port. Pass `workers: N` to launch the binary in prefork mode --
+  # used by tests that need to exercise cross-worker behaviour (e.g.
+  # the #128 parent-only run_end emission).
+  def self.spawn_app(source, mode: :sinatra, workers: 1)
     tmp  = Dir.mktmpdir("tep-test")
     src  = File.join(tmp, "app.rb")
     File.write(src, source)
@@ -54,7 +57,9 @@ module TepHarness
     end
     port = next_port
     log  = File.join(tmp, "app.log")
-    pid  = Process.spawn(bin, "-p", port.to_s, out: log, err: [:child, :out])
+    args = [bin, "-p", port.to_s]
+    args += ["-w", workers.to_s] if workers > 1
+    pid  = Process.spawn(*args, out: log, err: [:child, :out])
     wait_for_port(port, tmp: tmp, pid: pid)
     @running << { pid: pid, tmp: tmp, log: log, port: port }
     port
@@ -157,6 +162,18 @@ class TepTest < Minitest::Test
     end
   end
 
+  # Number of prefork workers to launch the test binary with.
+  # Defaults to 1 (the existing single-process shape). Tests that
+  # need to exercise multi-worker behaviour (e.g. #128 run_end
+  # aggregation across workers) call `workers 2` at class scope.
+  def self.workers(n = nil)
+    if n
+      @workers = n
+    else
+      @workers || 1
+    end
+  end
+
   @@boot_lock = Mutex.new
 
   def self.boot!
@@ -164,7 +181,7 @@ class TepTest < Minitest::Test
       return @port if @port
       src, mode = app_source
       raise "#{name}: app_source not set" unless src
-      @port = TepHarness.spawn_app(src, mode: mode)
+      @port = TepHarness.spawn_app(src, mode: mode, workers: workers)
     end
   end
 

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -292,6 +292,76 @@ class TestOpenAIServerShutdown < TepTest
   end
 end
 
+# Tep::Llm::OpenAI::Server cross-worker run_end aggregation (#128).
+# Spawns the binary in prefork mode (workers=2); fires two /v1/completions
+# requests so each worker most-likely handles one (SO_REUSEPORT
+# load-balances); SIGTERMs the parent; asserts exactly ONE run_end
+# in the JSONL with stats.requests=2 (aggregated across workers).
+#
+# The pre-#128 behaviour was N run_ends per N workers, each with that
+# worker's local stats.
+class TestOpenAIServerRunEndMultiWorker < TepTest
+  EVENTS_PATH = "/tmp/tep_test_openai_runend_multi.jsonl"
+
+  workers 2
+
+  app_source <<~RB
+    require 'sinatra'
+
+    class EchoBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["echo-1"]
+      end
+      def device_kind
+        "cpu"
+      end
+      def generate_from_tokens(model, token_ids, sampling)
+        c = Tep::Llm::OpenAI::Completion.new
+        c.text              = "ok"
+        c.prompt_tokens     = token_ids.length
+        c.completion_tokens = 2   # contributes 2 to aggregated tokens_out
+        c
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EchoBackend.new)
+    Tep::Llm::OpenAI::Server.serve!("#{EVENTS_PATH}")
+  RB
+
+  @@events_path_cleaned = false
+  def setup
+    unless @@events_path_cleaned
+      File.delete(EVENTS_PATH) if File.exist?(EVENTS_PATH)
+      @@events_path_cleaned = true
+    end
+    super
+  end
+
+  def test_parent_only_run_end_with_aggregated_stats
+    # 4 sequential requests; SO_REUSEPORT load-balances across workers.
+    # The test is shape-only on which worker handled which; we just
+    # need the AGGREGATED count to be 4 in the single run_end below.
+    4.times do |i|
+      res = post("/v1/completions",
+                 "{\"model\":\"echo-1\",\"prompt\":[#{i}],\"max_tokens\":1}")
+      assert_equal "200", res.code, "request #{i}"
+    end
+
+    TepHarness.terminate(@port)
+
+    lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
+    run_ends = lines.select { |e| e["kind"] == "run_end" }
+    assert_equal 1, run_ends.length,
+      "expected exactly one run_end across workers (was #{run_ends.length})"
+    re = run_ends[0]
+    assert_equal "completed", re["reason"]
+    # 4 requests across the workers, each with completion_tokens=2.
+    assert_equal 4, re["stats"]["requests"]
+    assert_equal 8, re["stats"]["tokens_out"]
+    assert_equal 0, re["stats"]["errors"]
+  end
+end
+
 # Tep::Llm::OpenAI::Server chat completions when a backend opts in.
 # Default backend.supports_chat? is false (TestOpenAIServer covers the
 # 501 gate); here ChatBackend overrides supports_chat? + chat_completion


### PR DESCRIPTION
Workers stop emitting run_end. Parent (single-process for workers=1, prefork parent for workers>1) emits exactly one run_end at shutdown.

Stats are derived by re-reading events.jsonl and summing inference events (`Tep::Events#run_end_aggregated`), so cross-worker tokens_out/requests aggregate cleanly without IPC.

Test: TestOpenAIServerRunEndMultiWorker spawns workers=2, fires 4 requests, SIGTERMs parent, asserts exactly 1 run_end with stats.requests=4, tokens_out=8.

Closes #128