### PR TITLE
fix(events): migrate #inference to toy/v1 spec shape (closes #136)

### DIFF
--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -95,26 +95,46 @@ module Tep
       append_line(line)
     end
 
-    # Emit one `inference` event. Token counts + wall_us (microsecond
-    # latency) are ints the caller measured. extra_json is a caller-
-    # built JSON object ("{}" if none) carrying sampling / request_id /
-    # principal_id -- emitted verbatim, so floats (temperature) live
-    # there, formatted by the caller.
+    # Emit one inference-time telemetry event in the toy/v1 spec
+    # shape (#136): kind:"eval", phase:"serve", name:"request",
+    # with model + token counts + latency_us nested inside `extra`
+    # alongside whatever the caller passed in extra_json. The
+    # producer-facing API stays the same (callers pass
+    # prompt_tokens, completion_tokens, wall_us); we rename
+    # wall_us -> latency_us at the wire level.
+    #
+    # extra_json is a caller-built JSON object ("{}" if none)
+    # carrying sampling / request_id / principal_id. We strip its
+    # outer braces and merge with the spec's per-completion fields
+    # to produce the final extra object.
     def inference(model, prompt_tokens, completion_tokens, wall_us, extra_json)
       @req_count = @req_count + 1
       @tok_out   = @tok_out + completion_tokens
       if @path.length == 0
         return 0
       end
-      line = "{" +
-        Json.encode_pair_str("kind", "inference") + "," +
-        Json.encode_pair_str("phase", "serve") + "," +
-        Json.encode_pair_int("t", rel_t) + "," +
+      # Build the merged extra: spec fields first, then caller's
+      # fields appended (if non-empty).
+      extra = "{" +
         Json.encode_pair_str("model", model) + "," +
         Json.encode_pair_int("prompt_tokens", prompt_tokens) + "," +
         Json.encode_pair_int("completion_tokens", completion_tokens) + "," +
-        Json.encode_pair_int("wall_us", wall_us) + "," +
-        "\"extra\":" + extra_json +
+        Json.encode_pair_int("latency_us", wall_us)
+      caller_inner = ""
+      if extra_json.length > 2
+        # Strip the outer braces -- "{...}" -> "...".
+        caller_inner = extra_json[1, extra_json.length - 2]
+      end
+      if caller_inner.length > 0
+        extra = extra + "," + caller_inner
+      end
+      extra = extra + "}"
+      line = "{" +
+        Json.encode_pair_str("kind", "eval") + "," +
+        Json.encode_pair_str("phase", "serve") + "," +
+        Json.encode_pair_int("t", rel_t) + "," +
+        Json.encode_pair_str("name", "request") + "," +
+        "\"extra\":" + extra +
       "}"
       append_line(line)
     end
@@ -174,9 +194,22 @@ module Tep
       i = 0
       while i < lines.length
         line_s = lines[i]
-        if Tep.str_find(line_s, "\"kind\":\"inference\"", 0) >= 0
+        # #136: inference events are kind:"eval" + phase:"serve" +
+        # name:"request". Match the joint shape to avoid counting
+        # future non-request eval events (e.g. training-time eval).
+        if Tep.str_find(line_s, "\"kind\":\"eval\"", 0) >= 0 &&
+           Tep.str_find(line_s, "\"name\":\"request\"", 0) >= 0
           reqs += 1
-          toks += Json.get_int(line_s, "completion_tokens")
+          # completion_tokens now lives nested inside the `extra`
+          # object. Tep::Json.find_value_start walks only the
+          # top-level keys (it skips over nested objects), so we
+          # have to extract extra first, then get_int within it.
+          extra_pos = Json.find_value_start(line_s, "extra")
+          if extra_pos >= 0
+            obj_end = Json.skip_container(line_s, extra_pos)
+            extra_obj = line_s[extra_pos, obj_end - extra_pos]
+            toks += Json.get_int(extra_obj, "completion_tokens")
+          end
         end
         i += 1
       end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -53,8 +53,11 @@ class TestEvents < TepTest
     lines = scenario_lines
     assert_equal 4, lines.length
     assert_equal "run_start", lines[0]["kind"]
-    assert_equal "inference", lines[1]["kind"]
-    assert_equal "inference", lines[2]["kind"]
+    # #136: inference events are kind:"eval"+name:"request".
+    assert_equal "eval",      lines[1]["kind"]
+    assert_equal "request",   lines[1]["name"]
+    assert_equal "eval",      lines[2]["kind"]
+    assert_equal "request",   lines[2]["name"]
     assert_equal "run_end",   lines[3]["kind"]
   end
 
@@ -77,15 +80,18 @@ class TestEvents < TepTest
 
   def test_inference_event_fields
     ev = scenario_lines[1]
-    assert_equal "inference", ev["kind"]
-    assert_equal "serve", ev["phase"]
-    assert_equal "smollm2-135m", ev["model"]
-    assert_equal 12, ev["prompt_tokens"]
-    assert_equal 8, ev["completion_tokens"]
-    assert_equal 87000, ev["wall_us"]
-    assert_equal "cmpl-abc", ev["extra"]["request_id"]
-    assert_equal "user:42", ev["extra"]["principal_id"]
+    # #136 spec shape: kind:"eval" + phase:"serve" + name:"request",
+    # with model + tokens + latency_us nested under extra.
+    assert_equal "eval",    ev["kind"]
+    assert_equal "serve",   ev["phase"]
+    assert_equal "request", ev["name"]
     assert_kind_of Integer, ev["t"]
+    assert_equal "smollm2-135m", ev["extra"]["model"]
+    assert_equal 12,      ev["extra"]["prompt_tokens"]
+    assert_equal 8,       ev["extra"]["completion_tokens"]
+    assert_equal 87000,   ev["extra"]["latency_us"]
+    assert_equal "cmpl-abc", ev["extra"]["request_id"]
+    assert_equal "user:42",  ev["extra"]["principal_id"]
   end
 
   def test_run_end_stats_accumulate

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -158,16 +158,18 @@ class TestOpenAIServerEvents < TepTest
     assert_equal "200", res.code
 
     lines2 = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
-    inferences = lines2.select { |e| e["kind"] == "inference" }
+    # #136: inference events are kind:"eval"+name:"request"; per-request
+    # fields nested under extra.
+    inferences = lines2.select { |e| e["kind"] == "eval" && e["name"] == "request" }
     assert_equal 1, inferences.length, "expected exactly one inference event"
     inf = inferences[0]
-    assert_equal "serve",  inf["phase"]
-    assert_equal "echo-1", inf["model"]
-    assert_equal 4,        inf["prompt_tokens"]
-    assert_equal 7,        inf["completion_tokens"]
-    assert_kind_of Integer, inf["wall_us"]
-    assert inf["wall_us"] >= 0
+    assert_equal "serve", inf["phase"]
     extra = inf["extra"]
+    assert_equal "echo-1", extra["model"]
+    assert_equal 4,        extra["prompt_tokens"]
+    assert_equal 7,        extra["completion_tokens"]
+    assert_kind_of Integer, extra["latency_us"]
+    assert extra["latency_us"] >= 0
     assert_equal "cmpl-tep", extra["request_id"]
     assert_match(/\Auser:/, extra["principal_id"])
   end
@@ -236,12 +238,14 @@ class TestOpenAIServerStreaming < TepTest
     # And the inference event landed in the JSONL with the right
     # completion_count (= 3, the number of emit_token calls).
     lines = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
-    inferences = lines.select { |e| e["kind"] == "inference" }
+    # #136 spec shape: kind:"eval"+name:"request", per-request fields
+    # nested under extra.
+    inferences = lines.select { |e| e["kind"] == "eval" && e["name"] == "request" }
     assert_equal 1, inferences.length
     inf = inferences[0]
-    assert_equal "echo-stream", inf["model"]
-    assert_equal 3,             inf["prompt_tokens"]
-    assert_equal 3,             inf["completion_tokens"]
+    assert_equal "echo-stream", inf["extra"]["model"]
+    assert_equal 3,             inf["extra"]["prompt_tokens"]
+    assert_equal 3,             inf["extra"]["completion_tokens"]
     assert_equal "cmpl-tep",    inf["extra"]["request_id"]
   end
 end


### PR DESCRIPTION
Four wire-shape changes per Tao's frozen toy/v1 spec:

- `kind: "inference"` → `"eval"`
- add `name: "request"` (required)
- move `model`/`prompt_tokens`/`completion_tokens`/latency into `extra`
- rename `wall_us` → `latency_us`

Producer API (`#inference(model, prompt_tokens, completion_tokens, wall_us, extra_json)`) unchanged. `run_end_aggregated` updated for the joint kind+name filter + the nested completion_tokens extraction.

events 6/6, openai_server 11/11.

Closes #136