### PR TITLE
feat(tls): non-blocking TLS -- cooperative outbound (#150) + scheduled inbound

### DIFF
--- a/lib/tep/http.rb
+++ b/lib/tep/http.rb
@@ -135,14 +135,14 @@ module Tep
     # extra poll(2) round per chunk for no benefit. Keeping the
     # blocking path keeps the cheap case cheap.
     def self.send_req(verb, url, body, headers)
-      # TLS currently has only a blocking path (the SSL handshake runs
-      # over a blocking socket), so route https through send_req_blocking
-      # even under the scheduler. Caveat: an https call inside
-      # Tep::Server::Scheduled blocks the worker for that request;
-      # plaintext keeps the cooperative path. (Non-blocking TLS is the
-      # phase-1b follow-up on tep#148.)
-      is_https = Tep::Url.split_url(url)["scheme"] == "https"
-      if Tep::Scheduler.scheduled_context? && !is_https
+      # Under Tep::Server::Scheduled, route BOTH http and https through
+      # the cooperative path. Plaintext parks on io_wait between recvs;
+      # https (tep#150) additionally drives a non-blocking TLS handshake
+      # (sphttp_tls_connect_start + handshake_step) and a want-aware
+      # SSL_read loop, so an outbound HTTPS call no longer blocks the
+      # whole worker. Outside a scheduled context the blocking path stays
+      # cheap (no extra poll(2) per chunk).
+      if Tep::Scheduler.scheduled_context?
         Http.send_req_coop(verb, url, body, headers)
       else
         Http.send_req_blocking(verb, url, body, headers)
@@ -276,7 +276,8 @@ module Tep
     def self.send_req_coop(verb, url, body, headers)
       out = Tep::Http::Response.new
       parts = Tep::Url.split_url(url)
-      if parts["scheme"] != "http"
+      scheme = parts["scheme"]
+      if scheme != "http" && scheme != "https"
         return out
       end
       host = parts["host"]
@@ -286,11 +287,42 @@ module Tep
         path = path + "?" + parts["query"]
       end
 
-      fd = Sock.sphttp_connect(host, port)
-      if fd < 0
-        return out
+      # Connect. https (tep#150): non-blocking TLS -- set up the SSL then
+      # drive SSL_do_handshake, parking on io_wait for the direction
+      # OpenSSL asks for until the handshake completes. http: a plain
+      # non-blocking connect. Either way `fd` ends up non-blocking with
+      # write/recv routed appropriately (SSL_* for https via the registry).
+      if scheme == "https"
+        fd = Sock.sphttp_tls_connect_start(host, port)
+        if fd < 0
+          return out
+        end
+        hs = Sock.sphttp_tls_handshake_step(fd)
+        while hs == 1 || hs == 2
+          mode = Tep::Scheduler::READ
+          if hs == 2
+            mode = Tep::Scheduler::WRITE
+          end
+          ready = Tep::Scheduler.io_wait(fd, mode, COOP_RECV_TIMEOUT)
+          if ready == 0
+            Sock.sphttp_close(fd)
+            return out
+          end
+          hs = Sock.sphttp_tls_handshake_step(fd)
+        end
+        if hs < 0
+          # Handshake/verify failure -- handshake_step already freed the
+          # SSL*; close the fd. (cert/hostname mismatch lands here.)
+          Sock.sphttp_close(fd)
+          return out
+        end
+      else
+        fd = Sock.sphttp_connect(host, port)
+        if fd < 0
+          return out
+        end
+        Sock.sphttp_set_nonblock(fd)
       end
-      Sock.sphttp_set_nonblock(fd)
 
       # Same head shape as send_req_blocking; inlined for the same
       # spinel-type-inference reason (see that path's comment).
@@ -332,9 +364,21 @@ module Tep
         end
         chunk = Sock.sphttp_recv_some(fd, 4096)
         if chunk.length == 0
-          # EOF (or transient EAGAIN that recv_some swallows). For
-          # HTTP/1.0 + Connection: close that's the end-of-response
-          # signal.
+          # An empty read is ambiguous: for TLS it may mean "no full
+          # record decoded yet" (SSL_read WANT_READ/WANT_WRITE), not EOF.
+          # Consult the want-status: 1 = want-read (re-park on READ at the
+          # loop top), 2 = want-write (TLS renegotiation -- park on WRITE
+          # then retry), anything else (3 EOF / -1 error, or a plaintext
+          # peer close) is the end of the HTTP/1.0 + Connection: close
+          # response.
+          st = Sock.sphttp_io_status
+          if st == 1
+            next
+          end
+          if st == 2
+            Tep::Scheduler.io_wait(fd, Tep::Scheduler::WRITE, COOP_RECV_TIMEOUT)
+            next
+          end
           break
         end
         raw = raw + chunk

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -114,6 +114,16 @@ module Sock
   # route through the SSL* via the same fd registry.
   ffi_func :sphttp_tls_server_init, [:str, :str],   :int
   ffi_func :sphttp_accept_tls,      [:int],         :int
+  # Non-blocking TLS (tep#150 outbound coop + scheduled inbound). *_start
+  # sets up the SSL but does NOT run the handshake; handshake_step drives
+  # one SSL_do_handshake (0=done / 1=want-read / 2=want-write / -1=fail)
+  # so a fiber parks on io_wait between steps. io_status reports the last
+  # recv/handshake want-state (0 ok / 1 read / 2 write / 3 eof / -1 err)
+  # so the coop recv loops tell a TLS partial record from a real EOF.
+  ffi_func :sphttp_tls_connect_start,  [:str, :int], :int
+  ffi_func :sphttp_tls_accept_start,   [:int],       :int
+  ffi_func :sphttp_tls_handshake_step, [:int],       :int
+  ffi_func :sphttp_io_status,          [],           :int
   ffi_func :sphttp_recv_some,     [:int, :int],     :str
   ffi_func :sphttp_recv_all,      [:int, :int],     :str
 

--- a/lib/tep/request.rb
+++ b/lib/tep/request.rb
@@ -155,6 +155,18 @@ module Tep
         end
         chunk = Sock.sphttp_recv_some(client_fd, cl - @raw_body.length)
         if chunk.length == 0
+          # Over TLS an empty read can be a partial record (SSL_read
+          # WANT_READ/WANT_WRITE) rather than a peer close -- re-park on
+          # the indicated direction and retry instead of truncating the
+          # body. Plaintext EOF/error (status 3/-1) still breaks.
+          st = Sock.sphttp_io_status
+          if st == 1
+            next
+          end
+          if st == 2
+            Tep::Scheduler.io_wait(client_fd, Tep::Scheduler::WRITE, 5)
+            next
+          end
           break   # peer closed mid-body
         end
         @raw_body = @raw_body + chunk

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -52,6 +52,17 @@ module Tep
         # second and runs Tep.on_shutdown (run_end + future hooks).
         Sock.sphttp_install_term_handlers
 
+        # Inbound TLS (tep#148 phase 2, scheduled variant): load the
+        # server cert/key once before forking so every worker inherits
+        # the SSL_CTX. A bad cert/key is fatal -- never silently serve
+        # plaintext on a port the operator believes is TLS. The handshake
+        # itself runs non-blocking per-connection (handle_connection).
+        if Tep::APP.tls_cert.length > 0 && Tep::APP.tls_key.length > 0
+          if Sock.sphttp_tls_server_init(Tep::APP.tls_cert, Tep::APP.tls_key) < 0
+            return 1
+          end
+        end
+
         if workers > 1
           i = 0
           while i < workers
@@ -128,8 +139,53 @@ module Tep
         end
       end
 
+      # Non-blocking server-side TLS handshake on an accepted fd.
+      # Returns 1 on success (SSL* registered -- reads/writes are now
+      # transparent), 0 on failure. Drives SSL_do_handshake, parking on
+      # io_wait for the direction OpenSSL asks for, bounded by
+      # HEADER_READ_TIMEOUT so a connection that opens but never
+      # completes the handshake (port probe, slowloris, plain-HTTP
+      # client) can't pin the fiber.
+      def self.tls_handshake(client)
+        if Sock.sphttp_tls_accept_start(client) < 0
+          return 0
+        end
+        deadline = Time.now.to_i + HEADER_READ_TIMEOUT
+        hs = Sock.sphttp_tls_handshake_step(client)
+        while hs == 1 || hs == 2
+          remaining = deadline - Time.now.to_i
+          if remaining <= 0
+            return 0
+          end
+          mode = Tep::Scheduler::READ
+          if hs == 2
+            mode = Tep::Scheduler::WRITE
+          end
+          ready = Tep::Scheduler.io_wait(client, mode, remaining)
+          if ready == 0
+            return 0
+          end
+          hs = Sock.sphttp_tls_handshake_step(client)
+        end
+        if hs < 0
+          return 0
+        end
+        1
+      end
+
       # Per-connection lifecycle.
       def self.handle_connection(client)
+        # Inbound TLS: complete a non-blocking server handshake before
+        # reading anything. Runs inside this per-connection fiber so a
+        # slow handshake parks cooperatively instead of blocking the
+        # accept loop. On failure (incl. a plaintext client hitting the
+        # TLS port) drop the connection.
+        if Tep::APP.tls_cert.length > 0
+          if Tep::Server::Scheduled.tls_handshake(client) == 0
+            Sock.sphttp_close(client)
+            return 0
+          end
+        end
         keep_going = true
         while keep_going
           blob = Tep::Server::Scheduled.read_request_blob(client, KEEPALIVE_TIMEOUT)
@@ -175,6 +231,18 @@ module Tep
           end
           chunk = Sock.sphttp_recv_some(fd, 4096)
           if chunk.length == 0
+            # Over TLS an empty read can be a partial record (SSL_read
+            # WANT_READ/WANT_WRITE), not EOF -- re-park on the indicated
+            # direction and retry rather than dropping the request. The
+            # loop top re-applies the deadline on the want-read path.
+            st = Sock.sphttp_io_status
+            if st == 1
+              next
+            end
+            if st == 2
+              Tep::Scheduler.io_wait(fd, Tep::Scheduler::WRITE, remaining)
+              next
+            end
             return ""
           end
           buf = buf + chunk

--- a/lib/tep/sphttp.c
+++ b/lib/tep/sphttp.c
@@ -489,6 +489,88 @@ int sphttp_accept_tls(int fd) {
     return 0;
 }
 
+/* ---- non-blocking TLS -- tep#150 (outbound coop) + scheduled inbound ----
+ *
+ * The blocking connect_tls / accept_tls above run the handshake inline,
+ * which is correct for the prefork-blocking server but would wedge a
+ * fiber under Tep::Server::Scheduled (the fd is non-blocking there, so
+ * the handshake -- and later SSL_read -- can return WANT_READ/WANT_WRITE
+ * instead of completing). These helpers split SSL setup from stepping so
+ * the Ruby fiber can park on Tep::Scheduler.io_wait for the indicated
+ * direction and retry. sphttp_io_status() exposes the last want-state so
+ * the cooperative recv loops can tell "no full TLS record yet" from a
+ * real EOF (both surface as an empty sphttp_recv_some result). */
+
+/* Last I/O want-state, set by sphttp_recv_some and the handshake
+ * stepper: 0 = ok (data / handshake done), 1 = want-read, 2 = want-write,
+ * 3 = clean EOF (peer close / TLS close_notify), -1 = hard error. */
+static int sphttp_io_last = 0;
+int sphttp_io_status(void) { return sphttp_io_last; }
+
+/* Map SSL_get_error for a <=0 SSL_read/SSL_do_handshake return to our
+ * want-state vocabulary. */
+static int sphttp_ssl_want(SSL *ssl, int ret) {
+    int e = SSL_get_error(ssl, ret);
+    if (e == SSL_ERROR_WANT_READ)   return 1;
+    if (e == SSL_ERROR_WANT_WRITE)  return 2;
+    if (e == SSL_ERROR_ZERO_RETURN) return 3;   /* clean close_notify */
+    return -1;
+}
+
+/* Begin an outbound TLS connection on a NON-BLOCKING socket: TCP
+ * connect, set non-blocking, build the client SSL (SNI + peer-cert +
+ * hostname verification), register it -- but DO NOT run the handshake.
+ * The caller drives it via sphttp_tls_handshake_step. Returns the fd, or
+ * -1 on any setup failure (fd closed). */
+int sphttp_tls_connect_start(const char *host, int port) {
+    int fd = sphttp_connect(host, port);
+    if (fd < 0) return -1;
+    if (fd >= SPHTTP_FD_MAX) { close(fd); return -1; }
+    if (sp_net_set_nonblock(fd) < 0) { close(fd); return -1; }
+    SSL_CTX *ctx = sphttp_ssl_ctx_get();
+    if (!ctx) { close(fd); return -1; }
+    SSL *ssl = SSL_new(ctx);
+    if (!ssl) { close(fd); return -1; }
+    SSL_set_fd(ssl, fd);
+    SSL_set_tlsext_host_name(ssl, host);
+    SSL_set_hostflags(ssl, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+    if (SSL_set1_host(ssl, host) != 1) { SSL_free(ssl); close(fd); return -1; }
+    SSL_set_connect_state(ssl);
+    sphttp_ssl_tab[fd] = ssl;
+    return fd;
+}
+
+/* Begin an inbound TLS handshake on an already-accepted, NON-BLOCKING
+ * fd. Registers the server SSL* but does not run the handshake. Returns
+ * 0 on success, -1 on setup failure (caller closes the fd). */
+int sphttp_tls_accept_start(int fd) {
+    if (!sphttp_ssl_server_ctx) return -1;
+    if (fd < 0 || fd >= SPHTTP_FD_MAX) return -1;
+    SSL *ssl = SSL_new(sphttp_ssl_server_ctx);
+    if (!ssl) return -1;
+    SSL_set_fd(ssl, fd);
+    SSL_set_accept_state(ssl);
+    sphttp_ssl_tab[fd] = ssl;
+    return 0;
+}
+
+/* Drive one step of a non-blocking handshake (client or server -- the
+ * SSL's connect/accept state set above picks the direction). Returns
+ * 0 = complete, 1 = want-read, 2 = want-write, -1 = hard failure. On
+ * hard failure the SSL* is freed + unregistered (caller closes fd). */
+int sphttp_tls_handshake_step(int fd) {
+    SSL *ssl = sphttp_ssl_for(fd);
+    if (!ssl) return -1;
+    int r = SSL_do_handshake(ssl);
+    if (r == 1) { sphttp_io_last = 0; return 0; }
+    int w = sphttp_ssl_want(ssl, r);
+    if (w == 1 || w == 2) { sphttp_io_last = w; return w; }
+    sphttp_ssl_tab[fd] = NULL;          /* incl. cert/hostname verify fail */
+    SSL_free(ssl);
+    sphttp_io_last = -1;
+    return -1;
+}
+
 /* Best-effort recv() that returns the bytes as a static buffer.
  * Pairs with sphttp_set_nonblock + sphttp_poll_run for the scheduler
  * loop. Returns "" on EAGAIN/empty so callers can branch on
@@ -501,9 +583,21 @@ const char *sphttp_recv_some(int fd, int maxlen) {
     ssize_t n = ssl ? (ssize_t)SSL_read(ssl, sphttp_recv_buf, maxlen)
                     : recv(fd, sphttp_recv_buf, (size_t)maxlen, 0);
     if (n <= 0) {
+        /* Record WHY we got nothing so the cooperative recv loops
+         * (send_req_coop / read_request_blob) can park-and-retry on a
+         * TLS partial record or a non-blocking EAGAIN instead of
+         * mistaking either for EOF. The blocking callers ignore it. */
+        if (ssl) {
+            sphttp_io_last = sphttp_ssl_want(ssl, (int)n);
+        } else if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            sphttp_io_last = 1;                    /* would block -> read */
+        } else {
+            sphttp_io_last = (n == 0) ? 3 : -1;    /* EOF vs error */
+        }
         sphttp_recv_buf[0] = '\0';
         return sphttp_recv_buf;
     }
+    sphttp_io_last = 0;
     sphttp_recv_buf[n] = '\0';
     return sphttp_recv_buf;
 }

--- a/test/test_inbound_tls_scheduled.rb
+++ b/test/test_inbound_tls_scheduled.rb
@@ -1,0 +1,101 @@
+require_relative "helper"
+require "openssl"
+require "socket"
+require "timeout"
+
+# Scheduled-server inbound TLS (#148 phase 2, scheduled variant):
+# Tep::Server::Scheduled terminates HTTPS with a NON-BLOCKING SSL_accept
+# (sphttp_tls_accept_start + handshake_step parked on the scheduler).
+# Mirrors test_inbound_tls.rb but with `set :scheduler, :scheduled`, so
+# it exercises the cooperative handshake + want-aware recv path.
+class TestInboundTlsScheduled < TepTest
+  CERT = "/tmp/tep_tls_sched_test_#{Process.pid}.crt"
+  KEY  = "/tmp/tep_tls_sched_test_#{Process.pid}.key"
+
+  app_source <<~RB
+    require 'sinatra'
+    set :scheduler, :scheduled
+    Tep.tls_cert = "#{CERT}"
+    Tep.tls_key  = "#{KEY}"
+
+    get '/hello' do
+      "tls-sched-ok"
+    end
+
+    post '/echo' do
+      "echo:" + request.body.read
+    end
+  RB
+
+  def self.gen_cert
+    return if File.exist?(CERT) && File.exist?(KEY)
+    key  = OpenSSL::PKey::RSA.new(2048)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version    = 2
+    cert.serial     = 1
+    cert.subject    = OpenSSL::X509::Name.parse("/CN=localhost")
+    cert.issuer     = cert.subject
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 60
+    cert.not_after  = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest::SHA256.new)
+    File.write(CERT, cert.to_pem)
+    File.write(KEY,  key.to_pem)
+  end
+
+  def setup
+    self.class.gen_cert    # must exist before the spawned binary boots
+    super
+  end
+
+  def tls_socket
+    sock = TCPSocket.new("127.0.0.1", @port)
+    ctx  = OpenSSL::SSL::SSLContext.new
+    ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE   # self-signed
+    ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+    ssl.connect
+    [ssl, sock]
+  end
+
+  def tls_get(path)
+    Timeout.timeout(15) do
+      ssl, sock = tls_socket
+      ssl.write("GET #{path} HTTP/1.0\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+      out = ssl.read.to_s
+      ssl.close rescue nil
+      sock.close rescue nil
+      out
+    end
+  end
+
+  def test_serves_a_request_over_tls_under_scheduler
+    resp = tls_get("/hello")
+    assert_match(/200/, resp)
+    assert_match(/tls-sched-ok/, resp)
+  end
+
+  def test_post_body_over_tls_under_scheduler
+    # Drives the want-aware body drain (consume_body_via_scheduler) over
+    # TLS -- a partial SSL record must not truncate the body.
+    resp = Timeout.timeout(15) do
+      ssl, sock = tls_socket
+      body = "hello-tls-body"
+      ssl.write("POST /echo HTTP/1.0\r\nHost: localhost\r\n" \
+                "Content-Type: text/plain\r\nContent-Length: #{body.bytesize}\r\n" \
+                "Connection: close\r\n\r\n#{body}")
+      out = ssl.read.to_s
+      ssl.close rescue nil
+      sock.close rescue nil
+      out
+    end
+    assert_match(/200/, resp)
+    assert_match(/echo:hello-tls-body/, resp)
+  end
+
+  def test_two_sequential_tls_connections
+    # A second connection must hand-shake cleanly after the first closed
+    # (server CTX reused across connections / fibers).
+    assert_match(/tls-sched-ok/, tls_get("/hello"))
+    assert_match(/tls-sched-ok/, tls_get("/hello"))
+  end
+end


### PR DESCRIPTION
Makes TLS cooperative under Tep::Server::Scheduled, both directions. Shared non-blocking handshake infra (connect_start/accept_start/handshake_step + io_status want-state); want-aware coop recv loops. New test exercises a real TLS handshake + POST body + sequential conns through the scheduler. Full suite green (487 runs, 0f/0e). Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)