### PR TITLE
chore: pin spinel to 8adbd7b + fix stale llm_gateway event-shape test

### DIFF
--- a/SPINEL_PIN
+++ b/SPINEL_PIN
@@ -1,0 +1,20 @@
+8adbd7b317d5353f41c91643fca036e8d806a29a
+
+# Pinned matz/spinel commit tep is verified to build + test against.
+# Only the first line (the ref) is read by tools/spinel-fresh.sh; the
+# rest is documentation. Bump via PR after confirming `make test`
+# (in the dev container) is green on the newer commit.
+#
+# 8adbd7b "Add GC.stat and GC.start (GC introspection part 1)"
+#   2026-05-29. Verified: 53/54 suites green in the dev container
+#   (test_real_world excluded -- pre-existing harness teardown
+#   reap-hang, unrelated to spinel; servers idle in accept() while the
+#   test process waits on a child that is never signalled to exit).
+#   Notable in-range landings: sp_core.c / sp_types.h header slimming,
+#   string-interp mutable_str fix (#1027), GC.stat/GC.start (#1021).
+#
+# Floating on master is risky while matz/spinel#1031 (GC may free
+# objects reachable only from a suspended fiber under concurrent
+# fiber-per-connection load) is open -- tep's scheduled server is
+# exactly that shape. Pinning keeps tep on a known-good commit until
+# that lands.

--- a/test/test_llm_gateway.rb
+++ b/test/test_llm_gateway.rb
@@ -83,10 +83,13 @@ class TestLlmGateway < TepTest
     lines = get("/events").body.split("\n").reject(&:empty?)
     assert_equal 1, lines.length, "expected exactly one inference event"
     ev = JSON.parse(lines[0])
-    assert_equal "inference", ev["kind"]
+    # toy/v1 inference shape (migrated in #136): kind "eval", name
+    # "request", and model/token fields nested under "extra".
+    assert_equal "eval", ev["kind"]
     assert_equal "serve", ev["phase"]
-    assert_equal "demo-llm", ev["model"]
-    assert_equal 3, ev["completion_tokens"]   # 3 SSE events dispatched
+    assert_equal "request", ev["name"]
+    assert_equal "demo-llm", ev["extra"]["model"]
+    assert_equal 3, ev["extra"]["completion_tokens"]   # 3 SSE events dispatched
     assert_equal "req-1", ev["extra"]["request_id"]
   end
 end


### PR DESCRIPTION
Introduces `SPINEL_PIN` (tep was floating on matz/spinel master) and pins to **8adbd7b** ("GC.stat/GC.start, GC introspection part 1").

## Why pin now
matz/spinel#1031 is open: *GC may free objects reachable only from a suspended fiber under concurrent fiber-per-connection load*. tep's scheduled server (`server_scheduled.rb` spawns `Fiber.new { handle_connection }` per conn, parked via `Fiber.yield`) is exactly that shape. Pinning keeps tep on a known-good commit until #1031 is understood.

## Verification
Full suite in the dev container against 8adbd7b: **53/54 suites green**. `test_real_world` excluded — it wedges on a *pre-existing harness teardown reap-hang* (test process in `do_wait`; spawned servers idle in `accept()`, never signalled to exit). Not spinel-related, not a #1031 instance (no crash/corruption/wedged connection).

## Stale-test fix
`test_llm_gateway#test_emits_one_inference_event` still asserted the pre-#136 event shape (top-level `"inference"` kind + `model`/`completion_tokens`). #136 migrated `#inference` to the toy/v1 shape (`kind:"eval"`, `name:"request"`, fields nested under `extra`); the test was missed and only surfaced now because earlier it had been run individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)