### PR TITLE
docs: correct false "spinel has no Float" claims in lib comments

### DIFF
--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -30,13 +30,18 @@
 # eval's defining fields, and overloading `eval` would break tao's
 # ingest (which keys the "final eval" on `kind` alone).
 #
-# Float-free by design (spinel has no Float + tep ships zero floats):
+# Integer-only number fields by design (a tep choice, NOT a spinel
+# constraint -- spinel supports Float fully; this module deliberately
+# avoids it for serving telemetry):
 #   * `t` is integer seconds since run_start (a JSON number; consumers
 #     reading it as float get N.0). Sub-second ordering isn't needed
 #     for serving telemetry -- per-request latency rides in wall_us.
-#   * `wall_us` (microsecond latency) is caller-measured + passed in.
+#   * `wall_us` (microsecond latency) is caller-measured + passed in
+#     as an int.
 #   * Floats that the schema does carry (sampling.temperature) live in
 #     the caller-built `extra` JSON string, which tep emits verbatim.
+#     Apps that want native Float support in extra can build their
+#     own JSON encoder around the float values.
 #
 # `started_at` / `ended_at` are ISO-8601 UTC via Sock.sphttp_iso8601_utc
 # (spinel's Time.now exposes only integer epoch seconds).
@@ -94,7 +99,7 @@ module Tep
     # latency) are ints the caller measured. extra_json is a caller-
     # built JSON object ("{}" if none) carrying sampling / request_id /
     # principal_id -- emitted verbatim, so floats (temperature) live
-    # there, out of tep's float-free core.
+    # there, formatted by the caller.
     def inference(model, prompt_tokens, completion_tokens, wall_us, extra_json)
       @req_count = @req_count + 1
       @tok_out   = @tok_out + completion_tokens

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -214,11 +214,14 @@ module Tep
         Tep::Json.parse_str_value(body, pos)
       end
 
-      # Sampling parameters handed to the backend. v1 carries max_tokens
-      # (the int tep needs to bound generation); temperature / top_p are
-      # JSON-number floats, which tep can't represent natively (no
-      # Float) -- a float-capable chunk adds them. A backend that needs
-      # them today reads the raw request body itself.
+      # Sampling parameters handed to the backend. v1 carries
+      # max_tokens; temperature / top_p (JSON-number floats) aren't
+      # parsed into this struct yet because Tep::Json has no float
+      # getter -- a follow-up chunk lands `Tep::Json.get_float` +
+      # `Sampling#temperature` / `#top_p`. (Spinel itself supports
+      # Float fully; this is a tep-side JSON-parser gap, not a
+      # codegen limitation.) Backends that need them today read the
+      # raw request body and parse out the floats themselves.
       class Sampling
         attr_accessor :max_tokens
 


### PR DESCRIPTION
Audit found this myth leaked into two source comments + a memory file. Spinel supports Float fully (verified with a probe today against master a03bb49).

Comments now state the actual rationales:
- events.rb: int-only fields are a tep choice for deterministic telemetry ingest, not a codegen limit.
- openai_server.rb Sampling: temperature/top_p are deferred because Tep::Json has no float-getter yet, not because spinel can't represent Float.

No behavior change. PR #131 commit message in history has the wrong rationale for the ms-based backoff; the outcome (ms via nanosleep int) is still correct.