### PR TITLE
fix(build): unbreak main CI (double-inline) + close RBS drift

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,20 @@ namespace :rbs do
     # (parser, generics arity, reference resolution within the loaded
     # set). It does NOT cross-check .rb against .rbs -- that's Steep's
     # job, deferred until the surface stabilises.
-    sh "rbs --repo sig -I sig validate"
+    #
+    # Resolve the rbs CLI from the gem itself rather than assuming it's
+    # on PATH. Under `bundle exec` (CI) the bundled rbs is on PATH; on a
+    # bare host (e.g. a distro ruby on gx10 where the gem's bin dir
+    # isn't exported) it is NOT, and a plain `sh "rbs ..."` fails with
+    # 127. Gem.bin_path locates the executable in both setups, and we
+    # run it through the current ruby so the shebang/PATH don't matter.
+    args = ["--repo", "sig", "-I", "sig", "validate"]
+    begin
+      sh RbConfig.ruby, Gem.bin_path("rbs", "rbs"), *args
+    rescue Gem::Exception
+      # rbs not installed as a gem; last resort is a bare PATH lookup.
+      sh "rbs", *args
+    end
   end
 end
 

--- a/SPINEL_PIN
+++ b/SPINEL_PIN
@@ -1,9 +1,20 @@
-f7602f4e1e00e99c7c48adf34d8cdc28e1fa1f7b
+cc94707765c376e507ebac1ac2d902ac765c6da5
 
 # Pinned matz/spinel commit tep is verified to build + test against.
 # Only the first line (the ref) is read by tools/spinel-fresh.sh.
 #
-# f7602f4 (2026-05-30). Bumped from 23ba632 (+31 commits) onto current
+# cc94707 (2026-05-31). Bumped from f7602f4 (+2 commits), both on the
+# `require` path that the spinelgems flow exercises (vendored gems emit
+# plain `require "json"` / `require "set"` that reach spinel's resolver):
+#   - fe4810f: clearer "not available in Spinel" diagnostic + native-lib
+#     allowlist so `require "json"` no longer warns.
+#   - cc94707: two resolve_plain_requires line-scanning fixes -- a
+#     `require "x"; code` one-liner no longer drops `code`, and a
+#     first-line `require` is no longer skipped when another follows
+#     (previously leaked to codegen as `cannot resolve call to require`).
+# No tep workaround to revert; robustness-only for the gem flow.
+#
+# Prior (f7602f4, 2026-05-30). Bumped from 23ba632 (+31 commits) onto current
 # master, which now additionally carries:
 #   - "Root heap-typed method parameters across internal GC" (#1068) ->
 #     another GC-rooting fix in the #1052 family (heap-typed params no

--- a/bin/tep
+++ b/bin/tep
@@ -1358,9 +1358,21 @@ def handle_top_call(node, routes, websockets, mcp_tools, mcp_resources, filters,
       first = args.first
       if first.is_a?(Prism::StringNode)
         path = first.unescaped
-        if path != "tep" && !path.start_with?("tep/")
-          base = input_path ? File.dirname(input_path) : Dir.pwd
-          cand = File.expand_path(path.end_with?(".rb") ? path : path + ".rb", base)
+        base = input_path ? File.dirname(input_path) : Dir.pwd
+        cand = File.expand_path(path.end_with?(".rb") ? path : path + ".rb", base)
+        # tep's own library is already inlined wholesale at the top
+        # (inlined_tep_library), so requiring it here must be a no-op --
+        # otherwise we inline the whole library a SECOND time. Beyond the
+        # by-name forms ("tep" / "tep/foo"), an example loads it by PATH
+        # (`require_relative "../lib/tep"`); since the app-local inliner
+        # became recursive (#166) that path form would re-pull every
+        # tep/*.rb, duplicating `module Pg` + its ffi_const into a C
+        # `redefinition` error. Resolve and compare against LIB_DIR so all
+        # spellings that land inside tep's own lib are skipped.
+        is_tep_lib = path == "tep" || path.start_with?("tep/") ||
+                     cand == File.join(LIB_DIR, "tep.rb") ||
+                     cand.start_with?(LIB_DIR + File::SEPARATOR)
+        if !is_tep_lib
           if File.file?(cand)
             passthrough << "# --- inlined require_relative #{path.inspect} (#{File.basename(cand)}) ---"
             passthrough << inline_require_relative_tree(cand, inlined_seen, warnings)

--- a/sig/tep/cache.rbs
+++ b/sig/tep/cache.rbs
@@ -1,0 +1,13 @@
+# Tep::Cache -- HTTP conditional-GET evaluation (issue #152).
+#
+# A response opts in by setting a validator (res.etag / res.last_modified).
+# The server short-circuits to 304 Not Modified when the request carries
+# a matching precondition. Responses that set no validator are unaffected.
+module Tep
+  module Cache
+    # True iff `req`'s precondition says the client's cached copy of
+    # `res` is still fresh (=> answer 304). Safe methods (GET/HEAD) only;
+    # returns false for any other verb.
+    def self.not_modified?: (Tep::Request req, Tep::Response res) -> bool
+  end
+end

--- a/sig/tep/events.rbs
+++ b/sig/tep/events.rbs
@@ -1,0 +1,32 @@
+# Tep::Events -- newline-delimited JSON (JSONL) run/telemetry emitter.
+# A "" path disables emission (zero I/O, zero alloc). Timestamps are
+# ISO-8601 UTC via Sock.sphttp_iso8601_utc (spinel's Time.now exposes
+# only integer epoch seconds). All emit methods return an Integer
+# (0 / a count); they're no-ops when disabled.
+module Tep
+  class Events
+    # `path` of "" disables emission.
+    def initialize: (String path) -> void
+
+    # True when a non-empty path was configured.
+    def enabled?: () -> bool
+
+    # Emit `run_start` once, before any request. host / backend_kind /
+    # model_name / model_path are plain strings; config_json is a
+    # caller-built JSON object emitted verbatim.
+    def run_start: (String host, String backend_kind, String model_name, String model_path, String config_json) -> Integer
+
+    # Per-inference record. extra_json is caller-built JSON (e.g. the
+    # sampling block, including any Float fields) emitted verbatim.
+    def inference: (String model, Integer prompt_tokens, Integer completion_tokens, Integer wall_us, String extra_json) -> Integer
+
+    # Bump the run-level error counter (surfaced in run_end_aggregated).
+    def record_error: () -> Integer
+
+    # Emit a `run_end` record with the given reason.
+    def run_end: (String reason) -> Integer
+    # Emit a `run_end` carrying aggregated counters (requests, errors,
+    # output tokens) accumulated over the run.
+    def run_end_aggregated: (String reason) -> Integer
+  end
+end

--- a/sig/tep/net.rbs
+++ b/sig/tep/net.rbs
@@ -1,0 +1,97 @@
+# Low-level FFI binding modules over sphttp.c (Sock) and the crypto
+# shim (Crypto). Unlike the Pg / Sqlite batteries these have no Ruby
+# wrapper class -- callers (tep's server, websocket, auth, jwt,
+# password, events) use the module methods directly, so the FFI
+# surface IS the public surface. Each method is a thin 1:1 over the C
+# signature; `:int` -> Integer, `:str` -> String. Buffer-returning
+# reads pair a `*_buf` (String) accessor with a `*_len` (Integer).
+module Sock
+  # Listen / accept (blocking + non-blocking).
+  def self.sphttp_listen: (Integer port, Integer backlog) -> Integer
+  def self.sphttp_accept: (Integer sfd) -> Integer
+  def self.sphttp_accept_nb: (Integer sfd) -> Integer
+  def self.sphttp_read_request: (Integer fd) -> Integer
+  def self.sphttp_request_buf: () -> String
+  def self.sphttp_request_len: () -> Integer
+  def self.sphttp_drain_body: (Integer fd, Integer remaining) -> String
+  def self.sphttp_write_str: (Integer fd, String s) -> Integer
+  def self.sphttp_write_bytes: (Integer fd, String s, Integer n) -> Integer
+
+  # WebSocket frame recv (buffer + length accessor pair).
+  def self.sphttp_recv_into_frame: (Integer fd) -> Integer
+  def self.sphttp_recv_frame_buf: () -> String
+  def self.sphttp_recv_frame_len: () -> Integer
+
+  # Process lifecycle / signals.
+  def self.sphttp_install_term_handlers: () -> Integer
+  def self.sphttp_shutdown_requested: () -> Integer
+  def self.sphttp_sleep_ms: (Integer ms) -> Integer
+
+  # Upstream connection pool (proxy keep-alive).
+  def self.sphttp_pool_checkout: (String key, Integer port) -> Integer
+  def self.sphttp_pool_checkin: (Integer fd, String key, Integer port) -> Integer
+  def self.sphttp_pool_close_idle: (Integer max_age_ms) -> Integer
+  def self.sphttp_pool_stat_checkouts: () -> Integer
+  def self.sphttp_pool_stat_checkins: () -> Integer
+  def self.sphttp_pool_stat_hits: () -> Integer
+  def self.sphttp_pool_stat_misses: () -> Integer
+
+  # Host / arch identity.
+  def self.sphttp_os_kind: () -> String
+  def self.sphttp_arch_kind: () -> String
+
+  # Time formatting / parsing (epoch-second basis).
+  def self.sphttp_iso8601_utc: (Integer epoch) -> String
+  def self.sphttp_http_date: (Integer epoch) -> String
+  def self.sphttp_parse_http_date: (String s) -> Integer
+
+  # Files / fork / chunked writes.
+  def self.sphttp_sendfile: (Integer fd, String path) -> Integer
+  def self.sphttp_filesize: (String path) -> Integer
+  def self.sphttp_file_mtime: (String path) -> Integer
+  def self.sphttp_close: (Integer fd) -> Integer
+  def self.sphttp_fork: () -> Integer
+  def self.sphttp_exit: (Integer code) -> Integer
+  def self.sphttp_getpid: () -> Integer
+  def self.sphttp_wait_any: () -> Integer
+  def self.sphttp_write_chunk: (Integer fd, String s) -> Integer
+  def self.sphttp_write_chunk_end: (Integer fd) -> Integer
+
+  # Poll / non-block helpers (the cooperative scheduler's io_wait).
+  def self.sphttp_poll_reset: () -> Integer
+  def self.sphttp_poll_add: (Integer fd, Integer events) -> Integer
+  def self.sphttp_poll_run: (Integer timeout_ms) -> Integer
+  def self.sphttp_poll_ready: (Integer idx) -> Integer
+  def self.sphttp_set_nonblock: (Integer fd) -> Integer
+  def self.sphttp_set_recv_timeout: (Integer fd, Integer ms) -> Integer
+
+  # Outbound connect (plain + TLS) and reads.
+  def self.sphttp_connect: (String host, Integer port) -> Integer
+  def self.sphttp_connect_tls: (String host, Integer port) -> Integer
+  def self.sphttp_tls_server_init: (String cert_path, String key_path) -> Integer
+  def self.sphttp_accept_tls: (Integer sfd) -> Integer
+
+  # Non-blocking TLS handshake stepping (scheduled server).
+  def self.sphttp_tls_connect_start: (String host, Integer port) -> Integer
+  def self.sphttp_tls_accept_start: (Integer fd) -> Integer
+  def self.sphttp_tls_handshake_step: (Integer fd) -> Integer
+  def self.sphttp_io_status: () -> Integer
+  def self.sphttp_recv_some: (Integer fd, Integer max) -> String
+  def self.sphttp_recv_all: (Integer fd, Integer max) -> String
+
+  # Subprocess capture (Tep::Shell).
+  def self.sphttp_shell_capture: (String cmd, Integer max_bytes) -> String
+end
+
+# HMAC / base64url / PBKDF2 / SHA helpers backing auth, jwt, password,
+# and the websocket handshake.
+module Crypto
+  def self.sp_crypto_hmac_sha256_hex: (String key, String msg) -> String
+  def self.sp_crypto_hmac_sha256_b64url: (String key, String msg) -> String
+  def self.sp_crypto_b64url_encode: (String s) -> String
+  def self.sp_crypto_b64url_decode: (String s) -> String
+  def self.sp_crypto_pbkdf2_sha256_b64url: (String password, String salt, Integer iterations) -> String
+  def self.sp_crypto_random_b64url: (Integer nbytes) -> String
+  def self.sp_crypto_sha1_hex: (String s) -> String
+  def self.sp_crypto_websocket_accept: (String key) -> String
+end

--- a/sig/tep/openai_server.rbs
+++ b/sig/tep/openai_server.rbs
@@ -1,0 +1,132 @@
+# Tep::Llm::OpenAI -- a mountable, OpenAI-compatible HTTP surface
+# (/v1/models, /v1/completions, /v1/chat/completions). An app
+# implements a Backend subclass, wires it with Server.use, then
+# Server.serve! mounts the routes. Streaming backends write tokens to
+# a typed sink (StreamSink / ChatStreamSink) rather than a block --
+# blocks don't lower across the spinel backend-call boundary.
+module Tep
+  class Llm
+    module OpenAI
+      # The interface an app's backend implements. The base methods are
+      # safe defaults (empty model list, chat/embeddings unsupported,
+      # cpu device) so a bare backend compiles + serves; subclasses
+      # override what they offer.
+      class Backend
+        # Available model names. /v1/models wraps these.
+        def list_models: () -> Array[String]
+        # PRIMARY: token-level generation (non-streaming /v1/completions).
+        def generate_from_tokens: (String model, Array[Integer] token_ids, Tep::Llm::OpenAI::Sampling sampling) -> Tep::Llm::OpenAI::Completion
+        # Streaming /v1/completions: write each token via sink.emit_token.
+        def generate_stream_from_tokens: (String model, Array[Integer] token_ids, Tep::Llm::OpenAI::Sampling sampling, Tep::Llm::OpenAI::StreamSink sink) -> Integer
+        # When false, /v1/chat/completions returns 501.
+        def supports_chat?: () -> bool
+        # Message-level generation; receives the raw req to apply its own
+        # chat template (use parse_messages to decode `messages`).
+        def chat_completion: (Tep::Request req) -> Tep::Llm::OpenAI::Completion
+        # Streaming chat: write each token via sink.emit_token.
+        def chat_completion_stream: (Tep::Request req, Tep::Llm::OpenAI::ChatStreamSink sink) -> Integer
+        # Device label surfaced into the run_start event's backend.kind.
+        def device_kind: () -> String
+        # When true, gates /v1/embeddings (chunk 7.3).
+        def supports_embeddings?: () -> bool
+      end
+
+      # The mountable server. Class methods: one backend per process is
+      # wired at boot (`use`), then the standard routes are mounted
+      # (`serve!`).
+      class Server
+        # Register the app's Backend subclass instance.
+        def self.use: (Tep::Llm::OpenAI::Backend backend) -> Integer
+        # Mount /v1/models, /v1/completions, /v1/chat/completions and
+        # (optionally) start the toy/v1 events stream. `events_jsonl` ""
+        # disables emission.
+        def self.serve!: (?String events_jsonl) -> Integer
+      end
+
+      # Parse the `messages` array from an OpenAI chat request body into
+      # [Tep::Llm::Message, ...] (one per {role, content}); empty when
+      # the key is missing or not an array.
+      def self.parse_messages: (String body) -> Array[Tep::Llm::Message]
+      # Locate a string value for `key` within the object spanning
+      # [obj_start, obj_end) in `body`; "" if absent.
+      def self.find_obj_key_str: (String body, Integer obj_start, Integer obj_end, String key) -> String
+
+      # Sampling parameters parsed from the request (max_tokens int;
+      # temperature / top_p Float).
+      class Sampling
+        attr_accessor max_tokens: Integer
+        attr_accessor temperature: Float
+        attr_accessor top_p: Float
+        def initialize: () -> void
+      end
+
+      # A backend's generation result: decoded text + token usage.
+      class Completion
+        attr_accessor text: String
+        attr_accessor prompt_tokens: Integer
+        attr_accessor completion_tokens: Integer
+        def initialize: () -> void
+      end
+
+      # Per-token write surface for streaming /v1/completions. The
+      # backend calls emit_token(piece); the sink formats the OpenAI
+      # text_completion SSE frame and writes one chunked frame.
+      class StreamSink
+        attr_accessor out: Tep::Stream
+        attr_accessor model: String
+        attr_accessor completion_count: Integer
+        def initialize: () -> void
+        def emit_token: (String piece) -> Integer
+      end
+
+      # Per-token write surface for streaming /v1/chat/completions. The
+      # backend calls emit_role_prelude once, then emit_token per delta,
+      # then emit_finish; each writes one OpenAI chat-streaming frame.
+      class ChatStreamSink
+        attr_accessor out: Tep::Stream
+        attr_accessor model: String
+        attr_accessor completion_count: Integer
+        def initialize: () -> void
+        def emit_role_prelude: (String role) -> Integer
+        def emit_token: (String piece) -> Integer
+        def emit_finish: (String reason) -> Integer
+      end
+
+      # Internal Streamer plumbing -- the server pumps these
+      # cooperatively; apps don't instantiate them directly.
+      class CompletionsStreamer < Tep::Streamer
+        attr_accessor model: String
+        attr_accessor token_ids: Array[Integer]
+        attr_accessor sampling: Tep::Llm::OpenAI::Sampling
+        attr_accessor prompt_tokens: Integer
+        attr_accessor t0: Integer
+        attr_accessor request_id: String
+        attr_accessor principal_id: String
+        def initialize: () -> void
+        def pump: (Tep::Stream out) -> Integer
+      end
+
+      class ChatCompletionsStreamer < Tep::Streamer
+        attr_accessor req_ref: Tep::Request
+        attr_accessor model: String
+        attr_accessor prompt_tokens: Integer
+        attr_accessor t0: Integer
+        attr_accessor request_id: String
+        attr_accessor principal_id: String
+        def initialize: () -> void
+        def pump: (Tep::Stream out) -> Integer
+      end
+
+      # Route handlers mounted by serve!; apps don't instantiate them.
+      class ModelsHandler < Tep::Handler
+        def handle: (Tep::Request req, Tep::Response res) -> Integer
+      end
+      class CompletionsHandler < Tep::Handler
+        def handle: (Tep::Request req, Tep::Response res) -> Integer
+      end
+      class ChatCompletionsHandler < Tep::Handler
+        def handle: (Tep::Request req, Tep::Response res) -> Integer
+      end
+    end
+  end
+end

--- a/sig/tep/pg.rbs
+++ b/sig/tep/pg.rbs
@@ -1,0 +1,236 @@
+# PG battery -- a libpq wrapper that mirrors the ruby-pg gem's public
+# surface (PG::Connection / PG::Result / PG::Error + SQLSTATE-keyed
+# subclasses) so an eventual ActiveRecord-on-spinel port reuses the
+# existing AR pg adapter with minimal divergence. The raw FFI binding
+# layer (`module Pg`) is internal and intentionally undocumented here;
+# callers use the `PG` surface below.
+module PG
+  # Connection status (libpq's ConnStatusType, collapsed).
+  CONNECTION_OK: Integer
+  CONNECTION_BAD: Integer
+
+  # Transaction status (libpq's PGTransactionStatusType).
+  PQTRANS_IDLE: Integer
+  PQTRANS_ACTIVE: Integer
+  PQTRANS_INTRANS: Integer
+  PQTRANS_INERROR: Integer
+  PQTRANS_UNKNOWN: Integer
+
+  # Diagnostic field codes for Result#error_field (libpq single-char
+  # codes exposed as integers).
+  DIAG_SEVERITY: Integer
+  DIAG_SQLSTATE: Integer
+  DIAG_MESSAGE_PRIMARY: Integer
+  DIAG_MESSAGE_DETAIL: Integer
+  DIAG_MESSAGE_HINT: Integer
+  DIAG_STATEMENT_POSITION: Integer
+  DIAG_CONTEXT: Integer
+  DIAG_SCHEMA_NAME: Integer
+  DIAG_TABLE_NAME: Integer
+  DIAG_COLUMN_NAME: Integer
+  DIAG_DATATYPE_NAME: Integer
+  DIAG_CONSTRAINT_NAME: Integer
+
+  # Convenience constructor matching ruby-pg's PG.connect. `opts` is a
+  # libpq conninfo String ("postgresql://...") or a String=>String Hash.
+  def self.connect: (String | Hash[String, String] opts) -> PG::Connection
+
+  # libpq version string ("16.2.0" ...). Diagnostic / banner use.
+  def self.libpq_version: () -> String
+
+  class Connection
+    # `:pgh` rather than `:handle` to avoid the poly-dispatch collision
+    # with Tep::Handler#handle (same-named-imeth unifier).
+    attr_accessor pgh: Integer
+    # Error context for the most recent exception raised by this
+    # connection -- spinel's `raise X.new(msg, ...)` lowering doesn't
+    # carry custom initializers (#622), so SQLSTATE / message / result
+    # handle live here. Read after `rescue PG::Error => e`.
+    attr_accessor last_sqlstate: String
+    attr_accessor last_error_message: String
+    attr_accessor last_result_rh: Integer
+
+    def initialize: (String | Hash[String, String] opts) -> void
+
+    def connected?: () -> bool
+    def close: () -> Integer
+    def finish: () -> Integer
+    def reset: () -> Connection
+    def status: () -> Integer
+    def transaction_status: () -> Integer
+    def server_version: () -> Integer
+    def error_message: () -> String
+
+    # LISTEN / NOTIFY (Battery 2 cross-worker pub/sub). Channel names
+    # must be safe SQL identifiers. Each returns -1 on a dead connection.
+    def listen: (String channel) -> Integer
+    def unlisten: (String channel) -> Integer
+    def notify: (String channel, String payload) -> Integer
+    # 1 = notification received (then read #last_notify_*), 0 = timeout,
+    # -1 = connection error.
+    def poll_notification: (Integer timeout_ms) -> Integer
+    def last_notify_channel: () -> String
+    def last_notify_payload: () -> String
+
+    # Returns a Result. On error the Result's #ok? is false and SQLSTATE
+    # / message mirror to #last_sqlstate / #last_error_message. Routes
+    # through the libpq async surface under Tep::Server::Scheduled.
+    def exec: (String sql) -> Result
+    # `params` is an Array of String / Integer / nil (positional $1..$N).
+    def exec_params: (String sql, Array[String | Integer | nil] params) -> Result
+    # Explicit async variants -- always use the libpq non-blocking path.
+    def async_exec: (String sql) -> Result
+    def async_exec_params: (String sql, Array[String | Integer | nil] params) -> Result
+
+    def escape_string: (String s) -> String
+    def escape_identifier: (String s) -> String
+    def escape_literal: (String s) -> String
+    def self.escape_string: (String s) -> String
+    def self.quote_ident: (String s) -> String
+  end
+
+  class Result
+    attr_accessor rh: Integer
+    def initialize: (Integer rh) -> void
+
+    def status: () -> Integer
+    # True when the query produced a non-error result (rows, command
+    # success, or empty query).
+    def ok?: () -> bool
+    def error_message: () -> String
+    def error_field: (Integer code) -> String
+    def cmd_status: () -> String
+    # 5-char SQLSTATE string; "" when the result isn't an error.
+    def sql_state: () -> String
+    def cmd_tuples: () -> Integer
+
+    def ntuples: () -> Integer
+    def nfields: () -> Integer
+    # ruby-pg aliases for ntuples / nfields.
+    def num_tuples: () -> Integer
+    def num_fields: () -> Integer
+
+    def fname: (Integer col) -> String
+    def fnumber: (String name) -> Integer
+    def ftype: (Integer col) -> Integer
+    def fformat: (Integer col) -> Integer
+    def fmod: (Integer col) -> Integer
+
+    def getvalue: (Integer row, Integer col) -> String
+    def getisnull: (Integer row, Integer col) -> bool
+    def getlength: (Integer row, Integer col) -> Integer
+    # ruby-pg alias for getvalue.
+    def value: (Integer row, Integer col) -> String
+
+    def fields: () -> Array[String]
+    def values: () -> Array[Array[String]]
+    def column_values: (Integer col) -> Array[String]
+
+    # Array-yielding iteration (no per-row Hash allocation).
+    def each_row: () { (Array[String]) -> void } -> Result
+    # Hash-yielding iteration -- matches ruby-pg's #each.
+    def each: () { (Hash[String, String]) -> void } -> Result
+    def clear: () -> Integer
+  end
+
+  # Exception hierarchy -- ruby-pg-shape, SQLSTATE-keyed. AR's pg
+  # adapter does `e.is_a?(PG::UniqueViolation)` to translate libpq
+  # errors; the class identity has to match. Raised via the two-arg
+  # `raise PG::Klass, msg` form; per-exception SQLSTATE / message
+  # context lives on the owning Connection (see Connection#last_*).
+  class Error < StandardError
+  end
+
+  class ConnectionBad < Error
+  end
+  class UnableToSend < Error
+  end
+  class ServerError < Error
+  end
+
+  # SQLSTATE class 23 -- integrity constraint violation
+  class IntegrityConstraintViolation < ServerError
+  end
+  class NotNullViolation < IntegrityConstraintViolation
+  end
+  class ForeignKeyViolation < IntegrityConstraintViolation
+  end
+  class UniqueViolation < IntegrityConstraintViolation
+  end
+  class CheckViolation < IntegrityConstraintViolation
+  end
+  class ExclusionViolation < IntegrityConstraintViolation
+  end
+
+  # SQLSTATE class 25 -- invalid transaction state
+  class InFailedSqlTransaction < ServerError
+  end
+  class ReadOnlySqlTransaction < ServerError
+  end
+
+  # SQLSTATE class 40 -- transaction rollback
+  class SerializationFailure < ServerError
+  end
+  class DeadlockDetected < ServerError
+  end
+
+  # SQLSTATE class 42 -- syntax / access rule violation
+  class SyntaxError < ServerError
+  end
+  class UndefinedColumn < ServerError
+  end
+  class UndefinedFunction < ServerError
+  end
+  class UndefinedTable < ServerError
+  end
+  class DuplicateColumn < ServerError
+  end
+  class DuplicateTable < ServerError
+  end
+  class InsufficientPrivilege < ServerError
+  end
+
+  # SQLSTATE class 57 -- operator intervention
+  class QueryCanceled < ServerError
+  end
+  class AdminShutdown < ServerError
+  end
+
+  # SQLSTATE class 08 -- connection exception
+  class ConnectionException < ServerError
+  end
+  class ConnectionDoesNotExist < ServerError
+  end
+
+  # Pool-side error (no SQLSTATE): raised by PG::Pool#checkout on
+  # checkout-timeout. `rescue PG::PoolExhausted` or the broader
+  # `rescue PG::Error` both catch it.
+  class PoolExhausted < Error
+  end
+
+  # Fixed-size connection pool. Holds N pre-opened connections, hands
+  # them out via #checkout / takes them back via #checkin, parks
+  # cooperatively under Tep::Server::Scheduled when the free list is
+  # empty. The block-form `with { |c| ... }` is deferred until spinel
+  # lights up instance-method typed yields (matz/spinel#628).
+  class Pool
+    attr_accessor url: String
+    attr_accessor size: Integer
+    attr_accessor free: Array[PG::Connection]
+    attr_accessor waiter_idxs: Array[Integer]
+    attr_accessor checkout_timeout_ms: Integer
+
+    def initialize: (String url, Integer size) -> void
+
+    # True iff every pooled connection opened successfully.
+    def healthy?: () -> bool
+    def set_checkout_timeout_ms: (Integer ms) -> Integer
+    # Acquire a connection. Raises PG::PoolExhausted past the timeout
+    # (non-scheduled callers); the scheduled path parks until a checkin.
+    def checkout: () -> PG::Connection
+    def checkin: (PG::Connection c) -> Integer
+    # Diagnostic: how many connections are currently available.
+    def available: () -> Integer
+    def close_all: () -> Integer
+  end
+end

--- a/sig/tep/proxy.rbs
+++ b/sig/tep/proxy.rbs
@@ -1,0 +1,123 @@
+# Tep::Proxy -- a reverse-proxy / API-gateway Handler. Subclass and
+# override the hooks (or use the bin/tep block-DSL) to route, rewrite,
+# retry, transform, and stream. The buffered path runs
+# before_forward / after_forward; opting into streaming via
+# stream_request? switches to the on_stream_chunk / on_stream_end
+# pumping path. Hooks receive object wrappers (StreamChunk /
+# StreamStats / UpstreamRequest) rather than bare primitives so they
+# survive spinel's poly-receiver dispatch as typed pointers
+# (see [[spinel-widening-dispatch]]).
+module Tep
+  class Proxy < Tep::Handler
+    attr_accessor upstream: String
+    attr_accessor timeout: Integer
+    # Body-size caps (chunk 6.6). Request over the cap -> 413 before
+    # any upstream call; response over the cap -> 502. 0 disables a cap.
+    attr_accessor max_request_body_bytes: Integer
+    attr_accessor max_response_body_bytes: Integer
+
+    def initialize: (String upstream) -> void
+
+    # ---- Overridable hooks ----
+
+    # Per-request retry policy. Default: a fresh RetryPolicy (1 attempt,
+    # no retry). Only the buffered path consults it; streaming never
+    # retries.
+    def retry_policy: (Tep::Request req) -> Tep::Proxy::RetryPolicy
+    # Per-request upstream selection. Default: @upstream. Return a
+    # scheme://host:port (+ optional fixed prefix), NOT the request path.
+    def pick_upstream: (Tep::Request req) -> String
+    # Map inbound path+query to the upstream path+query. Default: verbatim.
+    def rewrite_path: (String path) -> String
+    # Pre-forward hook. Mutate `ureq`; return true to short-circuit
+    # (skip the upstream call and send `res`), false to forward.
+    def before_forward: (Tep::Request req, Tep::Response res, Tep::Proxy::UpstreamRequest ureq) -> bool
+    # Post-forward hook (runs on the short-circuit path too). `ures` is
+    # the upstream response (status 0 + empty body on connect failure).
+    def after_forward: (Tep::Request req, Tep::Http::Response ures, Tep::Response res) -> Integer
+    # Streaming opt-in predicate. Default: false (buffered).
+    def stream_request?: (Tep::Request req) -> bool
+    # Per-chunk streaming hook. Default: pass `chunk.chunk_text` through.
+    def on_stream_chunk: (Tep::Proxy::StreamChunk chunk, Tep::Stream out, Tep::Proxy::StreamStats stats) -> Integer
+    # End-of-stream finalizer (fires once; stats.errored distinguishes
+    # clean vs error close). Default: no-op.
+    def on_stream_end: (Tep::Request req, Tep::Stream out, Tep::Proxy::StreamStats stats) -> Integer
+
+    # ---- Tep::Handler interface ----
+    def handle: (Tep::Request req, Tep::Response res) -> Integer
+
+    # Per-request retry configuration. base_backoff_ms grows by
+    # backoff_multiplier each attempt; retriable? treats status 0
+    # (connect/send failure) plus retry_on_status as retriable.
+    class RetryPolicy
+      attr_accessor max_attempts: Integer
+      attr_accessor base_backoff_ms: Integer
+      attr_accessor backoff_multiplier: Integer
+      attr_accessor retry_on_status: Array[Integer]
+
+      def initialize: () -> void
+      # Float-seconds convenience setter (0.5 -> 500ms); stored as int ms.
+      def base_backoff_secs=: (Float f) -> Float
+      def base_backoff_secs: () -> Float
+      # Milliseconds to sleep before attempt N (0-indexed). 0 when base is 0.
+      def backoff_for: (Integer attempt) -> Integer
+      def retriable?: (Integer status) -> bool
+    end
+
+    # Mutable upstream request, pre-filled from the inbound request with
+    # hop-by-hop headers stripped. Passed to before_forward.
+    class UpstreamRequest
+      attr_accessor verb: String
+      attr_accessor path: String
+      attr_accessor headers: Hash[String, String]
+      attr_accessor body: String
+      def initialize: () -> void
+      def set_header: (String k, String v) -> String
+    end
+
+    # Parsed upstream response head, produced by read_upstream_head.
+    class UpstreamHead
+      attr_accessor status: Integer
+      attr_accessor headers: Hash[String, String]
+      attr_accessor is_chunked: bool
+      attr_accessor is_sse: bool
+      attr_accessor leftover: String
+      attr_accessor ok: bool
+      def initialize: () -> void
+      # Parse a header blob (no trailing blank line) into the fields above.
+      def fill_from: (String blob) -> Integer
+    end
+
+    # One streamed body unit handed to on_stream_chunk. Read bytes via
+    # #chunk_text (a bare String arg would arrive poly under dispatch).
+    class StreamChunk
+      attr_accessor chunk_text: String
+      def initialize: (String chunk_text) -> void
+    end
+
+    # Per-stream counters carried across on_stream_chunk / on_stream_end.
+    # The framework maintains byte_count / chunk_count; accumulate your
+    # own counters in meta_bag.
+    class StreamStats
+      attr_accessor byte_count: Integer
+      attr_accessor chunk_count: Integer
+      attr_accessor errored: bool
+      attr_accessor meta_bag: Hash[String, String]
+      def initialize: () -> void
+    end
+
+    # Thin Streamer shim holding the held-open upstream fd + state;
+    # delegates the pump to Proxy#run_stream via polymorphic self so
+    # subclass hooks dispatch.
+    class ProxyStreamer < Tep::Streamer
+      attr_accessor proxy: Tep::Proxy
+      attr_accessor fd: Integer
+      attr_accessor leftover: String
+      attr_accessor is_chunked: bool
+      attr_accessor is_sse: bool
+      attr_accessor req: Tep::Request
+      def initialize: () -> void
+      def pump: (Tep::Stream out) -> Integer
+    end
+  end
+end


### PR DESCRIPTION
## Why

**Main CI has been red since #166 (2026-05-30).** A fresh `make all`
fails building `hello.rb` with `redefinition of cst_Pg_RES_TUPLES` — the
`Pg` FFI consts emitted twice.

Root cause (spinel-pin-independent): every example loads tep by path
(`require_relative "../lib/tep"`), and the whole library is already
inlined wholesale at the top of each translation. PR #166 made app-local
`require_relative` inlining **recursive**, but the guard only excluded
the by-name forms (`"tep"` / `"tep/..."`) — the path form slipped
through and re-pulled the entire library a second time → duplicate
`module Pg` + `ffi_const` → C redefinition. (#164's single-level inline
only spliced `lib/tep.rb`'s require manifest, so it was latent until
#166.)

## What

- **`fix(build)`** — resolve the `require_relative` target and skip
  anything inside tep's own `LIB_DIR`, in addition to the by-name forms.
  Vendored app-local gems (the recursive path's purpose) are unaffected.
- **`chore(spinel)`** — bump `SPINEL_PIN` `f7602f4` → `cc94707` (+2
  require-path resolver fixes; robustness-only for the gem flow, no
  workaround to revert).
- **`docs(rbs)`** — add the 6 missing signatures (`pg`, `proxy`, `net`,
  `cache`, `events`, `openai_server`; the convention is one `.rbs` per
  lib file). Also make `rake rbs:validate` host-portable (was exit 127
  on a bare host where the rbs gem's bin dir isn't on PATH).

## Verification (dev container, ruby 3.4 +PRISM)

- `make all` — green, zero `redefinition`.
- Full parallel suite — **492 runs, 1160 assertions, 0 failures, 0
  errors, 53 skips**.
- `rake rbs:validate` — exit 0 on the host; full `sig/` tree validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)