### PR TITLE
feat(http): connection pool primitives + Tep::Http::Pool (chunk 6.7a, refs #126)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -530,6 +530,13 @@ module Tep
   Tep::Http.delete("http://127.0.0.1:1/")
   Tep::Http.head("http://127.0.0.1:1/")
   Tep::Http.empty_headers
+  # Pool seed (chunk 6.7a). Pin the (str, int) -> int / (int, str, int) -> int
+  # arities so the FFI bindings resolve. Each call site exercises one
+  # primitive against the empty pool -- harmless at boot.
+  Tep::Http::Pool.claim("127.0.0.1", 1)
+  Tep::Http::Pool.release(-1, "127.0.0.1", 1)
+  Tep::Http::Pool.close_idle(30)
+  Tep::Http::Pool.stats
   _tep_seed_http = Tep::Http.new("http://127.0.0.1:1")
   _tep_seed_http.set_header("k", "v")
   _tep_seed_http.do_get("/")

--- a/lib/tep/http.rb
+++ b/lib/tep/http.rb
@@ -339,5 +339,61 @@ module Tep
         @body    = ""
       end
     end
+
+    # HTTP/1.1 outbound connection pool (chunk 6.7a -- design lands
+    # ahead of Tep::Http.send_req integration in 6.7b). Per-process,
+    # keyed by (host, port). Thin Ruby surface over the C primitives
+    # in sphttp.c.
+    #
+    # Method names are `claim` / `release` (NOT `checkout` / `checkin`)
+    # to avoid colliding with `PG::Pool#checkin` -- spinel unifies
+    # parameter types across same-named methods, so reusing the names
+    # widens PG::Pool's `c` (a PG::Connection) and our `fd` (an int)
+    # into a poly type and breaks the codegen.
+    #
+    # In 6.7a, this module is callable but NOT YET wired into
+    # send_req -- Tep::Http still opens a fresh socket per request +
+    # closes it. The 6.7b chunk lands the integration once the
+    # HTTP/1.1 keep-alive recv-N-bytes path is in place. Apps can
+    # already use Pool directly for their own outbound clients.
+    class Pool
+      # Try to claim an idle keep-alive fd for (host, port). Returns
+      # the fd (>=0) on hit, -1 on miss. The caller owns the fd on
+      # hit -- close it explicitly if the request fails, or
+      # `release` it for reuse.
+      def self.claim(host, port)
+        Sock.sphttp_pool_checkout(host, port)
+      end
+
+      # Register `fd` as an idle keep-alive socket for (host, port).
+      # Returns 0 on success, -1 on failure (pool full -- the LRU
+      # gets evicted internally, so failures are rare). Don't release
+      # after a 5xx that triggered retries (the half-broken socket
+      # would poison the pool) -- close directly via Sock.sphttp_close.
+      def self.release(fd, host, port)
+        Sock.sphttp_pool_checkin(fd, host, port)
+      end
+
+      # Close idle fds older than `idle_seconds`. Returns the count
+      # closed. Call periodically from the server's idle path; not
+      # called automatically yet.
+      def self.close_idle(idle_seconds)
+        Sock.sphttp_pool_close_idle(idle_seconds)
+      end
+
+      # Stats snapshot -- returns a Tep.str_hash with the four
+      # counters. checkouts/checkins are total calls; hits/misses
+      # are subsets of checkouts (hit + miss = checkouts). The
+      # C-side primitives keep the underlying counter names; this
+      # surface uses the same names for clarity.
+      def self.stats
+        h = Tep.str_hash
+        h["checkouts"] = Sock.sphttp_pool_stat_checkouts.to_s
+        h["checkins"]  = Sock.sphttp_pool_stat_checkins.to_s
+        h["hits"]      = Sock.sphttp_pool_stat_hits.to_s
+        h["misses"]    = Sock.sphttp_pool_stat_misses.to_s
+        h
+      end
+    end
   end
 end

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -43,6 +43,19 @@ module Sock
   # Tep::Proxy's retry-backoff loop.
   ffi_func :sphttp_sleep_ms,              [:int], :int
 
+  # HTTP/1.1 outbound connection pool (chunk 6.7a). Per-process pool
+  # keyed by (host, port). checkout returns an idle fd or -1; checkin
+  # registers one; close_idle sweeps entries older than idle_seconds.
+  # Stat getters fetch one counter each (avoids a struct-return over
+  # FFI). See Tep::Http::Pool for the Ruby surface.
+  ffi_func :sphttp_pool_checkout,         [:str, :int],     :int
+  ffi_func :sphttp_pool_checkin,          [:int, :str, :int], :int
+  ffi_func :sphttp_pool_close_idle,       [:int],           :int
+  ffi_func :sphttp_pool_stat_checkouts,   [],               :int
+  ffi_func :sphttp_pool_stat_checkins,    [],               :int
+  ffi_func :sphttp_pool_stat_hits,        [],               :int
+  ffi_func :sphttp_pool_stat_misses,      [],               :int
+
   # uname-based host introspection for the toy/v1 envelope (see
   # docs/events-schema.md). sphttp_os_kind returns lowercased
   # uname.sysname ("linux" / "darwin" / ...); sphttp_arch_kind

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -572,4 +572,143 @@ const char *sphttp_arch_kind(void) {
     return sphttp_arch_buf;
 }
 
+/* ---------- HTTP/1.1 outbound connection pool (chunk 6.7) ----------
+ *
+ * Per-process pool keyed by (host, port). Each slot caches one idle
+ * keep-alive socket; checkout() removes the matching idle slot,
+ * checkin() registers an idle slot, sweep() closes slots older than
+ * an idle-timeout. Pure C state -- single-threaded server model
+ * (each prefork worker has its own copy of these statics). The Ruby
+ * wrapper (Tep::Http::Pool) provides the ergonomic API + ms-grained
+ * stats.
+ *
+ * Fixed-size array with a basic LRU-by-last-used eviction when full.
+ * 256 slots is enough for any realistic gateway shape (each slot
+ * holds one host+port+fd triple), and the hot path is O(N) over
+ * slots -- acceptable for N=256 with cache-line locality. */
+#define SPHTTP_POOL_MAX  256
+#define SPHTTP_POOL_HOST 96
+struct sphttp_pool_slot {
+    int  fd;                                 /* -1 = empty */
+    int  port;
+    long last_used_secs;                     /* epoch seconds */
+    char host[SPHTTP_POOL_HOST];
+};
+static struct sphttp_pool_slot sphttp_pool[SPHTTP_POOL_MAX];
+static int  sphttp_pool_inited = 0;
+static long sphttp_pool_checkouts = 0;
+static long sphttp_pool_checkins  = 0;
+static long sphttp_pool_hits      = 0;
+static long sphttp_pool_misses    = 0;
+
+static void sphttp_pool_init_once(void) {
+    if (sphttp_pool_inited) return;
+    int i;
+    for (i = 0; i < SPHTTP_POOL_MAX; i++) {
+        sphttp_pool[i].fd   = -1;
+        sphttp_pool[i].port = 0;
+        sphttp_pool[i].last_used_secs = 0;
+        sphttp_pool[i].host[0] = '\0';
+    }
+    sphttp_pool_inited = 1;
+}
+
+/* Try to claim an idle fd for (host, port). Returns the fd (>=0)
+ * on hit, -1 on miss. Caller owns the fd on hit -- it's removed
+ * from the pool atomically. checkouts + hits/misses are bumped for
+ * observability. */
+int sphttp_pool_checkout(const char *host, int port) {
+    sphttp_pool_init_once();
+    sphttp_pool_checkouts++;
+    int i;
+    for (i = 0; i < SPHTTP_POOL_MAX; i++) {
+        if (sphttp_pool[i].fd >= 0 &&
+            sphttp_pool[i].port == port &&
+            strncmp(sphttp_pool[i].host, host, SPHTTP_POOL_HOST) == 0) {
+            int fd = sphttp_pool[i].fd;
+            sphttp_pool[i].fd = -1;
+            sphttp_pool[i].host[0] = '\0';
+            sphttp_pool_hits++;
+            return fd;
+        }
+    }
+    sphttp_pool_misses++;
+    return -1;
+}
+
+/* Register `fd` as an idle keep-alive socket for (host, port).
+ * Returns 0 on success, -1 on failure (pool full -- in that case
+ * the caller should close the fd; we do NOT close it for them so
+ * the call stays side-effect-light). LRU-evict the oldest entry
+ * when full: sweep finds the slot with the smallest last_used,
+ * closes its fd, reuses the slot. */
+int sphttp_pool_checkin(int fd, const char *host, int port) {
+    sphttp_pool_init_once();
+    if (fd < 0) return -1;
+    int i, free_slot = -1;
+    long now = (long)time(NULL);
+    /* First pass: find an empty slot. */
+    for (i = 0; i < SPHTTP_POOL_MAX; i++) {
+        if (sphttp_pool[i].fd < 0) {
+            free_slot = i;
+            break;
+        }
+    }
+    /* Second pass: evict the LRU if no empty slot. Seed `oldest`
+     * with slot 0 + scan from i=1 to avoid needing LONG_MAX (which
+     * would pull in limits.h for a single sentinel). */
+    if (free_slot < 0) {
+        long oldest = sphttp_pool[0].last_used_secs;
+        free_slot = 0;
+        for (i = 1; i < SPHTTP_POOL_MAX; i++) {
+            if (sphttp_pool[i].last_used_secs < oldest) {
+                oldest = sphttp_pool[i].last_used_secs;
+                free_slot = i;
+            }
+        }
+        if (sphttp_pool[free_slot].fd >= 0) {
+            close(sphttp_pool[free_slot].fd);
+        }
+    }
+    if (free_slot < 0) return -1;
+    sphttp_pool[free_slot].fd   = fd;
+    sphttp_pool[free_slot].port = port;
+    sphttp_pool[free_slot].last_used_secs = now;
+    /* strncpy WITHOUT trailing NUL guarantee on overflow -- but
+     * SPHTTP_POOL_HOST is bigger than any realistic hostname; we
+     * NUL-terminate manually for safety. */
+    strncpy(sphttp_pool[free_slot].host, host, SPHTTP_POOL_HOST - 1);
+    sphttp_pool[free_slot].host[SPHTTP_POOL_HOST - 1] = '\0';
+    sphttp_pool_checkins++;
+    return 0;
+}
+
+/* Close any pooled idle fd whose last_used is older than now_secs
+ * minus idle_seconds. Returns the count of slots closed. Callers
+ * sweep periodically (e.g. the server's main loop) to bound the
+ * idle-socket count under sustained low traffic. */
+int sphttp_pool_close_idle(int idle_seconds) {
+    sphttp_pool_init_once();
+    long now = (long)time(NULL);
+    long cutoff = now - (long)idle_seconds;
+    int i, closed = 0;
+    for (i = 0; i < SPHTTP_POOL_MAX; i++) {
+        if (sphttp_pool[i].fd >= 0 &&
+            sphttp_pool[i].last_used_secs < cutoff) {
+            close(sphttp_pool[i].fd);
+            sphttp_pool[i].fd = -1;
+            sphttp_pool[i].host[0] = '\0';
+            closed++;
+        }
+    }
+    return closed;
+}
+
+/* Stats getters -- callers (Tep::Http::Pool.stats) read each one
+ * via separate FFI calls to avoid a struct-return shape over FFI. */
+int sphttp_pool_stat_checkouts(void) { return (int)sphttp_pool_checkouts; }
+int sphttp_pool_stat_checkins(void)  { return (int)sphttp_pool_checkins; }
+int sphttp_pool_stat_hits(void)      { return (int)sphttp_pool_hits; }
+int sphttp_pool_stat_misses(void)    { return (int)sphttp_pool_misses; }
+
 /* File read/write moved to spinel's built-in File.read / File.write */

--- a/test/test_http_pool.rb
+++ b/test/test_http_pool.rb
@@ -1,0 +1,122 @@
+require_relative "helper"
+require "json"
+
+# Tep::Http::Pool (chunk 6.7a). The C-side pool primitives + Ruby
+# wrapper, exercised directly. No Tep::Http.send_req integration
+# yet -- that's 6.7b (needs the HTTP/1.1 keep-alive recv-N-bytes
+# path). Tests assert the pool keys, evicts LRU, and surfaces the
+# right stats.
+class TestHttpPool < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    # Scheduled server so self-calls (sphttp_connect to our own port
+    # for the /pool/register fd) don't deadlock the single worker.
+    set :scheduler, :scheduled
+    set :workers, 1
+
+    # Reset by closing all idle fds (well past their use). Used to
+    # make per-test state deterministic.
+    post '/pool/reset' do
+      res.headers["Content-Type"] = "text/plain"
+      Tep::Http::Pool.close_idle(-1).to_s   # idle > -1s -> closes all
+    end
+
+    # Open a real socket to ourselves + checkin to the pool. Returns
+    # the fd we just registered. The test treats the fd as opaque +
+    # only asserts on the pool's behaviour.
+    post '/pool/register' do
+      res.headers["Content-Type"] = "text/plain"
+      fd = Sock.sphttp_connect("127.0.0.1", params[:port].to_i)
+      if fd < 0
+        return "connect_failed"
+      end
+      Tep::Http::Pool.release(fd, "127.0.0.1", params[:port].to_i).to_s
+    end
+
+    # Claim and report the fd (>=0 hit, -1 miss). Close on hit so
+    # the test doesn't leak.
+    get '/pool/claim/:port' do
+      res.headers["Content-Type"] = "text/plain"
+      fd = Tep::Http::Pool.claim("127.0.0.1", params[:port].to_i)
+      if fd >= 0
+        Sock.sphttp_close(fd)
+        return "hit"
+      end
+      "miss"
+    end
+
+    # Stats snapshot as JSON.
+    get '/pool/stats' do
+      res.headers["Content-Type"] = "application/json"
+      s = Tep::Http::Pool.stats
+      "{" +
+        Tep::Json.encode_pair_int("checkouts", s["checkouts"].to_i) + "," +
+        Tep::Json.encode_pair_int("checkins",  s["checkins"].to_i) + "," +
+        Tep::Json.encode_pair_int("hits",      s["hits"].to_i) + "," +
+        Tep::Json.encode_pair_int("misses",    s["misses"].to_i) +
+      "}"
+    end
+
+    # Trivial route the pool's TCP open targets -- the connect
+    # itself is what we care about; the response shape is unused.
+    get '/ping' do
+      "pong"
+    end
+  RB
+
+  def setup
+    super
+    # Drain the pool + reset counters via "miss" cycles isn't possible
+    # (stats are monotonic process-wide). Tests assert DELTAS, not
+    # absolute counts.
+    post("/pool/reset", "")
+  end
+
+  def stats_now
+    JSON.parse(get("/pool/stats").body)
+  end
+
+  def test_release_then_claim_is_a_hit
+    s0 = stats_now
+    # Register an fd in the pool.
+    res = post("/pool/register?port=#{@port}", "")
+    assert_equal "200", res.code
+    assert_equal "0", res.body, "release should succeed (returned 0)"
+
+    # First claim should HIT.
+    res = get("/pool/claim/#{@port}")
+    assert_equal "hit", res.body, "expected pool hit for the released fd"
+
+    s1 = stats_now
+    assert_equal s0["hits"] + 1, s1["hits"]
+    assert_equal s0["checkins"] + 1, s1["checkins"]
+  end
+
+  def test_claim_on_empty_pool_is_a_miss
+    s0 = stats_now
+    res = get("/pool/claim/#{@port}")
+    assert_equal "miss", res.body
+    s1 = stats_now
+    assert_equal s0["misses"] + 1, s1["misses"]
+    assert_equal s0["hits"], s1["hits"]
+  end
+
+  def test_second_claim_after_one_release_misses
+    # Register one fd; claim it; second claim should miss.
+    post("/pool/register?port=#{@port}", "")
+    res = get("/pool/claim/#{@port}")
+    assert_equal "hit", res.body
+    res = get("/pool/claim/#{@port}")
+    assert_equal "miss", res.body
+  end
+
+  def test_close_idle_removes_pooled_fds
+    # Register an fd then sweep with idle_seconds=-1 (every fd is
+    # older than -1s from "now") -- subsequent claim should miss.
+    post("/pool/register?port=#{@port}", "")
+    post("/pool/reset", "")
+    res = get("/pool/claim/#{@port}")
+    assert_equal "miss", res.body
+  end
+end


### PR DESCRIPTION
First chunk of #126. Lands the pool design as callable surface, ahead of the Tep::Http.send_req integration in 6.7b (which needs HTTP/1.1 keep-alive + recv-N-bytes parser changes).

## What

- C: `sphttp_pool_checkout` / `sphttp_pool_checkin` / `sphttp_pool_close_idle` + 4 stat getters. 256-slot fixed array, LRU-evict on full.
- Ruby: `Tep::Http::Pool.claim(host, port)` / `release(fd, host, port)` / `close_idle(secs)` / `stats`. Named claim/release to avoid spinel widening with PG::Pool#checkin.
- Test: 4 cases (release-claim hit / empty-claim miss / one-shot consume / close_idle sweep), all pass.

## Out of scope (6.7b)

- Tep::Http.send_req integration (keep-alive + recv-N-bytes).
- Periodic pool sweep from idle path.

Refs #126