### PR TITLE
feat(http): caching phase 2 — ETag/Last-Modified + revalidation for static serving (#152)

### DIFF
--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -61,7 +61,7 @@ module Tep
     # Server.serve!(events_jsonl); empty path => zero-overhead disabled.
     # Late-seeded for the same reason as openai_backend.
     attr_accessor :openai_events
-    attr_accessor :asset_bodies, :asset_mimes
+    attr_accessor :asset_bodies, :asset_mimes, :asset_etags
     attr_accessor :sched_fibers, :sched_wake_at, :sched_current
     attr_accessor :sched_io_fd, :sched_io_mode, :sched_io_ready
     # Tep::Job background-worker idempotency flag. App-level so a
@@ -102,6 +102,7 @@ module Tep
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines
                                      # the bin/tep translator emits)
+      @asset_etags    = Tep.str_hash # path -> content-hash ETag (#152)
       # FiberSlot array for the cooperative scheduler. Initialise
       # with a noop-bodied slot to pin the array element type, then
       # drop it. Each slot holds one Fiber + a timer entry in the
@@ -129,6 +130,13 @@ module Tep
     def add_asset(path, body, mime)
       @asset_bodies[path] = body
       @asset_mimes[path]  = mime
+      # Content-hash ETag for cache revalidation (#152). SHA-1 is used
+      # purely as a fast content fingerprint here (not a security hash --
+      # collision resistance is irrelevant for an ETag, same as git's
+      # content addressing). Computed once at boot. (Binary bodies with
+      # embedded NULs hash by their leading bytes via the FFI string
+      # boundary; still stable per content, which is all an ETag needs.)
+      @asset_etags[path] = Crypto.sp_crypto_sha1_hex(body)
     end
 
     def set_session_secret(s)

--- a/lib/tep/assets.rb
+++ b/lib/tep/assets.rb
@@ -41,6 +41,10 @@ module Tep
       end
       res.headers["Content-Type"] = Tep::APP.asset_mimes[path]
       res.headers["Cache-Control"] = "public, max-age=3600"
+      # Content-hash ETag (#152): lets the browser revalidate with
+      # If-None-Match and get a 304 (handled by the server's
+      # Tep::Cache short-circuit) instead of re-downloading the body.
+      res.etag(Tep::APP.asset_etags[path])
       res.set_body_if_empty(Tep::APP.asset_bodies[path])
       true
     end

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -81,6 +81,7 @@ module Sock
 
   ffi_func :sphttp_sendfile,      [:int, :str],     :int
   ffi_func :sphttp_filesize,      [:str],           :int
+  ffi_func :sphttp_file_mtime,    [:str],           :int
   ffi_func :sphttp_close,         [:int],           :int
   ffi_func :sphttp_fork,          [],               :int
   ffi_func :sphttp_exit,          [:int],           :int

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -161,7 +161,13 @@ module Tep
           send_simple(client, 404, "file not found")
           return
         end
-        res.headers["Content-Length"] = sz.to_s
+        # Cache validators for revalidation (#152): a size-mtime ETag +
+        # Last-Modified, set before the conditional check.
+        mt = Sock.sphttp_file_mtime(res.file_path)
+        if mt >= 0
+          res.etag(sz.to_s + "-" + mt.to_s)
+          res.last_modified(mt)
+        end
         if !res.headers.key?("Content-Type")
           res.headers["Content-Type"] = "application/octet-stream"
         end
@@ -170,6 +176,15 @@ module Tep
         else
           res.headers["Connection"] = "close"
         end
+        # Conditional GET: 304 + no body (no sendfile) when the client's
+        # cached copy is still fresh.
+        if Tep::Cache.not_modified?(req, res)
+          res.set_status(304)
+          res.headers["Content-Length"] = "0"
+          Sock.sphttp_write_str(client, build_head(req, res))
+          return
+        end
+        res.headers["Content-Length"] = sz.to_s
         head = build_head(req, res)
         Sock.sphttp_write_str(client, head)
         Sock.sphttp_sendfile(client, res.file_path)

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -237,13 +237,26 @@ module Tep
           return 0
         end
 
-        # Conditional GET (issue #152): 304 + no body when the handler's
-        # validator (ETag / Last-Modified) satisfies the request
-        # precondition. File responses don't set validators yet (phase
-        # 2), so this only affects the inline-body path here.
+        # File validators for cache revalidation (#152): a size-mtime
+        # ETag + Last-Modified, set before headers are serialized below.
+        if res.file_path.length > 0
+          fsz = Sock.sphttp_filesize(res.file_path)
+          fmt = Sock.sphttp_file_mtime(res.file_path)
+          if fsz >= 0 && fmt >= 0
+            res.etag(fsz.to_s + "-" + fmt.to_s)
+            res.last_modified(fmt)
+          end
+        end
+
+        # Conditional GET (issue #152): 304 + no body when the request's
+        # precondition matches the response's validator (ETag /
+        # Last-Modified, whether set by the handler or for a file above).
+        # For a file we also clear file_path so the sendfile branch below
+        # is skipped and the empty 304 goes out the inline-body path.
         if Tep::Cache.not_modified?(req, res)
           res.set_status(304)
           res.set_body("")
+          res.file_path = ""
         end
 
         # Default Content-Type for inline-body responses. Matches

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -377,6 +377,16 @@ int sphttp_filesize(const char *path) {
     return (int)st.st_size;
 }
 
+/* mtime (Unix epoch seconds) of a regular file, or -1 if it doesn't
+ * stat / isn't a regular file. Used for send_file's Last-Modified +
+ * the size-mtime ETag (cache revalidation, #152). */
+int sphttp_file_mtime(const char *path) {
+    struct stat st;
+    if (stat(path, &st) < 0) return -1;
+    if ((st.st_mode & S_IFMT) != S_IFREG) return -1;
+    return (int)st.st_mtime;
+}
+
 int sphttp_close(int fd) {
     SSL *ssl = sphttp_ssl_for(fd);
     if (ssl) {

--- a/test/test_cache_static.rb
+++ b/test/test_cache_static.rb
@@ -1,0 +1,48 @@
+require_relative "helper"
+
+# Caching phase 2 (#152): static files served via send_file (public_dir)
+# carry a size-mtime ETag + Last-Modified and revalidate to 304.
+class TestCacheStatic < TepTest
+  app_source <<~RB
+    set :public_dir, '#{File.expand_path("../public", __dir__)}'
+
+    get '/' do
+      "root"
+    end
+  RB
+
+  def test_static_file_has_validators
+    res = get("/hello.txt")
+    assert_equal "200", res.code
+    refute_nil res["ETag"]
+    assert_match(/GMT\z/, res["Last-Modified"])
+    assert_match(/static file serving/, res.body)
+  end
+
+  def test_static_if_none_match_returns_304
+    etag = get("/hello.txt")["ETag"]
+    res = get("/hello.txt", {"If-None-Match" => etag})
+    assert_equal "304", res.code
+    assert_equal "", res.body.to_s
+    assert_equal etag, res["ETag"]   # validator preserved on 304
+  end
+
+  def test_static_if_modified_since_equal_returns_304
+    lm = get("/hello.txt")["Last-Modified"]
+    res = get("/hello.txt", {"If-Modified-Since" => lm})
+    assert_equal "304", res.code
+    assert_equal "", res.body.to_s
+  end
+
+  def test_static_if_modified_since_old_returns_200
+    res = get("/hello.txt", {"If-Modified-Since" => "Sat, 01 Jan 2000 00:00:00 GMT"})
+    assert_equal "200", res.code
+    assert_match(/static file serving/, res.body)
+  end
+
+  def test_static_if_none_match_mismatch_returns_200
+    res = get("/hello.txt", {"If-None-Match" => "\"nope\""})
+    assert_equal "200", res.code
+    assert_match(/static file serving/, res.body)
+  end
+end


### PR DESCRIPTION
Phase 2 of #152 (phase 1 was #154). Wires cache validators into the two static-serving paths so bundled assets + sent files **revalidate to 304** instead of always re-sending the body.

- **`Assets.serve`** (bundled assets): content-hash ETag, computed once at boot in `App#add_asset` via `Crypto.sp_crypto_sha1_hex` (a content fingerprint, not a security hash — git-style). Revalidation rides the existing `Tep::Cache` short-circuit.
- **`send_file`** (incl. `public_dir` serving): size-mtime ETag + Last-Modified from the file's stat. Both server write paths (prefork + scheduled) set these before the conditional check and, on a match, emit **304 + no body, skipping the sendfile**.
- New C: `sphttp_file_mtime(path)` → epoch (mirrors `sphttp_filesize`).

## Verification
`test_cache_static` (5 runs / 17 assertions): `send_file` responses carry ETag + Last-Modified; If-None-Match / If-Modified-Since → 304 (no body, validator preserved); mismatch / stale date → 200. Full suite **green: 477 runs, 0 failures, 0 errors** (no flake this round).

Closes #152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)