### PR TITLE
feat(proxy): body size caps with 413/502 error paths (closes #125)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -568,6 +568,10 @@ module Tep
   # 6.4 per-request upstream picker. Pin the Tep::Request param +
   # the :str return so subclass overrides resolve cleanly.
   _tep_seed_proxy.pick_upstream(_tep_seed_proxy_req)
+  # 6.6 body-cap accessors. Type-pin the int setters / getters so
+  # subclass overrides + block-DSL setters compile.
+  _tep_seed_proxy.max_request_body_bytes  = 1
+  _tep_seed_proxy.max_response_body_bytes = 1
   _tep_seed_proxy.stream_request?(_tep_seed_proxy_req)
   _tep_seed_pstats = Tep::Proxy::StreamStats.new
   _tep_seed_pchunk = Tep::Proxy::StreamChunk.new("data: x\n\n")

--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -47,10 +47,23 @@
 module Tep
   class Proxy < Tep::Handler
     attr_accessor :upstream, :timeout
+    # Body size caps (chunk 6.6). max_request_body_bytes bounds the
+    # inbound body the proxy will accept (over -> 413 Payload Too
+    # Large before any upstream call). max_response_body_bytes
+    # bounds the upstream response body the proxy will forward
+    # (over -> 502 with a proxy_error JSON). Defaults: 1 MiB request
+    # / 8 MiB response -- enough for typical JSON-API gateway use,
+    # small enough that a malicious / malfunctioning peer can't
+    # easily OOM the worker. Override in initialize() (or expose a
+    # block-DSL setter) for larger / smaller caps per deployment.
+    # Set either to 0 to disable that cap (not recommended).
+    attr_accessor :max_request_body_bytes, :max_response_body_bytes
 
     def initialize(upstream)
       @upstream = upstream
       @timeout  = 30
+      @max_request_body_bytes  = 1 * 1024 * 1024
+      @max_response_body_bytes = 8 * 1024 * 1024
     end
 
     # ---- Overridable hooks (subclasses customise these) ----
@@ -173,6 +186,23 @@ module Tep
     # ---- Tep::Handler interface ----
 
     def handle(req, res)
+      # Request-body cap (chunk 6.6). Reject oversize bodies BEFORE
+      # any upstream call. 413 Payload Too Large with an OpenAI-shape
+      # error JSON for symmetry with the other handler error paths.
+      # max_request_body_bytes == 0 disables the cap.
+      if @max_request_body_bytes > 0 && req.raw_body.length > @max_request_body_bytes
+        res.set_status(413)
+        res.headers["Content-Type"] = "application/json"
+        err_body = "{\"error\":{" +
+          Tep::Json.encode_pair_str("message",
+            "request body exceeds proxy cap of " +
+            @max_request_body_bytes.to_s + " bytes") + "," +
+          Tep::Json.encode_pair_str("type", "payload_too_large") +
+        "}}"
+        res.set_body(err_body)
+        return err_body
+      end
+
       ureq = Tep::Proxy::UpstreamRequest.new
       ureq.verb = req.verb
       ureq.path = rewrite_path(req.raw_path)
@@ -211,6 +241,26 @@ module Tep
 
       url  = pick_upstream(req) + ureq.path
       ures = Tep::Http.send_req(ureq.verb, url, ureq.body, ureq.headers)
+
+      # Response-body cap (chunk 6.6). If the upstream returned more
+      # bytes than the proxy will forward, fail with 502 + a
+      # proxy_error JSON. The body has already been buffered by
+      # Tep::Http (no streaming on the buffered path), so this is a
+      # post-hoc reject -- worst case the worker briefly holds the
+      # large body then drops it. A future streaming-aware cap can
+      # bail mid-recv.
+      if @max_response_body_bytes > 0 && ures.body.length > @max_response_body_bytes
+        res.set_status(502)
+        res.headers["Content-Type"] = "application/json"
+        err_body = "{\"error\":{" +
+          Tep::Json.encode_pair_str("message",
+            "upstream response body exceeds proxy cap of " +
+            @max_response_body_bytes.to_s + " bytes") + "," +
+          Tep::Json.encode_pair_str("type", "upstream_body_too_large") +
+        "}}"
+        res.set_body(err_body)
+        return err_body
+      end
 
       if ures.status > 0
         res.set_status(ures.status)

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -1,4 +1,5 @@
 require_relative "helper"
+require "json"
 
 # Tep::Proxy -- HTTP reverse-proxy battery (chunk 6.1, non-streaming).
 #
@@ -260,5 +261,120 @@ class TestProxyMultiUpstream < TepTest
     res = get("/p/route/#{@port}/b")
     assert_equal "200", res.code
     assert_equal "from-b", res.body
+  end
+end
+
+# Tep::Proxy 6.6: body size caps. max_request_body_bytes rejects
+# oversize POSTs with 413 before any upstream call; max_response_body_bytes
+# rejects oversize upstream responses with 502 + proxy_error JSON.
+class TestProxyBodyCaps < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # Two upstream endpoints with hardcoded sizes -- 50-byte (under
+    # the 200-byte response cap) and 500-byte (over).
+    get '/upstream/small' do
+      res.headers["Content-Type"] = "application/octet-stream"
+      "x" * 50
+    end
+
+    get '/upstream/large' do
+      res.headers["Content-Type"] = "application/octet-stream"
+      "x" * 500
+    end
+
+    post '/upstream/echo' do
+      res.headers["Content-Type"] = "application/octet-stream"
+      req.raw_body
+    end
+
+    # Proxies with tiny caps to make over/under testable. 100-byte
+    # request cap; 200-byte response cap. Each one extends Tep::Proxy
+    # DIRECTLY (not via a shared intermediate parent) -- spinel's
+    # widening over an intermediate-class initialize that sets the
+    # new attrs lets the upstream dispatch widen and Tep::Http.send_req
+    # returns status=0 / connect-failure 502. Three direct subclasses
+    # type-pin cleanly; the duplicated initialize is a deliberate
+    # workaround.
+    class TinyEchoProxy < Tep::Proxy
+      def initialize(upstream)
+        super
+        self.max_request_body_bytes  = 100
+        self.max_response_body_bytes = 200
+      end
+      def rewrite_path(path)
+        "/upstream/echo"
+      end
+    end
+
+    class TinySmallProxy < Tep::Proxy
+      def initialize(upstream)
+        super
+        self.max_request_body_bytes  = 100
+        self.max_response_body_bytes = 200
+      end
+      def rewrite_path(path)
+        "/upstream/small"
+      end
+    end
+
+    class TinyLargeProxy < Tep::Proxy
+      def initialize(upstream)
+        super
+        self.max_request_body_bytes  = 100
+        self.max_response_body_bytes = 200
+      end
+      def rewrite_path(path)
+        "/upstream/large"
+      end
+    end
+
+    post '/p/tiny-echo/:port' do
+      TinyEchoProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/tiny-small/:port' do
+      TinySmallProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/tiny-large/:port' do
+      TinyLargeProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+  RB
+
+  def test_request_under_cap_passes
+    res = post("/p/tiny-echo/#{@port}", "x" * 50)
+    assert_equal "200", res.code
+    assert_equal "x" * 50, res.body
+  end
+
+  def test_request_over_cap_returns_413
+    res = post("/p/tiny-echo/#{@port}", "x" * 500)
+    assert_equal "413", res.code
+    body = JSON.parse(res.body)
+    assert_equal "payload_too_large", body["error"]["type"]
+    assert_match(/proxy cap of 100 bytes/, body["error"]["message"])
+  end
+
+  def test_response_under_cap_passes
+    res = get("/p/tiny-small/#{@port}")
+    assert_equal "200", res.code
+    assert_equal 50, res.body.length
+  end
+
+  def test_response_over_cap_returns_502
+    res = get("/p/tiny-large/#{@port}")
+    assert_equal "502", res.code
+    refute_empty res.body, "expected an error-shape body, got empty (502 from connect failure path?)"
+    body = JSON.parse(res.body)
+    assert_equal "upstream_body_too_large", body["error"]["type"]
+    assert_match(/upstream response body exceeds proxy cap of 200 bytes/,
+                 body["error"]["message"])
   end
 end


### PR DESCRIPTION
Battery 6 chunk 6.6.

`max_request_body_bytes` (1 MiB default) rejects oversize POSTs with **413** + OpenAI-shape error JSON before any upstream call. `max_response_body_bytes` (8 MiB default) rejects oversize upstream responses with **502** + error JSON.

Test: `TestProxyBodyCaps` with 4 cases (under/over for each direction). 14/14 pass.

Workaround noted in commit: each TinyXxxProxy must extend Tep::Proxy directly (not via an intermediate parent owning the initialize), or spinel's widening over the intermediate-class shape breaks Tep::Http dispatch. Documented inline.

Closes #125