### PR TITLE
feat(build): inline app-local require_relative -> tep apps can use a real gem

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -176,7 +176,7 @@ def translate(input_path)
     # `something.frob`) is just user code: pass it through verbatim
     # so spinel sees it at program load.
     if call?(node) && node.receiver.nil?
-      result = handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough)
+      result = handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough, input_path)
       startup_block = result if result.is_a?(Hash) && result[:kind] == :startup
       return
     end
@@ -1097,7 +1097,7 @@ def handle_tep_live(node, live_views, warnings)
   }
 end
 
-def handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough)
+def handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters, not_founds, config, warnings, passthrough, input_path = nil)
   name = node.name.to_s
 
   if name == "mcp_tool"
@@ -1302,22 +1302,39 @@ def handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters,
 
   case name
   when "require", "require_relative"
-    # The translator inlines tep's own library (see inlined_tep_library);
-    # other require / require_relative calls are silently dropped because
-    # spinel resolves require_relative finicky-ly and the build-time
-    # inline is the reliable path. Warn on non-tep paths so app authors
-    # who didn't read the framework docs aren't left with a wall of
-    # "uninitialized constant" warnings from spinel, fifty lines later,
-    # with no hint of the cause.
+    # tep's own library is inlined wholesale (see inlined_tep_library), so
+    # `require_relative "tep"` / "tep/..." is a no-op. A plain `require
+    # "gem"` (by name) is dropped -- spinel has no gem load path. But an
+    # app-local `require_relative "vendor/foo"` IS honoured: we read the
+    # target now and splice its source straight into the program, exactly
+    # as we do for tep's library. spinel can't be relied on to resolve
+    # require_relative at build time, but build-time inlining is reliable
+    # -- and it lets a tep app vendor and use a real Ruby gem (e.g.
+    # examples/geohash/vendor/pr_geohash.rb). Only genuinely-missing files
+    # warn, so a typo still surfaces early instead of fifty spinel
+    # "uninitialized constant" lines later.
     if name == "require_relative"
       args = node.arguments&.arguments || []
       first = args.first
       if first.is_a?(Prism::StringNode)
         path = first.unescaped
-        unless path == "tep" || path.start_with?("tep/")
-          warnings << "external `require_relative #{path.inspect}` ignored " \
-                      "(tep build only inlines tep/lib). Pre-inline the " \
-                      "file into the app source, or use a wrapper script."
+        if path != "tep" && !path.start_with?("tep/")
+          base = input_path ? File.dirname(input_path) : Dir.pwd
+          cand = File.expand_path(path.end_with?(".rb") ? path : path + ".rb", base)
+          if File.file?(cand)
+            src = File.read(cand)
+            if src =~ /^\s*require_relative\b/
+              warnings << "inlined `require_relative #{path.inspect}`, but the " \
+                          "target has its own require_relative (NOT recursively " \
+                          "inlined) -- flatten the dependency if the build fails."
+            end
+            passthrough << "# --- inlined require_relative #{path.inspect} (#{File.basename(cand)}) ---"
+            passthrough << src
+          else
+            warnings << "external `require_relative #{path.inspect}` ignored " \
+                        "(no file at #{cand}). Vendor the file next to the app " \
+                        "or pre-inline it into the app source."
+          end
         end
       end
     end

--- a/examples/geohash/README.md
+++ b/examples/geohash/README.md
@@ -1,0 +1,52 @@
+# geohash — using a real published gem from a tep app
+
+This example demonstrates something tep couldn't do before: **compile and
+run an app that depends on an unmodified, published Ruby gem.**
+
+The gem is [`pr_geohash` 1.0.0](https://rubygems.org/gems/pr_geohash) (MIT),
+a pure-Ruby geohash encoder. Its source is vendored verbatim at
+[`vendor/pr_geohash.rb`](vendor/pr_geohash.rb) (original license header
+intact) and pulled in the ordinary Ruby way:
+
+```ruby
+require_relative 'vendor/pr_geohash'
+# ...
+get '/geohash' do
+  GeoHash.encode(params["lat"].to_f, params["lon"].to_f, 12)
+end
+```
+
+## How it works
+
+tep apps are ahead-of-time compiled by spinel — there is no runtime gem
+loader. `bin/tep build` inlines **app-local `require_relative` targets**
+straight into the generated program (the same mechanism it already used
+for tep's own library), so the gem becomes native compiled code in the
+binary. A plain `require "gem_name"` is still dropped — spinel has no gem
+search path — so to use a gem you vendor its source and `require_relative`
+it, as here.
+
+## Run it
+
+```sh
+bin/tep build examples/geohash/app.rb -o /tmp/geohash
+/tmp/geohash -p 4979 &
+curl 'http://127.0.0.1:4979/geohash?lat=48.8584&lon=2.2945&precision=8'
+# => u09tunqu   (identical to CRuby's GeoHash.encode)
+```
+
+`test/test_geohash_example.rb` builds this app and checks the output
+matches CRuby byte-for-byte.
+
+## What works, what doesn't (gem reuse is per-method)
+
+`GeoHash.encode` compiles and runs cleanly — it uses only `map`, `join`,
+integer bit-ops and Float comparisons, all of which spinel supports.
+
+`GeoHash.neighbors` and `GeoHash.decode` are deliberately **not** exposed:
+they rely on `Array#flatten` / `Array#transpose`, which spinel doesn't
+compile yet (the build fails with `undefined method 'flatten'`). That's
+the honest shape of gem reuse under tep today: the hot path of a
+well-behaved pure-Ruby gem drops straight in, while methods that reach for
+unsupported stdlib corners don't. Pick the entry points that stay inside
+the supported surface.

--- a/examples/geohash/app.rb
+++ b/examples/geohash/app.rb
@@ -1,0 +1,32 @@
+require 'sinatra'
+
+# Use a REAL, unmodified published Ruby gem -- pr_geohash 1.0.0 (MIT) --
+# from inside a tep app. spinel inlines `require_relative`, so the gem's
+# source is compiled straight into the AOT binary; no runtime gem loader
+# is involved. See examples/geohash/README.md for the why/how.
+require_relative 'vendor/pr_geohash'
+
+# GET /geohash?lat=..&lon=..&precision=..
+# Encodes a latitude/longitude into a geohash using GeoHash.encode from
+# the gem. Query params (not path segments) so the '-' and '.' in real
+# coordinates don't need escaping.
+get '/geohash' do
+  lat  = params["lat"].to_f
+  lon  = params["lon"].to_f
+  prec = params["precision"].to_i
+  if prec <= 0
+    prec = 12
+  end
+  GeoHash.encode(lat, lon, prec)
+end
+
+# NOTE: GeoHash.neighbors / GeoHash.decode are intentionally NOT exposed.
+# They lean on Array#flatten / Array#transpose, which spinel doesn't
+# compile yet (encode uses only map/join/bit-ops and works fine). A good
+# illustration that gem reuse is per-method: the hot path compiles, a
+# couple of helpers don't -- see README.md.
+
+get '/' do
+  "tep + pr_geohash 1.0.0 (a real, unmodified published gem)\n" +
+  "try: /geohash?lat=48.8584&lon=2.2945&precision=8\n"
+end

--- a/examples/geohash/vendor/pr_geohash.rb
+++ b/examples/geohash/vendor/pr_geohash.rb
@@ -1,0 +1,93 @@
+=begin
+geohash.rb
+Geohash library for pure ruby
+Distributed under the MIT License
+
+Based library is 
+// http://github.com/davetroy/geohash-js/blob/master/geohash.js
+// geohash.js
+// Geohash library for Javascript
+// (c) 2008 David Troy
+// Distributed under the MIT License
+=end
+
+module GeoHash
+  VERSION = "1.0.0"
+  
+  #########
+  # Decode from geohash
+  # 
+  # geohash:: geohash code
+  # return:: decoded bounding box [[north latitude, west longitude],[south latitude, east longitude]]
+  def decode(geohash)
+    latlng = [[-90.0, 90.0], [-180.0, 180.0]]
+    is_lng = 1
+    geohash.downcase.scan(/./) do |c|
+      BITS.each do |mask|
+        latlng[is_lng][(BASE32.index(c) & mask)==0 ? 1 : 0] = (latlng[is_lng][0] + latlng[is_lng][1]) / 2
+        is_lng ^= 1
+      end
+    end
+    latlng.transpose
+  end
+  module_function :decode
+  
+  #########
+  # Encode latitude and longitude into geohash
+  def encode(latitude, longitude, precision=12)
+    latlng = [latitude, longitude]
+    points = [[-90.0, 90.0], [-180.0, 180.0]]
+    is_lng = 1
+    (0...precision).map {
+      ch = 0
+      5.times do |bit|
+        mid = (points[is_lng][0] + points[is_lng][1]) / 2
+        points[is_lng][latlng[is_lng] > mid ? 0 : 1] = mid
+        ch |=  BITS[bit] if latlng[is_lng] > mid
+        is_lng ^= 1
+      end
+      BASE32[ch,1]
+    }.join
+  end
+  module_function :encode
+  
+  #########
+  # Calculate neighbors (8 adjacents) geohash
+  def neighbors(geohash)
+    [[:top, :right], [:right, :bottom], [:bottom, :left], [:left, :top]].map{ |dirs|
+      point = adjacent(geohash, dirs[0])
+      [point, adjacent(point, dirs[1])]
+    }.flatten
+  end
+  module_function :neighbors
+  
+  #########
+  # Calculate adjacents geohash
+  def adjacent(geohash, dir)
+    base, lastChr = geohash[0..-2], geohash[-1,1]
+    type = (geohash.length % 2)==1 ? :odd : :even
+    if BORDERS[dir][type].include?(lastChr)
+      base = adjacent(base, dir)
+    end
+    base + BASE32[NEIGHBORS[dir][type].index(lastChr),1]
+  end
+  module_function :adjacent
+  
+  
+  BITS = [0x10, 0x08, 0x04, 0x02, 0x01]
+  BASE32 = "0123456789bcdefghjkmnpqrstuvwxyz"
+  
+  NEIGHBORS = {
+    :right  => { :even => "bc01fg45238967deuvhjyznpkmstqrwx", :odd => "p0r21436x8zb9dcf5h7kjnmqesgutwvy" },
+    :left   => { :even => "238967debc01fg45kmstqrwxuvhjyznp", :odd => "14365h7k9dcfesgujnmqp0r2twvyx8zb" },
+    :top    => { :even => "p0r21436x8zb9dcf5h7kjnmqesgutwvy", :odd => "bc01fg45238967deuvhjyznpkmstqrwx" },
+    :bottom => { :even => "14365h7k9dcfesgujnmqp0r2twvyx8zb", :odd => "238967debc01fg45kmstqrwxuvhjyznp" }
+  }
+  
+  BORDERS = {
+    :right  => { :even => "bcfguvyz", :odd => "prxz" },
+    :left   => { :even => "0145hjnp", :odd => "028b" },
+    :top    => { :even => "prxz"    , :odd => "bcfguvyz" },
+    :bottom => { :even => "028b"    , :odd => "0145hjnp" }
+  }
+end # module GeoHash

--- a/test/test_geohash_example.rb
+++ b/test/test_geohash_example.rb
@@ -1,0 +1,74 @@
+require "minitest/autorun"
+require "net/http"
+require "socket"
+require "tmpdir"
+require "fileutils"
+
+# Proves tep can compile + run an app that uses a REAL, unmodified
+# published Ruby gem (pr_geohash 1.0.0, MIT) vendored next to the app and
+# pulled in with `require_relative`. `bin/tep build` inlines app-local
+# require_relative targets into the AOT binary (no runtime gem loader),
+# so GeoHash.encode runs as native compiled code. Reference outputs below
+# are CRuby's (ruby -I lib + GeoHash.encode) -- the spinel-compiled binary
+# must match them byte-for-byte.
+#
+# Unlike the other suites this builds the real examples/geohash/app.rb in
+# place (not an app_source heredoc in a tmpdir) so the relative
+# require_relative resolves against the vendored gem.
+class TestGeohashExample < Minitest::Test
+  TEP_BIN = File.expand_path("../bin/tep", __dir__)
+  APP     = File.expand_path("../examples/geohash/app.rb", __dir__)
+
+  def setup
+    @tmp  = Dir.mktmpdir("tep-geohash")
+    @bin  = File.join(@tmp, "geohash")
+    out   = `#{TEP_BIN} build #{APP} -o #{@bin} 2>&1`
+    raise "geohash example build failed:\n#{out}" unless $?.success? && File.executable?(@bin)
+    @port = 4970 + (Process.pid % 80)
+    @log  = File.join(@tmp, "app.log")
+    @pid  = Process.spawn(@bin, "-p", @port.to_s, out: @log, err: [:child, :out], pgroup: true)
+    wait_for_port(@port)
+  end
+
+  def teardown
+    if @pid
+      Process.kill("TERM", -@pid) rescue nil
+      Process.wait(@pid) rescue nil
+    end
+    FileUtils.remove_entry(@tmp) if @tmp && File.directory?(@tmp)
+  end
+
+  def wait_for_port(port, timeout: 10.0)
+    deadline = Time.now + timeout
+    while Time.now < deadline
+      begin
+        TCPSocket.new("127.0.0.1", port).close
+        return
+      rescue
+        sleep 0.05
+      end
+    end
+    raise "geohash app never bound :#{port}\n#{File.read(@log) rescue ''}"
+  end
+
+  def get(path)
+    Net::HTTP.get_response(URI("http://127.0.0.1:#{@port}#{path}")).body
+  end
+
+  # GeoHash.encode reference values (computed under CRuby).
+  def test_encode_paris_precision_8
+    assert_equal "u09tunqu", get("/geohash?lat=48.8584&lon=2.2945&precision=8")
+  end
+
+  def test_encode_tokyo_default_precision
+    assert_equal "xn76urx0zhkz", get("/geohash?lat=35.681&lon=139.767")
+  end
+
+  def test_encode_sydney_precision_6
+    assert_equal "r3gx2f", get("/geohash?lat=-33.8688&lon=151.2093&precision=6")
+  end
+
+  def test_index_mentions_the_gem
+    assert_match(/pr_geohash 1\.0\.0/, get("/"))
+  end
+end


### PR DESCRIPTION
`bin/tep build` now inlines app-local `require_relative` targets (resolve rel to app dir, splice source) -- so a tep app can vendor + use a real published gem. Demonstrated by examples/geohash, which uses the unmodified pr_geohash 1.0.0 (MIT): GeoHash.encode output matches CRuby byte-for-byte. Gem reuse is per-method (encode works; neighbors/decode need flatten/transpose, unsupported). Test builds the real example. Full suite green (487 runs, 0f/0e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)