### PR TITLE
feat(http): outbound TLS for Tep::Http (HTTPS via libssl) — #148 phase 1

### DIFF
--- a/lib/tep/http.rb
+++ b/lib/tep/http.rb
@@ -128,7 +128,14 @@ module Tep
     # extra poll(2) round per chunk for no benefit. Keeping the
     # blocking path keeps the cheap case cheap.
     def self.send_req(verb, url, body, headers)
-      if Tep::Scheduler.scheduled_context?
+      # TLS currently has only a blocking path (the SSL handshake runs
+      # over a blocking socket), so route https through send_req_blocking
+      # even under the scheduler. Caveat: an https call inside
+      # Tep::Server::Scheduled blocks the worker for that request;
+      # plaintext keeps the cooperative path. (Non-blocking TLS is the
+      # phase-1b follow-up on tep#148.)
+      is_https = Tep::Url.split_url(url)["scheme"] == "https"
+      if Tep::Scheduler.scheduled_context? && !is_https
         Http.send_req_coop(verb, url, body, headers)
       else
         Http.send_req_blocking(verb, url, body, headers)
@@ -138,8 +145,9 @@ module Tep
     def self.send_req_blocking(verb, url, body, headers)
       out = Tep::Http::Response.new
       parts = Tep::Url.split_url(url)
-      if parts["scheme"] != "http"
-        # HTTPS / unknown scheme -- not in v1.
+      scheme = parts["scheme"]
+      if scheme != "http" && scheme != "https"
+        # Unknown scheme.
         return out
       end
       host = parts["host"]
@@ -149,7 +157,12 @@ module Tep
         path = path + "?" + parts["query"]
       end
 
-      fd = Sock.sphttp_connect(host, port)
+      fd = -1
+      if scheme == "https"
+        fd = Sock.sphttp_connect_tls(host, port)   # verified TLS (port 443 via Tep::Url)
+      else
+        fd = Sock.sphttp_connect(host, port)
+      end
       if fd < 0
         return out
       end

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -8,6 +8,12 @@
 # portable shape.
 module Sock
   ffi_cflags "@TEP_SPHTTP_O@"
+  # Outbound TLS (sphttp_connect_tls) is backed by the system
+  # libssl/libcrypto. Linked for every app (like sqlite3 elsewhere);
+  # the plaintext path never calls into it, so apps that make no HTTPS
+  # requests pay only the link cost, not runtime. See tep#148.
+  ffi_lib "ssl"
+  ffi_lib "crypto"
 
   ffi_func :sphttp_listen,        [:int, :int],     :int
   ffi_func :sphttp_accept,        [:int],           :int
@@ -89,6 +95,10 @@ module Sock
 
   # Outbound TCP for clients (Tep::Http, etc.).
   ffi_func :sphttp_connect,       [:str, :int],     :int
+  # TLS variant: TCP connect + verified TLS handshake (SNI + hostname
+  # + peer cert). Returns an fd whose write/recv/close transparently
+  # route through the SSL*. -1 on connect/handshake/verify failure.
+  ffi_func :sphttp_connect_tls,   [:str, :int],     :int
   ffi_func :sphttp_recv_some,     [:int, :int],     :str
   ffi_func :sphttp_recv_all,      [:int, :int],     :str
 

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -28,6 +28,44 @@
 #define SPHTTP_BUFSIZE   65536
 #define SPHTTP_RESP_MAX  (4 * 1024 * 1024)
 
+/* ---------- TLS (libssl) binding -- outbound client; see tep#148 ----------
+ *
+ * The socket layer stays fd-based: sphttp_connect_tls returns a normal
+ * socket fd and registers an SSL* for it in sphttp_ssl_tab, keyed by fd.
+ * The read/write/close helpers consult the table and route through
+ * SSL_read/SSL_write/SSL_shutdown when an SSL* is present, else plain
+ * send/recv/close. So the FFI surface gains exactly one function
+ * (sphttp_connect_tls) and everything downstream is TLS-transparent.
+ * Sockets created via sphttp_connect_tls are BLOCKING, so SSL_read/
+ * SSL_write either complete or hard-error (no WANT_READ/WANT_WRITE
+ * churn). Inbound/server TLS (SSL_accept) is a later phase reusing
+ * this same table + a server-side SSL_CTX. */
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/x509v3.h>
+
+#define SPHTTP_FD_MAX 4096
+static SSL     *sphttp_ssl_tab[SPHTTP_FD_MAX];   /* fd -> SSL*, NULL = plaintext */
+static SSL_CTX *sphttp_ssl_ctx = NULL;
+
+static SSL *sphttp_ssl_for(int fd) {
+    if (fd < 0 || fd >= SPHTTP_FD_MAX) return NULL;
+    return sphttp_ssl_tab[fd];
+}
+
+/* Lazily build the shared client SSL_CTX: TLS 1.2+, peer verification
+ * on, system CA bundle. NULL on failure (callers fall back to -1). */
+static SSL_CTX *sphttp_ssl_ctx_get(void) {
+    if (sphttp_ssl_ctx) return sphttp_ssl_ctx;
+    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+    if (!ctx) return NULL;
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+    SSL_CTX_set_default_verify_paths(ctx);
+    sphttp_ssl_ctx = ctx;
+    return ctx;
+}
+
 static char sphttp_req_buf[SPHTTP_BUFSIZE];
 static int  sphttp_req_len = 0;
 
@@ -213,15 +251,22 @@ const char *sphttp_drain_body(int fd, int total_len) {
 }
 
 int sphttp_write_str(int fd, const char *s) {
+    SSL *ssl = sphttp_ssl_for(fd);
     size_t len = strlen(s);
     size_t off = 0;
     while (off < len) {
-        ssize_t n = send(fd, s + off, len - off, 0);
-        if (n <= 0) {
-            if (errno == EINTR) continue;
-            return -1;
+        if (ssl) {
+            int w = SSL_write(ssl, s + off, (int)(len - off));
+            if (w <= 0) return -1;
+            off += (size_t)w;
+        } else {
+            ssize_t n = send(fd, s + off, len - off, 0);
+            if (n <= 0) {
+                if (errno == EINTR) continue;
+                return -1;
+            }
+            off += (size_t)n;
         }
-        off += (size_t)n;
     }
     return 0;
 }
@@ -231,15 +276,22 @@ int sphttp_write_str(int fd, const char *s) {
  * frames, raw protocol bodies). Returns 0 on success, -1 on send
  * failure. */
 int sphttp_write_bytes(int fd, const char *data, int n) {
+    SSL *ssl = sphttp_ssl_for(fd);
     size_t total = (n < 0) ? 0 : (size_t)n;
     size_t off = 0;
     while (off < total) {
-        ssize_t w = send(fd, data + off, total - off, 0);
-        if (w <= 0) {
-            if (errno == EINTR) continue;
-            return -1;
+        if (ssl) {
+            int w = SSL_write(ssl, data + off, (int)(total - off));
+            if (w <= 0) return -1;
+            off += (size_t)w;
+        } else {
+            ssize_t w = send(fd, data + off, total - off, 0);
+            if (w <= 0) {
+                if (errno == EINTR) continue;
+                return -1;
+            }
+            off += (size_t)w;
         }
-        off += (size_t)w;
     }
     return 0;
 }
@@ -322,6 +374,12 @@ int sphttp_filesize(const char *path) {
 }
 
 int sphttp_close(int fd) {
+    SSL *ssl = sphttp_ssl_for(fd);
+    if (ssl) {
+        SSL_shutdown(ssl);
+        SSL_free(ssl);
+        sphttp_ssl_tab[fd] = NULL;   /* fd < SPHTTP_FD_MAX guaranteed by sphttp_ssl_for */
+    }
     return close(fd);
 }
 
@@ -474,6 +532,39 @@ int sphttp_connect(const char *host, int port) {
     return fd;
 }
 
+/* Outbound TLS connect: TCP connect to host:port, then a TLS 1.2+
+ * handshake with SNI + peer-cert verification + hostname check.
+ * Registers the SSL* against the returned fd so subsequent
+ * write/recv/close route through it transparently. Returns the fd on
+ * success, -1 on connect/handshake/verification failure. */
+int sphttp_connect_tls(const char *host, int port) {
+    int fd = sphttp_connect(host, port);
+    if (fd < 0) return -1;
+    if (fd >= SPHTTP_FD_MAX) { close(fd); return -1; }
+
+    SSL_CTX *ctx = sphttp_ssl_ctx_get();
+    if (!ctx) { close(fd); return -1; }
+    SSL *ssl = SSL_new(ctx);
+    if (!ssl) { close(fd); return -1; }
+
+    SSL_set_fd(ssl, fd);
+    /* SNI -- required by virtually every multi-tenant TLS endpoint. */
+    SSL_set_tlsext_host_name(ssl, host);
+    /* Verify the presented cert actually matches `host`. */
+    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    if (SSL_set1_host(ssl, host) != 1) { SSL_free(ssl); close(fd); return -1; }
+
+    if (SSL_connect(ssl) != 1) {
+        /* Handshake or verification failed (incl. bad/expired cert,
+         * hostname mismatch, untrusted CA). */
+        SSL_free(ssl);
+        close(fd);
+        return -1;
+    }
+    sphttp_ssl_tab[fd] = ssl;
+    return fd;
+}
+
 /* Best-effort recv() that returns the bytes as a static buffer.
  * Pairs with sphttp_set_nonblock + sphttp_poll_run for the scheduler
  * loop. Returns "" on EAGAIN/empty so callers can branch on
@@ -482,7 +573,9 @@ int sphttp_connect(const char *host, int port) {
 static char sphttp_recv_buf[SPHTTP_BUFSIZE];
 const char *sphttp_recv_some(int fd, int maxlen) {
     if (maxlen <= 0 || maxlen >= SPHTTP_BUFSIZE) maxlen = SPHTTP_BUFSIZE - 1;
-    ssize_t n = recv(fd, sphttp_recv_buf, (size_t)maxlen, 0);
+    SSL *ssl = sphttp_ssl_for(fd);
+    ssize_t n = ssl ? (ssize_t)SSL_read(ssl, sphttp_recv_buf, maxlen)
+                    : recv(fd, sphttp_recv_buf, (size_t)maxlen, 0);
     if (n <= 0) {
         sphttp_recv_buf[0] = '\0';
         return sphttp_recv_buf;
@@ -500,9 +593,12 @@ const char *sphttp_recv_some(int fd, int maxlen) {
 static char sphttp_recv_all_buf[SPHTTP_BUFSIZE];
 const char *sphttp_recv_all(int fd, int max_bytes) {
     if (max_bytes <= 0 || max_bytes >= SPHTTP_BUFSIZE) max_bytes = SPHTTP_BUFSIZE - 1;
+    SSL *ssl = sphttp_ssl_for(fd);
     int total = 0;
     while (total < max_bytes) {
-        ssize_t n = recv(fd, sphttp_recv_all_buf + total, (size_t)(max_bytes - total), 0);
+        ssize_t n = ssl
+            ? (ssize_t)SSL_read(ssl, sphttp_recv_all_buf + total, max_bytes - total)
+            : recv(fd, sphttp_recv_all_buf + total, (size_t)(max_bytes - total), 0);
         if (n <= 0) break;
         total += (int)n;
     }


### PR DESCRIPTION
Implements **phase 1 (outbound)** of #148. `Tep::Http` can now make **verified HTTPS** requests — previously `send_req` rejected any non-`http` scheme, blocking every HTTPS-only upstream (the qdrant spike's wall #1).

## sphttp.c — TLS binding (system libssl/libcrypto)
- Lazy shared client `SSL_CTX`: TLS 1.2+, `SSL_VERIFY_PEER`, system CA bundle.
- **fd→`SSL*` registry** so `write_str`/`write_bytes`/`recv_some`/`recv_all`/`close` are transparently TLS-aware (SSL_* when the fd has an SSL\*, else plain). FFI surface gains exactly one function.
- `sphttp_connect_tls(host, port)`: TCP connect + handshake with **SNI** + **hostname verification** (`SSL_set1_host`) + peer-cert verification.

## net.rb / http.rb
- `ffi_lib "ssl"/"crypto"` (linked for every app like sqlite3; plaintext path never calls in) + `sphttp_connect_tls` decl.
- `https` routed through the blocking `send_req` selecting `connect_tls`; scheme reject removed.
- **Caveat:** TLS has only a blocking path for now, so an https call under `Tep::Server::Scheduled` blocks the worker for that request (non-blocking TLS = phase 1b). Plaintext keeps the cooperative path.

## Verification
- `Tep::Http.get("https://example.com/")` → **200** (handshake + cert verify + I/O).
- GET to a **live Qdrant Cloud** instance (HTTPS + api-key header) → **200**, valid JSON — the original spike goal is now reachable via raw `Tep::Http`.
- Full parallel suite **green: 461 runs, 0 failures, 0 errors** — the every-app `-lssl`/`-lcrypto` link is regression-free.

Inbound/server TLS (`SSL_accept`) reuses this infra — phase 2 on #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)