### PR TITLE
feat(pg): PG::Pool#checkout raises PG::PoolExhausted on timeout

### DIFF
--- a/lib/tep/pg.rb
+++ b/lib/tep/pg.rb
@@ -828,6 +828,14 @@ module PG
   class ConnectionException    < ServerError; end                  # 08000
   class ConnectionDoesNotExist < ServerError; end                  # 08003
 
+  # Pool-side error (no SQLSTATE): raised by PG::Pool#checkout when
+  # the pool stays empty past the checkout timeout. Subclasses Error
+  # so callers can `rescue PG::PoolExhausted` or the broader
+  # `rescue PG::Error`. (Raising namespaced errors from instance
+  # methods became viable with matz/spinel#1041; before that, checkout
+  # surfaced exhaustion as a sentinel nil-equivalent Connection.)
+  class PoolExhausted          < Error; end
+
   # -------- Connection pool --------
   #
   # PG::Pool -- a fixed-size connection pool for PG::Connection
@@ -868,10 +876,13 @@ module PG
   #     Other fibers run in the meantime; eventually a checkin
   #     refills the free list and the parked fiber retries.
   #
-  # No raise from checkout -- spinel's rescue dispatch for
-  # module-namespaced classes still lags (matz/spinel#627 follow-on).
-  # Pool exhaustion timeouts surface as a sentinel "" / nil-equivalent
-  # Connection that the caller treats as failure (see `checkout_timeout`).
+  # On exhaustion (non-scheduled callers only), checkout raises
+  # PG::PoolExhausted once it has waited past @checkout_timeout_ms.
+  # This used to be a sentinel nil-equivalent return because spinel
+  # couldn't rescue module-namespaced exception classes; matz/spinel#1041
+  # fixed that, so `rescue PG::PoolExhausted` / `rescue PG::Error` now
+  # work. The scheduled path parks indefinitely (waking on checkin) and
+  # so has no exhaustion timeout -- only the spin fallback does.
   class Pool
     attr_accessor :url, :size, :free, :waiter_idxs, :checkout_timeout_ms
 
@@ -991,7 +1002,10 @@ module PG
         Tep::Scheduler.pause(1)   # full-second pause; non-scheduled fallback
         waited_ms += 1000
         if waited_ms >= @checkout_timeout_ms
-          return @free[0]
+          raise PG::PoolExhausted,
+                "PG::Pool#checkout timed out after " +
+                @checkout_timeout_ms.to_s + "ms; all " +
+                @size.to_s + " connections in use"
         end
       end
       @free.delete_at(0)

--- a/test/test_pg.rb
+++ b/test/test_pg.rb
@@ -436,6 +436,39 @@ class TestPg < TepTest
       POOL.checkin(c2)
       "first=" + v1 + " second=" + v2
     end
+
+    # GET /pool_exhaust -- drain every connection, then a further
+    # checkout past the (lowered) timeout raises PG::PoolExhausted.
+    # Verifies the raise is rescuable both as the exact class and via
+    # the PG::Error parent. Restores the pool + timeout before
+    # returning so the route is idempotent across test runs.
+    get '/pool_exhaust' do
+      POOL.set_checkout_timeout_ms(1)
+      held = []
+      n = POOL.size
+      i = 0
+      while i < n
+        held.push(POOL.checkout)
+        i += 1
+      end
+      exact = "no"
+      parent = "no"
+      begin
+        POOL.checkout
+      rescue PG::PoolExhausted => e
+        exact = "yes"
+      end
+      begin
+        POOL.checkout
+      rescue PG::Error => e
+        parent = "yes"
+      end
+      while held.length > 0
+        POOL.checkin(held.delete_at(0))
+      end
+      POOL.set_checkout_timeout_ms(5000)
+      "exact=" + exact + " parent=" + parent
+    end
   RB
 
   def test_connect_succeeds
@@ -596,6 +629,14 @@ class TestPg < TepTest
   def test_pool_returned_connection_is_reusable
     res = get("/pool_reusable")
     assert_equal "first=1 second=2", res.body
+  end
+
+  def test_pool_exhaustion_raises_pool_exhausted
+    res = get("/pool_exhaust")
+    assert_equal "200", res.code
+    # checkout past the timeout raises PG::PoolExhausted, caught both
+    # as the exact class and via the PG::Error parent (matz/spinel#1041).
+    assert_equal "exact=yes parent=yes", res.body
   end
 
   # --- async exec ---


### PR DESCRIPTION
Absorbs the sentinel-return workaround in `PG::Pool#checkout`, now that matz/spinel#1041 (merged + pinned via #145) lets instance methods raise module-namespaced exception classes that callers can `rescue` as the exact class or a parent.

## Change
- Add `PG::PoolExhausted < PG::Error` (pool-side, no SQLSTATE).
- `checkout_spin_fallback` **raises** `PG::PoolExhausted` once it waits past `@checkout_timeout_ms`, instead of returning `@free[0]` (a nil-equivalent sentinel callers had to sniff for). The scheduled path is unchanged — it parks until `checkin`, no timeout.
- Update the stale "no raise from checkout" comment.
- `test_pg`: `/pool_exhaust` drains the pool then checks out past a lowered timeout; new test asserts the raise is caught both as `PG::PoolExhausted` and via the `PG::Error` parent.

`checkout` is user-facing with no internal sentinel-dependent callers (only a docstring example references it).

## Verification
- Against a real PostgreSQL (compose `pg` service): `test_pg` **27 runs / 71 assertions / 0 failures** (was 26); new exhaustion test → `exact=yes parent=yes`.
- Full parallel suite with `PG_TEST_URL` (pg.rb compiles into every app): **461 runs, 0 failures, 0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)