### PR TITLE
feat(server): inbound TLS termination (#148 phase 2)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -174,6 +174,14 @@ module Tep
   def self.session_secret;     APP.session_secret;        end
   def self.session_secret=(v); APP.set_session_secret(v); end
 
+  # Inbound TLS (tep#148 phase 2). Point these at a PEM cert + key and
+  # Tep::Server terminates HTTPS itself; unset (default) = plain HTTP.
+  #   Tep.tls_cert = "cert.pem"; Tep.tls_key = "key.pem"
+  def self.tls_cert;     APP.tls_cert;        end
+  def self.tls_cert=(v); APP.set_tls_cert(v); end
+  def self.tls_key;      APP.tls_key;         end
+  def self.tls_key=(v);  APP.set_tls_key(v);  end
+
   # Spinel infers method parameter types from concrete call sites.
   # If a user app never calls Tep.before / Tep.not_found / etc.,
   # spinel falls back to int and the underlying set_* assignment
@@ -199,6 +207,8 @@ module Tep
   _tep_seed_res = Response.new
   _tep_seed_res.set_cookie("", "", str_hash)
   APP.set_session_secret("")
+  APP.set_tls_cert("")
+  APP.set_tls_key("")
   _tep_seed_sess = Session.new
   _tep_seed_sess.load_from("", "")
   _tep_seed_sess.to_cookie_value("")

--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -10,6 +10,7 @@
 module Tep
   class App
     attr_accessor :router, :static_root, :session_secret
+    attr_accessor :tls_cert, :tls_key
     attr_accessor :before_filter, :after_filter, :nf_handler
     # The auth-filter runs BEFORE before_filter so handler bodies and
     # user filters always see a populated req.identity. Separate slot
@@ -74,6 +75,8 @@ module Tep
       @router         = Router.new
       @static_root    = ""
       @session_secret = ""
+      @tls_cert       = ""   # inbound TLS cert path (tep#148 ph2; "" = plain HTTP)
+      @tls_key        = ""   # inbound TLS key path
       @before_filter  = Filter.new   # no-op default
       @after_filter   = Filter.new
       @auth_filter    = Filter.new   # no-op until Tep::Auth.install!
@@ -141,6 +144,16 @@ module Tep
 
     def set_session_secret(s)
       @session_secret = s
+    end
+
+    # Inbound TLS cert/key paths (tep#148 phase 2). Set via
+    # Tep.tls_cert= / Tep.tls_key=; read by Tep::Server.run at boot.
+    def set_tls_cert(s)
+      @tls_cert = s
+    end
+
+    def set_tls_key(s)
+      @tls_key = s
     end
 
     def add_route(verb, pattern, handler)

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -108,6 +108,12 @@ module Sock
   # + peer cert). Returns an fd whose write/recv/close transparently
   # route through the SSL*. -1 on connect/handshake/verify failure.
   ffi_func :sphttp_connect_tls,   [:str, :int],     :int
+  # Inbound (server) TLS (tep#148 phase 2). server_init loads cert+key
+  # once (before prefork); accept_tls wraps an accepted fd in a TLS
+  # handshake (0 ok / -1 fail, caller closes). read/write/close then
+  # route through the SSL* via the same fd registry.
+  ffi_func :sphttp_tls_server_init, [:str, :str],   :int
+  ffi_func :sphttp_accept_tls,      [:int],         :int
   ffi_func :sphttp_recv_some,     [:int, :int],     :str
   ffi_func :sphttp_recv_all,      [:int, :int],     :str
 

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -25,8 +25,12 @@ module Tep
     end
 
     def run(port, workers, quiet)
+      scheme = "http"
+      if Tep::APP.tls_cert.length > 0
+        scheme = "https"
+      end
       if !quiet
-        puts "[tep " + VERSION + "] listening on http://0.0.0.0:" + port.to_s +
+        puts "[tep " + VERSION + "] listening on " + scheme + "://0.0.0.0:" + port.to_s +
              " (workers=" + workers.to_s + ")"
       end
 
@@ -34,6 +38,17 @@ module Tep
       # them; on signal, sphttp_accept returns -1 and the worker loop
       # runs Tep.on_shutdown (flushes events.run_end + future hooks).
       Sock.sphttp_install_term_handlers
+
+      # Inbound TLS (tep#148 phase 2): load the server cert/key once
+      # before forking so every worker inherits the SSL_CTX. A bad
+      # cert/key is fatal -- fail loud rather than serve plaintext on a
+      # port the operator believes is TLS.
+      if Tep::APP.tls_cert.length > 0 && Tep::APP.tls_key.length > 0
+        if Sock.sphttp_tls_server_init(Tep::APP.tls_cert, Tep::APP.tls_key) < 0
+          puts "tep: TLS init failed (cert=" + Tep::APP.tls_cert + ", key=" + Tep::APP.tls_key + ")"
+          exit(1)
+        end
+      end
 
       if workers <= 1
         sfd = Sock.sphttp_listen(port, 0)
@@ -95,6 +110,22 @@ module Tep
             break
           end
           next
+        end
+        # Inbound TLS: complete the server-side handshake on the freshly
+        # accepted fd before reading the request. Bound the handshake
+        # with a recv timeout first -- otherwise a connection that opens
+        # but never sends a ClientHello (a port probe, a slowloris, a
+        # plain-HTTP client) blocks SSL_accept and wedges this worker.
+        # Clear the timeout after a successful handshake so normal
+        # (incl. keep-alive) request reads aren't bounded. On failure
+        # drop the connection.
+        if Tep::APP.tls_cert.length > 0
+          Sock.sphttp_set_recv_timeout(client, 5000)
+          if Sock.sphttp_accept_tls(client) < 0
+            Sock.sphttp_close(client)
+            next
+          end
+          Sock.sphttp_set_recv_timeout(client, 0)
         end
         handle_connection(client)
       end

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -203,17 +203,20 @@ int sphttp_accept_nb(int sfd) {
  * recv()s for the body are the caller's job (we expose a length helper).
  * Returns the parsed length (>0), 0 on clean EOF, -1 on error. */
 int sphttp_read_request(int fd) {
+    SSL *ssl = sphttp_ssl_for(fd);   /* inbound TLS: decrypt via SSL_read */
     sphttp_req_len = 0;
     sphttp_req_buf[0] = '\0';
     while (sphttp_req_len < SPHTTP_BUFSIZE - 1) {
-        ssize_t n = recv(fd, sphttp_req_buf + sphttp_req_len,
-                         SPHTTP_BUFSIZE - 1 - sphttp_req_len, 0);
+        int want = SPHTTP_BUFSIZE - 1 - sphttp_req_len;
+        ssize_t n = ssl
+            ? (ssize_t)SSL_read(ssl, sphttp_req_buf + sphttp_req_len, want)
+            : recv(fd, sphttp_req_buf + sphttp_req_len, (size_t)want, 0);
         if (n == 0) {
             if (sphttp_req_len == 0) return 0;
             break;
         }
         if (n < 0) {
-            if (errno == EINTR) continue;
+            if (!ssl && errno == EINTR) continue;
             return -1;
         }
         sphttp_req_len += (int)n;
@@ -238,14 +241,16 @@ int sphttp_request_len(void) {
 static char sphttp_body_buf[SPHTTP_BUFSIZE];
 
 const char *sphttp_drain_body(int fd, int total_len) {
+    SSL *ssl = sphttp_ssl_for(fd);
     int n = total_len;
     if (n < 0) n = 0;
     if (n >= SPHTTP_BUFSIZE) n = SPHTTP_BUFSIZE - 1;
     int got = 0;
     while (got < n) {
-        ssize_t r = recv(fd, sphttp_body_buf + got, n - got, 0);
+        ssize_t r = ssl ? (ssize_t)SSL_read(ssl, sphttp_body_buf + got, n - got)
+                        : recv(fd, sphttp_body_buf + got, n - got, 0);
         if (r <= 0) {
-            if (errno == EINTR) continue;
+            if (!ssl && errno == EINTR) continue;
             break;
         }
         got += (int)r;
@@ -319,10 +324,12 @@ static int  sphttp_frame_len = 0;
  * to have parked on a poll/io_wait beforehand -- this fn does NOT
  * retry. */
 int sphttp_recv_into_frame(int fd) {
+    SSL *ssl = sphttp_ssl_for(fd);
     sphttp_frame_len = 0;
-    ssize_t n = recv(fd, sphttp_frame_buf, SPHTTP_BUFSIZE, 0);
+    ssize_t n = ssl ? (ssize_t)SSL_read(ssl, sphttp_frame_buf, SPHTTP_BUFSIZE)
+                    : recv(fd, sphttp_frame_buf, SPHTTP_BUFSIZE, 0);
     if (n < 0) {
-        if (errno == EINTR) {
+        if (!ssl && errno == EINTR) {
             /* one retry on EINTR for ergonomics; further EINTRs surface */
             n = recv(fd, sphttp_frame_buf, SPHTTP_BUFSIZE, 0);
             if (n < 0) return -1;
@@ -597,6 +604,45 @@ int sphttp_connect_tls(const char *host, int port) {
     }
     sphttp_ssl_tab[fd] = ssl;
     return fd;
+}
+
+/* ---- inbound (server) TLS -- tep#148 phase 2 ----
+ *
+ * A separate server-side SSL_CTX (cert + key). sphttp_tls_server_init
+ * loads them once (before the prefork, so workers inherit the CTX);
+ * sphttp_accept_tls wraps an already-accepted plain-TCP fd in a TLS
+ * handshake and registers the SSL* so read/write/close are transparent
+ * (same fd->SSL* table as the client path). Blocking fd, so SSL_accept
+ * completes or hard-errors. */
+static SSL_CTX *sphttp_ssl_server_ctx = NULL;
+
+/* Load cert chain + private key into the server CTX. Returns 0 on
+ * success, -1 on any failure (missing/unreadable files, key mismatch). */
+int sphttp_tls_server_init(const char *cert_path, const char *key_path) {
+    SSL_CTX *ctx = SSL_CTX_new(TLS_server_method());
+    if (!ctx) return -1;
+    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+    if (SSL_CTX_use_certificate_chain_file(ctx, cert_path) != 1) { SSL_CTX_free(ctx); return -1; }
+    if (SSL_CTX_use_PrivateKey_file(ctx, key_path, SSL_FILETYPE_PEM) != 1) { SSL_CTX_free(ctx); return -1; }
+    if (SSL_CTX_check_private_key(ctx) != 1) { SSL_CTX_free(ctx); return -1; }
+    sphttp_ssl_server_ctx = ctx;
+    return 0;
+}
+
+/* Server-side TLS handshake over an accepted fd. Returns 0 on success
+ * (SSL* registered for fd), -1 on failure -- the caller closes the fd. */
+int sphttp_accept_tls(int fd) {
+    if (!sphttp_ssl_server_ctx) return -1;
+    if (fd < 0 || fd >= SPHTTP_FD_MAX) return -1;
+    SSL *ssl = SSL_new(sphttp_ssl_server_ctx);
+    if (!ssl) return -1;
+    SSL_set_fd(ssl, fd);
+    if (SSL_accept(ssl) != 1) {
+        SSL_free(ssl);
+        return -1;
+    }
+    sphttp_ssl_tab[fd] = ssl;
+    return 0;
 }
 
 /* Best-effort recv() that returns the bytes as a static buffer.

--- a/test/test_inbound_tls.rb
+++ b/test/test_inbound_tls.rb
@@ -1,0 +1,101 @@
+require_relative "helper"
+require "openssl"
+require "socket"
+require "timeout"
+
+# Inbound server TLS (#148 phase 2): Tep::Server terminates HTTPS when
+# Tep.tls_cert / Tep.tls_key are set. Boots a tep binary with a
+# self-signed cert and drives it with a TLS client.
+class TestInboundTls < TepTest
+  # Per-process cert paths (unique under the parallel runner). Baked
+  # into app_source at class load; generated before the binary boots.
+  CERT = "/tmp/tep_tls_test_#{Process.pid}.crt"
+  KEY  = "/tmp/tep_tls_test_#{Process.pid}.key"
+
+  app_source <<~RB
+    require 'sinatra'
+    Tep.tls_cert = "#{CERT}"
+    Tep.tls_key  = "#{KEY}"
+
+    get '/hello' do
+      "tls-ok"
+    end
+  RB
+
+  def self.gen_cert
+    return if File.exist?(CERT) && File.exist?(KEY)
+    key  = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 1
+    cert.subject    = OpenSSL::X509::Name.parse("/CN=localhost")
+    cert.issuer     = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 60
+    cert.not_after  = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+    File.write(CERT, cert.to_pem)
+    File.write(KEY,  key.to_pem)
+  end
+
+  def setup
+    self.class.gen_cert    # must exist before the spawned binary boots
+    super
+  end
+
+  def tls_get(path)
+    # Timeout-wrapped so a server-side handshake/read hang fails the
+    # test fast instead of wedging forever.
+    Timeout.timeout(15) do
+      sock = TCPSocket.new("127.0.0.1", @port)
+      ctx  = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE   # self-signed
+      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+      ssl.connect
+      ssl.write("GET #{path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+      out = ssl.read.to_s
+      ssl.close rescue nil
+      sock.close rescue nil
+      out
+    end
+  end
+
+  def test_serves_a_request_over_tls
+    resp = tls_get("/hello")
+    assert_match(/200/, resp)
+    assert_match(/tls-ok/, resp)
+  end
+
+  def test_presents_the_configured_certificate
+    cn = Timeout.timeout(15) do
+      sock = TCPSocket.new("127.0.0.1", @port)
+      ctx  = OpenSSL::SSL::SSLContext.new
+      ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+      ssl.connect
+      subj = ssl.peer_cert.subject.to_s
+      ssl.close rescue nil
+      sock.close rescue nil
+      subj
+    end
+    assert_match(/CN=localhost/, cn)
+  end
+
+  def test_plaintext_request_to_tls_port_is_dropped
+    # A plain-HTTP request to the TLS port: SSL_accept fails on the
+    # non-TLS bytes, the server drops the connection -> no HTTP reply.
+    sock = TCPSocket.new("127.0.0.1", @port)
+    sock.write("GET /hello HTTP/1.0\r\nConnection: close\r\n\r\n")
+    data = ""
+    begin
+      data = sock.read_nonblock(64)
+    rescue IO::WaitReadable
+      IO.select([sock], nil, nil, 1.0)
+      data = (sock.read_nonblock(64) rescue "")
+    rescue
+      data = ""
+    end
+    sock.close rescue nil
+    refute_match(/HTTP\//, data.to_s)   # no plaintext HTTP response
+  end
+end


### PR DESCRIPTION
Phase 2 of #148. `Tep::Server` now terminates HTTPS itself when `Tep.tls_cert` / `Tep.tls_key` are set (PEM cert + key); unset = plain HTTP. Reuses the `fd→SSL*` registry from outbound TLS (#149).

## sphttp.c
- `sphttp_tls_server_init(cert, key)`: server `SSL_CTX` (TLS 1.2+), load + check the cert/key pair. Called once before the prefork so workers inherit it.
- `sphttp_accept_tls(fd)`: `SSL_accept` on an accepted fd; registers the `SSL*`.
- **Made the inbound readers SSL-aware** — `sphttp_read_request` / `drain_body` / `recv_into_frame` now `SSL_read` when the fd carries an `SSL*`. They used raw `recv()`, so a TLS request was read as **encrypted bytes → no response** (the bug behind a multi-hour hang while debugging). Plaintext fds are byte-identical to before.

## server.rb
- `run()`: init the CTX before forking (fatal on bad cert/key — fail loud, don't serve plaintext on a TLS port); banner shows `https`.
- `worker_loop()`: **bound the handshake with a 5s recv timeout** before `SSL_accept`, so a connection that never sends a ClientHello (port probe, slowloris, plain-HTTP client) can't wedge the blocking worker; clear it after a successful handshake.

## Config
`Tep.tls_cert=` / `Tep.tls_key=` (mirrors `Tep.session_secret=`).

## Scope
**Prefork server only.** The scheduled server needs a non-blocking `SSL_accept` (WANT_READ/WRITE → `io_wait`) — a follow-up alongside #150.

## Verification
`test_inbound_tls` (3 runs / 8 assertions): serves over TLS, presents the configured cert, drops plain-HTTP to the TLS port. Manual `openssl s_client` returns `200 OK / tls-hi`. Full suite **green: 480 runs, 0 failures** (WebSocket included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)