### PR TITLE
feat: get_float + Sampling.temperature/top_p + RetryPolicy.base_backoff_secs (closes #133)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -579,9 +579,17 @@ module Tep
   _tep_seed_retry_policy.base_backoff_ms     = 0
   _tep_seed_retry_policy.backoff_multiplier  = 2
   _tep_seed_retry_policy.retry_on_status     = [502, 503, 504]
+  # Float-seconds setter (#133). Pin the Float -> int(ms) lowering
+  # so the conversion call site resolves.
+  _tep_seed_retry_policy.base_backoff_secs = 0.0
+  _tep_seed_retry_policy.base_backoff_secs
   # Pin Sock.sphttp_sleep_ms's :int param so the backoff call site
   # resolves (called from Tep::Proxy#handle).
   Sock.sphttp_sleep_ms(0)
+  # Tep::Json.get_float seed (#133). Pin the (String, String) -> Float
+  # surface so callers (CompletionsHandler temperature/top_p,
+  # backends that parse their own bodies) resolve cleanly.
+  Tep::Json.get_float("{\"temperature\":0.7}", "temperature")
   _tep_seed_retry_policy.backoff_for(0)
   _tep_seed_retry_policy.retriable?(502)
   _tep_seed_proxy.retry_policy(_tep_seed_proxy_req)
@@ -636,7 +644,9 @@ module Tep
   # 7.1b /v1/completions surface.
   Tep::Json.get_int_array("{}", "prompt")
   _tep_seed_oai_sampling = Tep::Llm::OpenAI::Sampling.new
-  _tep_seed_oai_sampling.max_tokens = 0
+  _tep_seed_oai_sampling.max_tokens  = 0
+  _tep_seed_oai_sampling.temperature = 1.0
+  _tep_seed_oai_sampling.top_p       = 1.0
   _tep_seed_oai_comp = Tep::Llm::OpenAI::Completion.new
   _tep_seed_oai_backend.generate_from_tokens("m", Tep::Json.get_int_array("{}", "prompt"), _tep_seed_oai_sampling)
   _tep_seed_oai_completions = Tep::Llm::OpenAI::CompletionsHandler.new

--- a/lib/tep/json.rb
+++ b/lib/tep/json.rb
@@ -204,6 +204,35 @@ module Tep
       Json.parse_int_value(s, pos)
     end
 
+    # Decode a JSON number value at `key` -> Float. Accepts both
+    # integer-literal (`42`) and float-literal (`3.14`, `-0.5`, `1e2`)
+    # JSON-number syntax; the integer form returns N.0. Missing key
+    # or malformed value returns 0.0 (consistent with the other
+    # getters' missing-key defaults).
+    #
+    # Implementation: delegates the value-span walking to skip_value
+    # (already handles all JSON-number syntax + structural-char
+    # boundaries), then String#to_f on the substring. Inlined rather
+    # than factored into a parse_float_value helper because spinel's
+    # type inference mis-widens `s` to int through the indirection
+    # ("cannot resolve call to 'length' on int" + the downstream
+    # skip_ws/skip_value pointer-vs-int conversion errors).
+    def self.get_float(s, key)
+      pos = Json.find_value_start(s, key)
+      if pos < 0
+        return 0.0
+      end
+      pos = Json.skip_ws(s, pos)
+      if pos >= s.length
+        return 0.0
+      end
+      end_pos = Json.skip_value(s, pos)
+      if end_pos <= pos
+        return 0.0
+      end
+      s[pos, end_pos - pos].to_f
+    end
+
     def self.has_key?(s, key)
       Json.find_value_start(s, key) >= 0
     end

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -215,18 +215,17 @@ module Tep
       end
 
       # Sampling parameters handed to the backend. v1 carries
-      # max_tokens; temperature / top_p (JSON-number floats) aren't
-      # parsed into this struct yet because Tep::Json has no float
-      # getter -- a follow-up chunk lands `Tep::Json.get_float` +
-      # `Sampling#temperature` / `#top_p`. (Spinel itself supports
-      # Float fully; this is a tep-side JSON-parser gap, not a
-      # codegen limitation.) Backends that need them today read the
-      # raw request body and parse out the floats themselves.
+      # max_tokens + temperature + top_p (the three OpenAI completion
+      # knobs every client sets). Floats parsed via Tep::Json.get_float.
+      # Defaults match OpenAI's API defaults so a backend that ignores
+      # sampling gets pass-through behavior.
       class Sampling
-        attr_accessor :max_tokens
+        attr_accessor :max_tokens, :temperature, :top_p
 
         def initialize
-          @max_tokens = 0
+          @max_tokens  = 0
+          @temperature = 1.0
+          @top_p       = 1.0
         end
       end
 
@@ -359,6 +358,15 @@ module Tep
           token_ids = Tep::Json.get_int_array(body, "prompt")
           sampling  = Tep::Llm::OpenAI::Sampling.new
           sampling.max_tokens = Tep::Json.get_int(body, "max_tokens")
+          # Floats from the JSON body; defaults stay at 1.0 if the
+          # key is absent (Tep::Json.get_float returns 0.0 for
+          # missing, but we only overwrite when present).
+          if Tep::Json.has_key?(body, "temperature")
+            sampling.temperature = Tep::Json.get_float(body, "temperature")
+          end
+          if Tep::Json.has_key?(body, "top_p")
+            sampling.top_p = Tep::Json.get_float(body, "top_p")
+          end
 
           # OpenAI signals streaming with "stream": true in the JSON
           # body; Tep::Json has no bool getter, so we sniff the literal

--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -53,7 +53,13 @@ module Tep
   # Backoff is integer-MILLISECONDS via Sock.sphttp_sleep_ms (a
   # nanosleep-backed C helper). Sub-second pacing is the right
   # default for HTTP retries -- whole-second backoffs throw away
-  # throughput on transient blips that resolve quickly.
+  # throughput on transient blips that resolve quickly. Two setters
+  # for the base backoff:
+  #   * base_backoff_ms = 100              # int, direct ms.
+  #   * base_backoff_secs = 0.1            # Float, converted to ms.
+  # Set whichever reads better at the call site; both feed the same
+  # ms-int through backoff_for. If both are set, the LAST write
+  # wins (whichever setter you called second).
   #
   # Default shape: max_attempts=1 (no retry, back-compat).
   class Proxy
@@ -68,6 +74,20 @@ module Tep
         # Default: transient upstream errors (gateway / unavailable /
         # timeout). 502 also catches our own connect-failure mapping.
         @retry_on_status = [502, 503, 504]
+      end
+
+      # Float-seconds convenience setter (e.g. 0.5 -> 500ms). Stores
+      # the value in @base_backoff_ms as an int so backoff_for / the
+      # sleep call stay int-only on the hot path.
+      def base_backoff_secs=(f)
+        @base_backoff_ms = (f * 1000.0).to_i
+      end
+
+      # Reader symmetric to the setter (Float seconds derived from
+      # the stored ms). Cheap; only the setter does the conversion
+      # in the common case.
+      def base_backoff_secs
+        @base_backoff_ms.to_f / 1000.0
       end
 
       # Milliseconds to sleep BEFORE attempt N (0-indexed). attempt=0

--- a/test/test_json.rb
+++ b/test/test_json.rb
@@ -54,6 +54,11 @@ class TestJson < TepTest
       res.headers["Content-Type"] = "text/plain"
       Tep::Json.get_str(req.raw_body, "after")
     end
+
+    post '/parse_float' do
+      res.headers["Content-Type"] = "text/plain"
+      Tep::Json.get_float(req.raw_body, "x").to_s
+    end
   RB
 
   def test_quote_escapes
@@ -133,5 +138,31 @@ class TestJson < TepTest
     body = '{"first":"has \\"quote\\" inside","after":"target"}'
     res = post("/skip_nested", body)
     assert_equal "target", res.body.strip
+  end
+
+  def test_get_float_decimal
+    res = post("/parse_float", '{"x":3.14}')
+    assert_equal "3.14", res.body.strip
+  end
+
+  def test_get_float_negative
+    res = post("/parse_float", '{"x":-0.5}')
+    assert_equal "-0.5", res.body.strip
+  end
+
+  def test_get_float_integer_literal
+    # JSON integer 42 read as float -> 42.0
+    res = post("/parse_float", '{"x":42}')
+    assert_equal "42.0", res.body.strip
+  end
+
+  def test_get_float_exponent
+    res = post("/parse_float", '{"x":1.5e2}')
+    assert_equal "150.0", res.body.strip
+  end
+
+  def test_get_float_missing_key_returns_zero
+    res = post("/parse_float", '{"other":42}')
+    assert_equal "0.0", res.body.strip
   end
 end

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -19,7 +19,11 @@ class TestOpenAIServer < TepTest
       end
       def generate_from_tokens(model, token_ids, sampling)
         c = Tep::Llm::OpenAI::Completion.new
-        c.text              = "echoed " + token_ids.length.to_s + " tokens"
+        # Echo back the sampling knobs so the test can assert they
+        # reached the backend with the values the client requested.
+        c.text              = "echoed " + token_ids.length.to_s +
+                              " tokens t=" + sampling.temperature.to_s +
+                              " p=" + sampling.top_p.to_s
         c.prompt_tokens     = token_ids.length
         c.completion_tokens = sampling.max_tokens
         c
@@ -67,18 +71,28 @@ class TestOpenAIServer < TepTest
   end
 
   def test_completions_returns_text_completion
+    # No temperature / top_p sent -> defaults of 1.0 reach the backend.
     res = post("/v1/completions",
                "{\"model\":\"echo-1\",\"prompt\":[10,20,30],\"max_tokens\":5}")
     assert_equal "200", res.code
     body = JSON.parse(res.body)
     assert_equal "text_completion", body["object"]
     assert_equal "echo-1", body["model"]
-    # generate_from_tokens saw the 3-token prompt + max_tokens=5.
-    assert_equal "echoed 3 tokens", body["choices"][0]["text"]
+    assert_equal "echoed 3 tokens t=1.0 p=1.0", body["choices"][0]["text"]
     assert_equal "stop", body["choices"][0]["finish_reason"]
     assert_equal 3, body["usage"]["prompt_tokens"]
     assert_equal 5, body["usage"]["completion_tokens"]
     assert_equal 8, body["usage"]["total_tokens"]
+  end
+
+  def test_completions_threads_temperature_and_top_p
+    # Explicit floats in the body -> Sampling.temperature/top_p set.
+    res = post("/v1/completions",
+               "{\"model\":\"echo-1\",\"prompt\":[1,2]," +
+               "\"max_tokens\":1,\"temperature\":0.7,\"top_p\":0.9}")
+    assert_equal "200", res.code
+    body = JSON.parse(res.body)
+    assert_equal "echoed 2 tokens t=0.7 p=0.9", body["choices"][0]["text"]
   end
 end
 

--- a/test/test_proxy.rb
+++ b/test/test_proxy.rb
@@ -463,6 +463,20 @@ class TestProxyRetries < TepTest
       end
     end
 
+    # Same again but uses the Float-seconds convenience setter to
+    # prove it stores the right ms (0.2 -> 200ms).
+    class FlakyBackoffSecsProxy < Tep::Proxy
+      def retry_policy(req)
+        p = Tep::Proxy::RetryPolicy.new
+        p.max_attempts      = 2
+        p.base_backoff_secs = 0.2
+        p
+      end
+      def rewrite_path(path)
+        "/upstream/flaky"
+      end
+    end
+
     get '/p/flaky/:port' do
       FlakyProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
       res.body
@@ -480,6 +494,11 @@ class TestProxyRetries < TepTest
 
     get '/p/flaky-backoff/:port' do
       FlakyBackoffProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
+      res.body
+    end
+
+    get '/p/flaky-backoff-secs/:port' do
+      FlakyBackoffSecsProxy.new("http://127.0.0.1:" + params[:port]).handle(req, res)
       res.body
     end
   RB
@@ -511,11 +530,8 @@ class TestProxyRetries < TepTest
 
   def test_backoff_ms_is_actually_sub_second
     # RetryPolicy uses sphttp_sleep_ms; verify a single retry with a
-    # 200ms backoff DOES sleep (call takes >= ~150ms) but isn't
-    # whole-second-resolution (i.e. nowhere near 1s for a 200ms cap).
-    # Sentinel: 200ms backoff + 1 retry => total elapsed < 1s but
-    # > 100ms. Spinel has no Float so we measure in epoch-int via
-    # the test driver's Time.now.
+    # 200ms backoff DOES sleep (call takes >= ~100ms) but isn't
+    # whole-second-resolution (nowhere near 1s for a 200ms cap).
     reset_flaky
     t0 = Time.now
     res = get("/p/flaky-backoff/#{@port}")
@@ -523,5 +539,18 @@ class TestProxyRetries < TepTest
     assert_equal "200", res.code
     assert_operator elapsed, :>, 0.1, "expected >= ~100ms (the 200ms backoff) but got #{elapsed}s"
     assert_operator elapsed, :<, 1.0, "expected sub-second (ms-grained backoff) but got #{elapsed}s"
+  end
+
+  def test_backoff_secs_float_setter_equivalent_to_ms_int
+    # Same shape as the ms test, but configured via base_backoff_secs
+    # = 0.2 (Float). Proves the Float -> int(ms) conversion stores
+    # the right value internally.
+    reset_flaky
+    t0 = Time.now
+    res = get("/p/flaky-backoff-secs/#{@port}")
+    elapsed = Time.now - t0
+    assert_equal "200", res.code
+    assert_operator elapsed, :>, 0.1
+    assert_operator elapsed, :<, 1.0
   end
 end


### PR DESCRIPTION
Three small follow-ups to the float-claim correction (#132):

1. `Tep::Json.get_float(s, key)` — the real missing piece. Delegates the span-walk to existing `skip_value`, then `String#to_f`. 5 new tests cover decimal / negative / int-literal-as-float / exponent / missing-key.
2. `Sampling.temperature` + `top_p` (Float, default 1.0). `CompletionsHandler` parses both when present. Backend now sees the values; test asserts thread-through.
3. `RetryPolicy.base_backoff_secs=` Float convenience setter — `0.2` stored as 200ms internally. Symmetric reader. Both fields feed the same `backoff_for`.

Suite: json 18/18, openai_server 11/11, proxy 19/19.

Closes #133