### PR TITLE
feat(proxy): retries on transient upstream failures with ms backoff (closes #124)

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -1360,6 +1360,10 @@ PROXY_HOOK_IMETH = {
   # lowers to a subclass override; default behavior (return @upstream)
   # is preserved when the block isn't supplied.
   "pick_upstream"   => "pick_upstream",
+  # 6.5: per-request retry policy. `retry_policy do |req| ... end`
+  # lowers to a subclass override returning a Tep::Proxy::RetryPolicy.
+  # Default (no override) returns a no-retry policy.
+  "retry_policy"    => "retry_policy",
 }.freeze
 
 # Route verbs a proxy var can be mounted on (`Tep.<verb> "p", api`).

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -572,6 +572,19 @@ module Tep
   # subclass overrides + block-DSL setters compile.
   _tep_seed_proxy.max_request_body_bytes  = 1
   _tep_seed_proxy.max_response_body_bytes = 1
+  # 6.5 retry policy. Pin the RetryPolicy slot via instantiation +
+  # the hook return type via a call to #retry_policy(req).
+  _tep_seed_retry_policy = Tep::Proxy::RetryPolicy.new
+  _tep_seed_retry_policy.max_attempts        = 1
+  _tep_seed_retry_policy.base_backoff_ms     = 0
+  _tep_seed_retry_policy.backoff_multiplier  = 2
+  _tep_seed_retry_policy.retry_on_status     = [502, 503, 504]
+  # Pin Sock.sphttp_sleep_ms's :int param so the backoff call site
+  # resolves (called from Tep::Proxy#handle).
+  Sock.sphttp_sleep_ms(0)
+  _tep_seed_retry_policy.backoff_for(0)
+  _tep_seed_retry_policy.retriable?(502)
+  _tep_seed_proxy.retry_policy(_tep_seed_proxy_req)
   _tep_seed_proxy.stream_request?(_tep_seed_proxy_req)
   _tep_seed_pstats = Tep::Proxy::StreamStats.new
   _tep_seed_pchunk = Tep::Proxy::StreamChunk.new("data: x\n\n")

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -37,6 +37,12 @@ module Sock
   ffi_func :sphttp_install_term_handlers, [], :int
   ffi_func :sphttp_shutdown_requested,    [], :int
 
+  # Millisecond sleep helper for sub-second pacing. spinel's
+  # Tep::Scheduler.pause is integer-second only; this exposes the
+  # POSIX nanosleep path. Returns 0 on success, -1 on EINTR. Used by
+  # Tep::Proxy's retry-backoff loop.
+  ffi_func :sphttp_sleep_ms,              [:int], :int
+
   # uname-based host introspection for the toy/v1 envelope (see
   # docs/events-schema.md). sphttp_os_kind returns lowercased
   # uname.sysname ("linux" / "darwin" / ...); sphttp_arch_kind

--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -45,6 +45,66 @@
 # must be reachable over plaintext http:// (https:// upstreams need
 # the TLS-capable outbound client deferred to a later chunk).
 module Tep
+  # Retry behaviour for the buffered forward path (chunk 6.5).
+  # Returned by Tep::Proxy#retry_policy(req); fresh instance per
+  # request so the policy can be derived from the request (e.g.
+  # idempotent verbs get more attempts, POSTs none).
+  #
+  # Backoff is integer-MILLISECONDS via Sock.sphttp_sleep_ms (a
+  # nanosleep-backed C helper). Sub-second pacing is the right
+  # default for HTTP retries -- whole-second backoffs throw away
+  # throughput on transient blips that resolve quickly.
+  #
+  # Default shape: max_attempts=1 (no retry, back-compat).
+  class Proxy
+    class RetryPolicy
+      attr_accessor :max_attempts, :base_backoff_ms, :backoff_multiplier
+      attr_accessor :retry_on_status
+
+      def initialize
+        @max_attempts        = 1
+        @base_backoff_ms     = 0
+        @backoff_multiplier  = 2
+        # Default: transient upstream errors (gateway / unavailable /
+        # timeout). 502 also catches our own connect-failure mapping.
+        @retry_on_status = [502, 503, 504]
+      end
+
+      # Milliseconds to sleep BEFORE attempt N (0-indexed). attempt=0
+      # is the first retry's pre-delay; attempt=1 the second's, etc.
+      # Returns 0 when base is 0 (test-friendly: no delay between
+      # retries by default).
+      def backoff_for(attempt)
+        if @base_backoff_ms <= 0
+          return 0
+        end
+        d = @base_backoff_ms
+        i = 0
+        while i < attempt
+          d = d * @backoff_multiplier
+          i += 1
+        end
+        d
+      end
+
+      # Should the proxy retry given the upstream response status?
+      # Connect/send failures (status == 0) always count as retriable.
+      def retriable?(status)
+        if status == 0
+          return true
+        end
+        i = 0
+        while i < @retry_on_status.length
+          if @retry_on_status[i] == status
+            return true
+          end
+          i += 1
+        end
+        false
+      end
+    end
+  end
+
   class Proxy < Tep::Handler
     attr_accessor :upstream, :timeout
     # Body size caps (chunk 6.6). max_request_body_bytes bounds the
@@ -67,6 +127,30 @@ module Tep
     end
 
     # ---- Overridable hooks (subclasses customise these) ----
+
+    # Per-request retry policy (chunk 6.5). Return a
+    # Tep::Proxy::RetryPolicy whose max_attempts > 1 to retry the
+    # buffered forward on transient upstream failure. Default: 1
+    # attempt (no retry). Override to enable retries; gate on the
+    # request shape so non-idempotent POSTs can skip retries while
+    # GETs use them:
+    #
+    #   class ApiGateway < Tep::Proxy
+    #     def retry_policy(req)
+    #       p = Tep::Proxy::RetryPolicy.new
+    #       p.max_attempts     = 3
+    #       p.base_backoff_ms  = 100   # exponential: 100ms, 200ms, 400ms
+    #       p
+    #     end
+    #   end
+    #
+    # Also available as a block-DSL hook (lowered by bin/tep).
+    # Streaming requests don't retry (the stream may have already
+    # written bytes to the client when failure occurs); only the
+    # buffered path consults the policy.
+    def retry_policy(req)
+      Tep::Proxy::RetryPolicy.new
+    end
 
     # Per-request upstream selection (chunk 6.4). Return the URL of
     # the upstream this request should be forwarded to. Default
@@ -239,8 +323,29 @@ module Tep
         return start_streaming_forward(req, res, ureq)
       end
 
-      url  = pick_upstream(req) + ureq.path
-      ures = Tep::Http.send_req(ureq.verb, url, ureq.body, ureq.headers)
+      url    = pick_upstream(req) + ureq.path
+      policy = retry_policy(req)
+      attempt = 0
+      ures = Tep::Http::Response.new
+      while attempt < policy.max_attempts
+        ures = Tep::Http.send_req(ureq.verb, url, ureq.body, ureq.headers)
+        # Success or non-retriable failure -- done.
+        if !policy.retriable?(ures.status)
+          break
+        end
+        attempt += 1
+        # Sleep before the NEXT attempt, only if there is one. Backoff
+        # is integer milliseconds via the nanosleep-backed C helper;
+        # default 0 (no delay) keeps tests fast.
+        if attempt < policy.max_attempts
+          backoff = policy.backoff_for(attempt - 1)
+          if backoff > 0
+            Sock.sphttp_sleep_ms(backoff)
+          end
+        end
+      end
+      # Expose retry count to observability filters via req.ivars.
+      req.ivars["proxy_retry_count"] = attempt.to_s
 
       # Response-body cap (chunk 6.6). If the upstream returned more
       # bytes than the proxy will forward, fail with 502 + a

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -56,6 +56,24 @@ int sphttp_shutdown_requested(void) {
     return (int)sphttp_term_flag;
 }
 
+/* Sub-second sleep, granular to a millisecond. spinel's Time / sleep
+ * surface deals in integer epoch-seconds only; this helper exposes
+ * usleep for callers that need finer-grained pacing (e.g. Tep::Proxy's
+ * retry backoff loop). Returns 0 on success, -1 on EINTR (the caller
+ * decides whether to retry). ms <= 0 returns immediately. */
+int sphttp_sleep_ms(int ms) {
+    if (ms <= 0) return 0;
+    /* usleep accepts useconds_t but is deprecated on some BSDs; the
+     * portable shape is nanosleep, which we use here. */
+    struct timespec ts;
+    ts.tv_sec  = ms / 1000;
+    ts.tv_nsec = (long)(ms % 1000) * 1000000L;
+    if (nanosleep(&ts, NULL) < 0) {
+        return -1;
+    }
+    return 0;
+}
+
 /* Bind & listen on 0.0.0.0:port. If `reuseport` != 0 we set
  * SO_REUSEPORT so multiple worker processes can listen on the same
  * port and the kernel will load-balance accept() across them. */

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -378,3 +378,150 @@ class TestProxyBodyCaps < TepTest
                  body["error"]["message"])
   end
 end
+
+# Tep::Proxy 6.5: retries on transient upstream failures.
+class TestProxyRetries < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # Upstream with a per-process attempt counter -- returns 503 on
+    # the first hit, 200 on every subsequent hit. Resets via a
+    # /reset route between tests so each test gets a clean slate.
+    class FlakyState
+      attr_accessor :hits
+      def initialize; @hits = 0; end
+    end
+    STATE = FlakyState.new
+
+    get '/upstream/flaky' do
+      STATE.hits = STATE.hits + 1
+      if STATE.hits == 1
+        res.set_status(503)
+        return "{\\"error\\":\\"unavailable\\"}"
+      end
+      res.headers["Content-Type"] = "text/plain"
+      "ok"
+    end
+
+    get '/upstream/always_503' do
+      res.set_status(503)
+      "{\\"error\\":\\"unavailable\\"}"
+    end
+
+    post '/reset_flaky' do
+      STATE.hits = 0
+      "0"
+    end
+
+    # Direct-subclass shape (same workaround as the body-caps tests:
+    # an intermediate-class initialize that sets new attrs widens
+    # incorrectly across multiple grandchildren).
+    class FlakyProxy < Tep::Proxy
+      def retry_policy(req)
+        p = Tep::Proxy::RetryPolicy.new
+        p.max_attempts = 3
+        # base_backoff_seconds stays 0 (test-friendly).
+        p
+      end
+      def rewrite_path(path)
+        "/upstream/flaky"
+      end
+    end
+
+    class GiveUpProxy < Tep::Proxy
+      def retry_policy(req)
+        p = Tep::Proxy::RetryPolicy.new
+        p.max_attempts = 2   # 1 retry; both hit the always-503
+        p
+      end
+      def rewrite_path(path)
+        "/upstream/always_503"
+      end
+    end
+
+    class NoRetryProxy < Tep::Proxy
+      # Default retry_policy (max_attempts=1) -- 503 surfaces as 503.
+      def rewrite_path(path)
+        "/upstream/flaky"
+      end
+    end
+
+    # Same flaky upstream but with an explicit 200ms backoff. Used
+    # to verify the ms-grained sleep actually fires.
+    class FlakyBackoffProxy < Tep::Proxy
+      def retry_policy(req)
+        p = Tep::Proxy::RetryPolicy.new
+        p.max_attempts    = 2
+        p.base_backoff_ms = 200
+        p
+      end
+      def rewrite_path(path)
+        "/upstream/flaky"
+      end
+    end
+
+    get '/p/flaky/:port' do
+      FlakyProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/giveup/:port' do
+      GiveUpProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/noretry/:port' do
+      NoRetryProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/flaky-backoff/:port' do
+      FlakyBackoffProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+  RB
+
+  def reset_flaky
+    post("/reset_flaky", "")
+  end
+
+  def test_retries_recover_from_one_503
+    reset_flaky
+    res = get("/p/flaky/#{@port}")
+    assert_equal "200", res.code
+    assert_equal "ok", res.body
+  end
+
+  def test_gives_up_after_max_attempts
+    res = get("/p/giveup/#{@port}")
+    assert_equal "503", res.code
+    # always_503 returns the error JSON body verbatim through the proxy.
+    body = JSON.parse(res.body)
+    assert_equal "unavailable", body["error"]
+  end
+
+  def test_no_retry_default_surfaces_503
+    reset_flaky
+    res = get("/p/noretry/#{@port}")
+    assert_equal "503", res.code   # would have been 200 with retry
+  end
+
+  def test_backoff_ms_is_actually_sub_second
+    # RetryPolicy uses sphttp_sleep_ms; verify a single retry with a
+    # 200ms backoff DOES sleep (call takes >= ~150ms) but isn't
+    # whole-second-resolution (i.e. nowhere near 1s for a 200ms cap).
+    # Sentinel: 200ms backoff + 1 retry => total elapsed < 1s but
+    # > 100ms. Spinel has no Float so we measure in epoch-int via
+    # the test driver's Time.now.
+    reset_flaky
+    t0 = Time.now
+    res = get("/p/flaky-backoff/#{@port}")
+    elapsed = Time.now - t0
+    assert_equal "200", res.code
+    assert_operator elapsed, :>, 0.1, "expected >= ~100ms (the 200ms backoff) but got #{elapsed}s"
+    assert_operator elapsed, :<, 1.0, "expected sub-second (ms-grained backoff) but got #{elapsed}s"
+  end
+end


### PR DESCRIPTION
Battery 6 chunk 6.5. RetryPolicy hook (max_attempts / base_backoff_ms / backoff_multiplier / retry_on_status). Default returns a no-retry policy (back-compat). Subclass override + block-DSL form.

Backoff is integer **milliseconds** via a new sphttp_sleep_ms C helper (nanosleep-backed). Sub-second pacing — whole-second backoff would throw away throughput on transient blips. (An earlier draft mistakenly used seconds with a 'spinel has no Float' rationale; ms is just an int.)

Tests: 4 new + 14 existing = 18/18 pass. Includes a backoff-actually-fires test that asserts the 200ms backoff produces >100ms but <1s elapsed time.

Closes #124