### PR TITLE
feat(examples): maidenhead -- a tep app whose entire gem API compiles

### DIFF
--- a/examples/geohash/README.md
+++ b/examples/geohash/README.md
@@ -44,9 +44,15 @@ matches CRuby byte-for-byte.
 integer bit-ops and Float comparisons, all of which spinel supports.
 
 `GeoHash.neighbors` and `GeoHash.decode` are deliberately **not** exposed:
-they rely on `Array#flatten` / `Array#transpose`, which spinel doesn't
-compile yet (the build fails with `undefined method 'flatten'`). That's
-the honest shape of gem reuse under tep today: the hot path of a
-well-behaved pure-Ruby gem drops straight in, while methods that reach for
-unsupported stdlib corners don't. Pick the entry points that stay inside
-the supported surface.
+they rely on `Array#flatten` (on a string-element array) / `Array#transpose`,
+which spinel doesn't compile yet — tracked upstream as
+[matz/spinel#1078](https://github.com/matz/spinel/issues/1078) (flatten is
+specialized for int-element arrays only) and
+[matz/spinel#1079](https://github.com/matz/spinel/issues/1079) (transpose
+missing). That's the honest shape of gem reuse under tep today: the hot
+path of a well-behaved pure-Ruby gem drops straight in, while methods that
+reach for unsupported stdlib corners don't. Pick the entry points that stay
+inside the supported surface.
+
+For an example where the gem's **entire** API compiles — no caveats — see
+[`examples/maidenhead`](../maidenhead/README.md).

--- a/examples/maidenhead/README.md
+++ b/examples/maidenhead/README.md
@@ -1,0 +1,45 @@
+# maidenhead — a tep app that *fully* runs on an external gem
+
+This app is built entirely on a real, unmodified published Ruby gem:
+[`maidenhead` 1.0.1](https://rubygems.org/gems/maidenhead) (MIT), the
+ham-radio [Maidenhead Locator System](https://en.wikipedia.org/wiki/Maidenhead_Locator_System)
+converter. The source is vendored verbatim at
+[`vendor/maidenhead.rb`](vendor/maidenhead.rb) (license at
+[`vendor/LICENSE.txt`](vendor/LICENSE.txt)) and pulled in with
+`require_relative`, which `bin/tep build` inlines into the AOT binary.
+
+**Every route exercises the gem, and the entire public API compiles** —
+there is no unsupported-method caveat (contrast the sibling `geohash`
+example, where the gem's hot path works but two helpers need spinel
+features that aren't there yet).
+
+```ruby
+require_relative 'vendor/maidenhead'
+
+get '/valid'     { Maidenhead.valid_maidenhead?(params["loc"]) ... }
+get '/to_latlon' { Maidenhead.to_latlon(params["loc"]) ... }
+get '/to_grid'   { Maidenhead.to_maidenhead(lat, lon, precision) }
+```
+
+## Run it
+
+```sh
+bin/tep build examples/maidenhead/app.rb -o /tmp/maidenhead
+/tmp/maidenhead -p 4981 &
+
+curl 'http://127.0.0.1:4981/valid?loc=FN31pr'                          # => true
+curl 'http://127.0.0.1:4981/to_latlon?loc=FN31pr'                      # => 41.731076,-72.704514
+curl 'http://127.0.0.1:4981/to_grid?lat=40.7128&lon=-74.0060&precision=3'  # => FN20xr
+```
+
+Each result is identical to CRuby's `Maidenhead.*`.
+`test/test_maidenhead_example.rb` builds this app and checks every route
+against CRuby's output.
+
+## How a tep app uses a gem
+
+tep apps are ahead-of-time compiled by spinel — there is no runtime gem
+loader. `bin/tep build` inlines app-local `require_relative` targets into
+the generated program, so the gem becomes native compiled code. A plain
+`require "gem_name"` is dropped (spinel has no gem search path), so the
+pattern is: vendor the gem source, `require_relative` it.

--- a/examples/maidenhead/app.rb
+++ b/examples/maidenhead/app.rb
@@ -1,0 +1,43 @@
+require 'sinatra'
+
+# A tep app built entirely on a REAL, unmodified published Ruby gem --
+# maidenhead 1.0.1 (MIT), the ham-radio Maidenhead grid-locator <-> lat/lon
+# converter. Vendored verbatim at vendor/maidenhead.rb (license at
+# vendor/LICENSE.txt) and pulled in with require_relative, which bin/tep
+# inlines into the AOT binary. Unlike the geohash example, EVERY route
+# here exercises the gem and the whole public API compiles -- there is no
+# unsupported-method caveat. See README.md.
+require_relative 'vendor/maidenhead'
+
+# GET /valid?loc=FN31pr  -> "true" / "false"
+get '/valid' do
+  if Maidenhead.valid_maidenhead?(params["loc"])
+    "true"
+  else
+    "false"
+  end
+end
+
+# GET /to_latlon?loc=FN31pr  -> "41.731076,-72.704514"
+get '/to_latlon' do
+  r = Maidenhead.to_latlon(params["loc"])
+  r[0].to_s + "," + r[1].to_s
+end
+
+# GET /to_grid?lat=40.7128&lon=-74.0060&precision=3  -> "FN20xr"
+get '/to_grid' do
+  lat  = params["lat"].to_f
+  lon  = params["lon"].to_f
+  prec = params["precision"].to_i
+  if prec <= 0
+    prec = 5
+  end
+  Maidenhead.to_maidenhead(lat, lon, prec)
+end
+
+get '/' do
+  "tep + maidenhead 1.0.1 (a real, unmodified published gem)\n" +
+  "try: /valid?loc=FN31pr\n" +
+  "     /to_latlon?loc=FN31pr\n" +
+  "     /to_grid?lat=40.7128&lon=-74.0060&precision=3\n"
+end

--- a/examples/maidenhead/vendor/LICENSE.txt
+++ b/examples/maidenhead/vendor/LICENSE.txt
@@ -1,0 +1,20 @@
+Copyright (c) 2013 Michael Graff
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/examples/maidenhead/vendor/maidenhead.rb
+++ b/examples/maidenhead/vendor/maidenhead.rb
@@ -1,0 +1,211 @@
+##
+# Easily convert between latitude and longitude coordinates the the Maidenhead
+# Locator System coordinates.
+class Maidenhead
+  #
+  # Verify that the provided Maidenhead locator string is valid.
+  #
+  def self.valid_maidenhead?(location)
+    return false unless location.is_a?String
+    return false unless location.length >= 2
+    return false unless (location.length % 2) == 0
+
+    length = location.length / 2
+    length.times do |counter|
+      grid = location[counter * 2, 2]
+      if (counter == 0)
+        return false unless grid =~ /[a-rA-R]{2}/
+      elsif (counter % 2) == 0
+        return false unless grid =~ /[a-xA-X]{2}/
+      else
+        return false unless grid =~ /[0-9]{2}/
+      end
+    end
+
+    true
+  end
+
+  #
+  # Convert from a Maidenhead locator string to latitude and longitude.
+  # Location may be between 1 and 5 grids in size (2 to 10 characters).
+  # Longer values may work, but accuracy is not guaranteed as latitude
+  # and longitude values returned are rounded ot 6 decimal places.
+  #
+  # For each grid, an arbitrary but repeatable latitude and longitude
+  # is returned.
+  #
+  def self.to_latlon(location)
+    maidenhead = Maidenhead.new
+    maidenhead.locator = location
+    [ maidenhead.lat, maidenhead.lon ]
+  end
+
+  #
+  # Set the locator string.  It must be a valid string, or an ArgumentError
+  # will be raised.  This also directly computes the latitude and longitude
+  # values for this locator, so they will be valid after caling this method.
+  #
+  def locator=(location)
+    unless Maidenhead.valid_maidenhead?(location)
+      raise ArgumentError.new("Location is not a valid Maidenhead Locator System string")
+    end
+
+    @locator = location
+    @lat = -90.0
+    @lon = -180.0
+
+    pad_locator
+
+    convert_part_to_latlon(0, 1)
+    convert_part_to_latlon(1, 10)
+    convert_part_to_latlon(2, 10 * 24)
+    convert_part_to_latlon(3, 10 * 24 * 10)
+    convert_part_to_latlon(4, 10 * 24 * 10 * 24)
+  end
+
+  #
+  # Convert from latitude and longitude to a Maidenhead locator string.
+  # Latitude should be between -90 and 90, and longitude should be between
+  # -180 and 180.  Precision defaults to 5 blocks, which returns 10 characters.
+  # More precise coordinates may work, but accuracy is not guaranteed.
+  #
+  def self.to_maidenhead(lat, lon, precision = 5)
+    maidenhead = Maidenhead.new
+    maidenhead.lat = lat
+    maidenhead.lon = lon
+    maidenhead.precision = precision
+    maidenhead.locator
+  end
+
+  #
+  # Set the latitude.  Values must be between -90.0 and +90.0 or an
+  # ArgumentError will be raised.
+  #
+  def lat=(pos)
+    @lat = range_check("lat", 90.0, pos)
+  end
+
+  #
+  # Retrieve the latitude, usually post-conversion from a locator string.
+  # The result is rounded to 6 decimal places.
+  #
+  def lat
+    @lat.round(6)
+  end
+
+  #
+  # Set the longitude.  Values must be between -180.0 and +180.0 or an
+  # ArgumentError will be raised.
+  #
+  def lon=(pos)
+    @lon = range_check("lon", 180.0, pos)
+  end
+
+  #
+  # Retrieve the longitude, usually post-conversion from a locator string.
+  # The result is rounded to 6 decimal places.
+  #
+  def lon
+    @lon.round(6)
+  end
+
+  #
+  # Set the desired precision when converting from a latitude / longitude
+  # to a maidenhead locator.  This specifies the number of groups to use,
+  # usually 2 through 5, which results in 4 through 10 characters.
+  #
+  def precision=(value)
+    @precision = value
+  end
+
+  def precision
+    @precision
+  end
+
+  #
+  # Convert from a latitude / longitude position, which must have been
+  # set via #lat= and #lon=, to a locator.
+  #
+  def locator
+    @locator = ''
+
+    @lat_tmp = @lat + 90.0
+    @lon_tmp = @lon + 180.0
+    @precision_tmp = @precision
+
+    calculate_field
+    calculate_values
+
+    @locator
+  end
+
+  private
+
+  def pad_locator
+    length = @locator.length / 2
+    while (length < 5)
+      if (length % 2) == 1
+        @locator += '55'
+      else
+        @locator += 'LL'
+      end
+      length = @locator.length / 2
+    end
+  end
+
+  def convert_part_to_latlon(counter, divisor)
+    grid_lon = @locator[counter * 2, 1]
+    grid_lat = @locator[counter * 2 + 1, 1]
+
+    @lat += l2n(grid_lat) * 10.0 / divisor
+    @lon += l2n(grid_lon) * 20.0 / divisor
+  end
+
+  def calculate_field
+    @lat_tmp = (@lat_tmp / 10) + 0.0000001
+    @lon_tmp = (@lon_tmp / 20) + 0.0000001
+    @locator += n2l(@lon_tmp.floor).upcase + n2l(@lat_tmp.floor).upcase
+    @precision_tmp -= 1
+  end
+
+  def compute_locator(counter, divisor)
+    @lat_tmp = (@lat_tmp - @lat_tmp.floor) * divisor
+    @lon_tmp = (@lon_tmp - @lon_tmp.floor) * divisor
+
+    if (counter % 2) == 0
+      @locator += "#{@lon_tmp.floor}#{@lat_tmp.floor}"
+    else
+      @locator += n2l(@lon_tmp.floor) + n2l(@lat_tmp.floor)
+    end
+  end
+
+  def calculate_values
+    @precision_tmp.times do |counter|
+      if (counter % 2) == 0
+        compute_locator(counter, 10)
+      else
+        compute_locator(counter, 24)
+      end
+    end
+  end
+
+  def l2n(letter)
+    if letter =~ /[0-9]+/
+      letter.to_i
+    else
+      letter.downcase.ord - 97
+    end
+  end
+
+  def n2l(number)
+    (number + 97).chr
+  end
+
+  def range_check(target, range, pos)
+    pos = pos.to_f
+    if pos < -range or pos > range
+      raise ArgumentError.new("#{target} must be between -#{range} and +#{range}")
+    end
+    pos
+  end
+end

--- a/test/test_maidenhead_example.rb
+++ b/test/test_maidenhead_example.rb
@@ -1,0 +1,71 @@
+require "minitest/autorun"
+require "net/http"
+require "socket"
+require "tmpdir"
+require "fileutils"
+
+# Companion to test_geohash_example.rb, but for the example whose ENTIRE
+# gem API compiles: examples/maidenhead/app.rb runs on the unmodified
+# published maidenhead 1.0.1 gem (MIT), vendored + require_relative'd.
+# Every route is checked against CRuby's Maidenhead.* output. Builds the
+# real example in place so the relative require_relative resolves.
+class TestMaidenheadExample < Minitest::Test
+  TEP_BIN = File.expand_path("../bin/tep", __dir__)
+  APP     = File.expand_path("../examples/maidenhead/app.rb", __dir__)
+
+  def setup
+    @tmp  = Dir.mktmpdir("tep-maidenhead")
+    @bin  = File.join(@tmp, "maidenhead")
+    out   = `#{TEP_BIN} build #{APP} -o #{@bin} 2>&1`
+    raise "maidenhead example build failed:\n#{out}" unless $?.success? && File.executable?(@bin)
+    @port = 4960 + (Process.pid % 80)
+    @log  = File.join(@tmp, "app.log")
+    @pid  = Process.spawn(@bin, "-p", @port.to_s, out: @log, err: [:child, :out], pgroup: true)
+    wait_for_port(@port)
+  end
+
+  def teardown
+    if @pid
+      Process.kill("TERM", -@pid) rescue nil
+      Process.wait(@pid) rescue nil
+    end
+    FileUtils.remove_entry(@tmp) if @tmp && File.directory?(@tmp)
+  end
+
+  def wait_for_port(port, timeout: 10.0)
+    deadline = Time.now + timeout
+    while Time.now < deadline
+      begin
+        TCPSocket.new("127.0.0.1", port).close
+        return
+      rescue
+        sleep 0.05
+      end
+    end
+    raise "maidenhead app never bound :#{port}\n#{File.read(@log) rescue ''}"
+  end
+
+  def get(path)
+    Net::HTTP.get_response(URI("http://127.0.0.1:#{@port}#{path}")).body
+  end
+
+  def test_valid_true
+    assert_equal "true", get("/valid?loc=FN31pr")
+  end
+
+  def test_valid_false
+    assert_equal "false", get("/valid?loc=invalid")
+  end
+
+  def test_to_latlon
+    assert_equal "41.731076,-72.704514", get("/to_latlon?loc=FN31pr")
+  end
+
+  def test_to_grid_precision_3
+    assert_equal "FN20xr", get("/to_grid?lat=40.7128&lon=-74.0060&precision=3")
+  end
+
+  def test_to_grid_precision_2
+    assert_equal "IO91", get("/to_grid?lat=51.5074&lon=-0.1278&precision=2")
+  end
+end


### PR DESCRIPTION
A fully-working external-gem example to complement geohash: tep running entirely on the unmodified published maidenhead 1.0.1 (MIT). Every route uses the gem; outputs match CRuby byte-for-byte. Also files + links the upstream gaps behind geohash's missing methods (matz/spinel#1078 flatten element-type, #1079 transpose). Full suite green (492 runs, 0f/0e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)