### PR TITLE
fix(server): break accept() loop on SIGTERM set between accepts; bound test reaps

### DIFF
--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -116,6 +116,18 @@ int sphttp_accept(int sfd) {
     socklen_t clen = sizeof(caddr);
     int fd;
     for (;;) {
+        /* Check the term flag BEFORE blocking, not only on EINTR.
+         * SIGTERM/SIGINT can land while we're between accepts (e.g.
+         * just after closing a keep-alive connection, looping back
+         * here): the handler sets the flag but there's no syscall in
+         * flight to interrupt, so without this pre-check the next
+         * accept() blocks forever with the flag already set -- a racy
+         * hang that shows up as a wedged server on shutdown under
+         * load. (A residual nanosecond-wide race remains between this
+         * check and accept() entering the kernel; the bulletproof fix
+         * is signalfd/self-pipe + pselect. See sphttp_accept_nb for
+         * the scheduled-server path, which sidesteps this entirely.) */
+        if (sphttp_term_flag) return -1;
         fd = accept(sfd, (struct sockaddr *)&caddr, &clen);
         if (fd >= 0) return fd;
         if (errno == EINTR) {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -59,7 +59,13 @@ module TepHarness
     log  = File.join(tmp, "app.log")
     args = [bin, "-p", port.to_s]
     args += ["-w", workers.to_s] if workers > 1
-    pid  = Process.spawn(*args, out: log, err: [:child, :out])
+    # Spawn the app as its own process-group leader (pgroup: true ->
+    # pgid == this pid). The server's shutdown contract is SIGTERM-to-
+    # the-pgroup (lib/tep/server.rb): in prefork mode the parent forks
+    # workers that block in accept(), and only a GROUP-wide signal
+    # reaches them. Teardown signals the group (see #reap); the group
+    # being distinct from the test runner's keeps that signal off us.
+    pid  = Process.spawn(*args, out: log, err: [:child, :out], pgroup: true)
     wait_for_port(port, tmp: tmp, pid: pid)
     @running << { pid: pid, tmp: tmp, log: log, port: port }
     port
@@ -77,36 +83,60 @@ module TepHarness
   def self.terminate(port, timeout: 5.0)
     s = find_by_port(port)
     return unless s
-    begin
-      Process.kill("TERM", s[:pid])
-    rescue Errno::ESRCH
-    end
-    deadline = Time.now + timeout
-    until Time.now > deadline
-      begin
-        pid, _ = Process.waitpid2(s[:pid], Process::WNOHANG)
-        break if pid
-      rescue Errno::ECHILD
-        break
-      end
-      sleep 0.05
-    end
+    reap(s[:pid], timeout: timeout)
     @running.delete(s)
   end
 
   def self.kill_all
     @running.each do |s|
-      begin
-        Process.kill("TERM", s[:pid])
-      rescue Errno::ESRCH
-      end
-      begin
-        Process.wait(s[:pid])
-      rescue Errno::ECHILD
-      end
+      reap(s[:pid])
       FileUtils.rm_rf(s[:tmp])
     end
     @running.clear
+  end
+
+  # Gracefully stop a spawned app and wait for it to exit, BOUNDED.
+  # Signals the whole process group (negative pid) so prefork workers
+  # blocked in accept() actually receive the signal -- a bare
+  # `Process.kill("TERM", pid)` hits only the parent, leaving workers
+  # wedged and the parent stuck in wait_any, which used to hang the
+  # at_exit reap forever (test process in do_wait). Escalates to
+  # SIGKILL if the graceful stop doesn't land in time, so no
+  # misbehaving server can stall the suite.
+  def self.reap(pid, timeout: 5.0)
+    signal_group(pid, "TERM")
+    return if wait_exit(pid, timeout)
+    signal_group(pid, "KILL")
+    wait_exit(pid, 2.0)
+  end
+
+  # Signal `pid`'s process group; fall back to the bare pid if the
+  # group is already gone. Swallows ESRCH (already dead).
+  def self.signal_group(pid, sig)
+    begin
+      Process.kill(sig, -pid)
+    rescue Errno::ESRCH
+      begin
+        Process.kill(sig, pid)
+      rescue Errno::ESRCH
+      end
+    end
+  end
+
+  # Poll-wait for `pid` to exit, up to `timeout` seconds. Returns true
+  # if it was reaped (or is already gone), false on timeout.
+  def self.wait_exit(pid, timeout)
+    deadline = Time.now + timeout
+    loop do
+      begin
+        got, _ = Process.waitpid2(pid, Process::WNOHANG)
+        return true if got
+      rescue Errno::ECHILD
+        return true
+      end
+      return false if Time.now > deadline
+      sleep 0.02
+    end
   end
 
   def self.wait_for_port(port, timeout: 5.0, tmp: nil, pid: nil)

--- a/test/test_real_world.rb
+++ b/test/test_real_world.rb
@@ -36,14 +36,14 @@ class TestRealWorld < TepTest
     out = `#{Shellwords.escape(File.expand_path("../bin/tep", __dir__))} build #{Shellwords.escape(src)} -o #{Shellwords.escape(bin)} 2>&1`
     raise "build failed:\n#{out}" unless $?.success?
     port = TestRealWorld.next_port
-    pid = Process.spawn(bin, "-p", port.to_s, "-q", out: "/dev/null", err: "/dev/null")
+    pid = Process.spawn(bin, "-p", port.to_s, "-q",
+                        pgroup: true, out: "/dev/null", err: "/dev/null")
     wait_for_port(port)
     @port = port
     begin
       yield port
     ensure
-      Process.kill("TERM", pid) rescue nil
-      Process.wait(pid) rescue nil
+      TepHarness.reap(pid)
     end
   end
 
@@ -157,14 +157,13 @@ class TestRealWorld < TepTest
     raise "blog build failed:\n#{out}" unless $?.success?
     port = TestRealWorld.next_port
     pid = Process.spawn({"TEP_BLOG_DB" => db}, bin, "-p", port.to_s, "-q",
-                        out: "/dev/null", err: "/dev/null")
+                        pgroup: true, out: "/dev/null", err: "/dev/null")
     wait_for_port(port)
     @port = port
     begin
       yield port
     ensure
-      Process.kill("TERM", pid) rescue nil
-      Process.wait(pid) rescue nil
+      TepHarness.reap(pid)
     end
   end
 
@@ -280,11 +279,7 @@ class TestRealWorld < TepTest
     begin
       yield port
     ensure
-      begin
-        Process.kill("-TERM", pid)
-      rescue Errno::ESRCH, Errno::EPERM
-      end
-      Process.wait(pid) rescue nil
+      TepHarness.reap(pid)
     end
   end
 

--- a/test/test_websocket_echo.rb
+++ b/test/test_websocket_echo.rb
@@ -35,8 +35,23 @@ class TestWebSocketEcho < Minitest::Test
   end
 
   def teardown
-    if @pid
-      Process.kill("TERM", @pid) rescue nil
+    return unless @pid
+    # Bounded reap: TERM, wait up to 5s, then SIGKILL. A bare
+    # Process.wait can hang forever if the server ignores TERM
+    # (single-process here, so the pid signal suffices -- no pgroup).
+    Process.kill("TERM", @pid) rescue nil
+    deadline = Time.now + 5
+    reaped = false
+    until Time.now > deadline
+      got = (Process.waitpid(@pid, Process::WNOHANG) rescue :gone)
+      if got
+        reaped = true
+        break
+      end
+      sleep 0.02
+    end
+    unless reaped
+      Process.kill("KILL", @pid) rescue nil
       Process.wait(@pid) rescue nil
     end
   end


### PR DESCRIPTION
Root-cause + fix for the parallel test runner wedging on `test_real_world` (test process in `do_wait`, spawned server idle in `inet_csk_accept`, never exiting). Two bugs:

## Server — `sphttp_accept` SIGTERM race
`sphttp_accept` only checked `sphttp_term_flag` *inside* the `EINTR` branch, never before blocking. SIGTERM landing while the worker is **between** accepts (e.g. just after closing a keep-alive conn, looping back) sets the flag with no syscall in flight to interrupt → the next `accept()` blocks forever with the flag already set. Racy → intermittent wedged-server-on-shutdown, worse under load. Fixed with a pre-check at the top of the loop.

Confirmed live: the wedged server was single-process, in `accept()`, and had **not** died from TERM — handler ran, `accept()` never returned.

> Residual nanosecond race remains between the pre-check and `accept()` entering the kernel; the bulletproof fix is signalfd/self-pipe + `pselect` (noted in-code as a follow-up). The scheduled server (`sphttp_accept_nb`) sidesteps this entirely.

## Harness — unbounded, parent-only reaps
`TepHarness` now reaps via a **bounded, process-group-aware** helper: TERM the whole group (negative pid) so prefork workers in `accept()` actually get signalled (parent-only TERM left them wedged + parent stuck in `wait_any`), wait with a timeout, then escalate to **SIGKILL**. `kill_all`'s previously-unbounded `Process.wait` could hang the `at_exit` reap forever. Apps spawn with `pgroup: true`; `test_real_world`'s three ad-hoc teardowns + `test_websocket_echo` now use the bounded reap.

Both layers matter: the server fix makes graceful TERM + `run_end` emission reliable; the harness fix is the safety net so no misbehaving server can hang the suite.

## Verification
Full parallel suite in the dev container: **460 runs, 0 failures, 0 errors, 52 skips**. `test_real_world` now completes (18 runs / 120 assertions) — previously hung indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)