### PR TITLE
feat(pg): raise SQLSTATE-mapped PG::Error subclasses on query error

### DIFF
--- a/examples/pg_hello.rb
+++ b/examples/pg_hello.rb
@@ -53,19 +53,23 @@ get '/tables' do
   out
 end
 
+# exec raises the SQLSTATE-mapped PG::Error subclass on failure (the
+# ruby-pg / AR shape). Rescue the leaf (PG::UndefinedTable) or the base
+# (PG::Error); the SQLSTATE / message stay on the connection's last_*.
 get '/error' do
   c = PG.connect(PG_URL)
-  r = c.exec("SELECT * FROM tep_no_such_table")
   out = ""
-  if r.ok?
+  begin
+    r = c.exec("SELECT * FROM tep_no_such_table")
+    r.clear
     out = "unexpected: query succeeded"
-  else
-    out = "result not ok\n" +
+  rescue PG::UndefinedTable => e
+    out = "rescued PG::UndefinedTable\n" +
           "sqlstate: " + c.last_sqlstate + "\n" +
           "is undefined-table? " + (c.last_sqlstate == "42P01" ? "yes" : "no") + "\n" +
-          "message: " + r.error_message
+          "is PG::Error? " + (e.is_a?(PG::Error) ? "yes" : "no") + "\n" +
+          "message: " + e.message
   end
-  r.clear
   c.close
   res.headers["Content-Type"] = "text/plain"
   out

--- a/lib/tep/pg.rb
+++ b/lib/tep/pg.rb
@@ -148,7 +148,15 @@ module PG
   # Convenience constructor matching ruby-pg's PG.connect entry.
   # opts is either a libpq conninfo String ("postgresql://...") or
   # a String=>String Hash of libpq keys (host, port, dbname, user,
-  # password, sslmode, ...). Raises PG::ConnectionBad on failure.
+  # password, sslmode, ...).
+  #
+  # Unlike ruby-pg (which raises PG::ConnectionBad), connect does NOT
+  # raise on failure: it returns a connection-failed Connection
+  # (`connected?` false, `last_error_message` set). This is deliberate
+  # -- PG::Pool type-seeds its free list with `PG::Connection.new("")`
+  # at module load, before any server is reachable, so the constructor
+  # has to be non-raising. Check `conn.connected?` before use. (Query
+  # methods #exec / #exec_params DO raise; see Connection#exec.)
   def self.connect(opts)
     Connection.new(opts)
   end
@@ -212,11 +220,14 @@ module PG
         @last_error_message = Pg.tep_pg_error_message(0)
         @last_sqlstate = ""
         # Connection-failure surfaces via `c.last_error_message` +
-        # `c.connected?` after the constructor returns. Spinel can't
-        # rescue module-namespaced exception classes today
-        # (matz/spinel#627) -- raising would skip user-side rescue
-        # and crash the worker. Document the contract: callers must
-        # check `c.connected?` before exec.
+        # `c.connected?` after the constructor returns -- the
+        # constructor stays non-raising on purpose (PG::Pool seeds its
+        # free list with `PG::Connection.new("")` before a server is
+        # reachable; a raising constructor would blow up at module
+        # load). Callers must check `c.connected?` before exec. NB:
+        # this is the lone non-raising path -- query methods raise
+        # PG::Error subclasses now that spinel supports namespaced
+        # raise + rescue (matz/spinel#627 + #1041).
       end
       @pgh = h
     end
@@ -298,25 +309,35 @@ module PG
       Pg.tep_pg_notify_payload
     end
 
-    # Run a no-params query. Returns a PG::Result. On error the
-    # result's `ok?` is false and `error_message` / `sql_state`
-    # describe the failure; SQLSTATE + message are also mirrored
-    # to `conn.last_sqlstate` / `#last_error_message`.
+    # Run a no-params query. Returns a PG::Result on success.
+    #
+    # ON ERROR IT RAISES the SQLSTATE-mapped PG::Error subclass
+    # (PG::UniqueViolation, PG::UndefinedTable, ... -> PG::ServerError
+    # for unmapped states) -- the ruby-pg / AR shape. The failed
+    # PGresult is freed before the raise; the SQLSTATE / message stay
+    # readable on `conn.last_sqlstate` / `#last_error_message` for
+    # post-rescue inspection:
+    #
+    #     begin
+    #       c.exec(sql)
+    #     rescue PG::UniqueViolation => e
+    #       ...                     # e.message + c.last_sqlstate
+    #     rescue PG::Error => e     # base catches any server error
+    #       ...
+    #     end
+    #
+    # Raising (instead of the old Result-on-error sentinel) became
+    # viable once spinel learned namespaced raise + hierarchy-walking
+    # rescue (matz/spinel#627 + #1041). NB: PG.connect is the one path
+    # that still does NOT raise -- it returns a connection-failed
+    # instance so PG::Pool can type-seed without a live server (check
+    # `conn.connected?`).
     #
     # Under `Tep::Server::Scheduled` this routes through the libpq
     # async surface (PQsendQuery + PQflush + PQconsumeInput parked
     # on Tep::Scheduler.io_wait), so other fibers in the same
     # worker can run while the query is in flight. Under prefork
-    # it routes through the blocking PQexec. Both produce
-    # identical Result shapes.
-    #
-    # v1 returns Result-on-error instead of raising because
-    # spinel's `rescue Module::Klass` doesn't resolve the
-    # constant path (top-level-class rescue is fixed but the
-    # module-namespaced case lags; tracking comment on
-    # matz/spinel#627). The PG::Error subclass tree is defined
-    # below so future code that wants to introspect / subclass
-    # has it; raising flips on once the namespace fix lands.
+    # it routes through the blocking PQexec. Both raise identically.
     def exec(sql)
       if Tep::Scheduler.scheduled_context?
         return async_exec(sql)
@@ -329,7 +350,7 @@ module PG
 
     # Parameterised query with positional binds ($1, $2, ...).
     # `params` is an Array of String / Integer / nil. Same
-    # Result-on-error model + auto-routing as `exec`.
+    # raise-on-error contract + auto-routing as `exec`.
     def exec_params(sql, params)
       Pg.tep_pg_param_clear
       i = 0
@@ -362,7 +383,7 @@ module PG
       Pg.tep_pg_set_nonblocking(@pgh, 1)
       ok = Pg.tep_pg_send_query(@pgh, sql)
       if ok != 1
-        return Connection.make_send_failure_result(self)
+        Connection.raise_send_failure(self)
       end
       Connection.drain_send(@pgh)
       Connection.wait_for_result_ready(@pgh)
@@ -401,7 +422,7 @@ module PG
       Pg.tep_pg_set_nonblocking(@pgh, 1)
       ok = Pg.tep_pg_send_query_params(@pgh, sql)
       if ok != 1
-        return Connection.make_send_failure_result(self)
+        Connection.raise_send_failure(self)
       end
       Connection.drain_send(@pgh)
       Connection.wait_for_result_ready(@pgh)
@@ -453,15 +474,17 @@ module PG
 
     # --- Internal helpers for the async loop ---
 
-    # PQsendQuery returned 0 (immediate failure -- bad SQL syntax
-    # at the libpq level, conn already closed, etc.). Mirror the
-    # error onto the conn's last_* and return a "synthetic"
-    # Result-with-rh=-1 so the same Result-shape contract holds.
-    def self.make_send_failure_result(conn)
+    # PQsendQuery returned 0 (immediate failure -- conn already
+    # closed, send buffer error, etc.). Mirror the error onto the
+    # conn's last_* and raise, matching the exec error path (ruby-pg
+    # surfaces a send failure as PG::UnableToSend < PG::Error). No
+    # SQLSTATE is available pre-result, so this maps to the transport
+    # leaf rather than going through raise_for_sqlstate.
+    def self.raise_send_failure(conn)
       conn.last_sqlstate = ""
       conn.last_error_message = conn.error_message
       conn.last_result_rh = -1
-      PG::Result.new(-1)
+      raise PG::UnableToSend, conn.error_message
     end
 
     # Drain libpq's send buffer. PQflush returns 0 when done; 1
@@ -569,7 +592,18 @@ module PG
       end
       conn.last_sqlstate = sqlstate
       conn.last_error_message = msg
-      conn.last_result_rh = r.rh
+      # Free the failed PGresult NOW: once we raise out of
+      # exec/exec_params the caller's `r.clear` never runs, so this is
+      # the only chance to release it. The SQLSTATE / message are
+      # already copied onto conn.last_* (Strings) for post-rescue
+      # inspection, so dropping the handle loses nothing callers need.
+      conn.last_result_rh = -1
+      r.clear
+      # ruby-pg / AR parity: raise the SQLSTATE-mapped PG::Error
+      # subclass (live since matz/spinel#627 + #1041 -- namespaced
+      # raise + hierarchy-walking rescue). Callers `rescue
+      # PG::UniqueViolation` (leaf) or `rescue PG::Error` (base).
+      PG.raise_for_sqlstate(sqlstate, msg)
       0
     end
   end
@@ -835,6 +869,71 @@ module PG
   # methods became viable with matz/spinel#1041; before that, checkout
   # surfaced exhaustion as a sentinel nil-equivalent Connection.)
   class PoolExhausted          < Error; end
+
+  # Raise the PG::Error subclass mapped from a 5-char SQLSTATE.
+  # Connection#exec / #exec_params call this (via record_error_if_any)
+  # so a failed query surfaces as a typed exception -- the ruby-pg / AR
+  # shape, where the adapter does `rescue PG::UniqueViolation` /
+  # `e.is_a?(PG::UndefinedTable)`. An unmapped SQLSTATE falls through to
+  # PG::ServerError, so `rescue PG::Error` still catches every server
+  # error. The mapping is the SQLSTATE-keyed subset the leaf classes
+  # cover (AR-coverage); add a leaf + an arm here together.
+  #
+  # Literal-class dispatch (one `raise PG::Klass` per arm) rather than
+  # `raise klass_var` -- raising a Class held in a local doesn't lower
+  # under spinel; the constant-path raise is what matz/spinel#1041 made
+  # work.
+  def self.raise_for_sqlstate(state, msg)
+    # 23 -- integrity constraint violation
+    if state == "23502"
+      raise PG::NotNullViolation, msg
+    elsif state == "23503"
+      raise PG::ForeignKeyViolation, msg
+    elsif state == "23505"
+      raise PG::UniqueViolation, msg
+    elsif state == "23514"
+      raise PG::CheckViolation, msg
+    elsif state == "23P01"
+      raise PG::ExclusionViolation, msg
+    # 25 -- invalid transaction state
+    elsif state == "25P02"
+      raise PG::InFailedSqlTransaction, msg
+    elsif state == "25006"
+      raise PG::ReadOnlySqlTransaction, msg
+    # 40 -- transaction rollback
+    elsif state == "40001"
+      raise PG::SerializationFailure, msg
+    elsif state == "40P01"
+      raise PG::DeadlockDetected, msg
+    # 42 -- syntax / access rule violation
+    elsif state == "42601"
+      raise PG::SyntaxError, msg
+    elsif state == "42703"
+      raise PG::UndefinedColumn, msg
+    elsif state == "42883"
+      raise PG::UndefinedFunction, msg
+    elsif state == "42P01"
+      raise PG::UndefinedTable, msg
+    elsif state == "42701"
+      raise PG::DuplicateColumn, msg
+    elsif state == "42P07"
+      raise PG::DuplicateTable, msg
+    elsif state == "42501"
+      raise PG::InsufficientPrivilege, msg
+    # 57 -- operator intervention
+    elsif state == "57014"
+      raise PG::QueryCanceled, msg
+    elsif state == "57P01"
+      raise PG::AdminShutdown, msg
+    # 08 -- connection exception
+    elsif state == "08000"
+      raise PG::ConnectionException, msg
+    elsif state == "08003"
+      raise PG::ConnectionDoesNotExist, msg
+    else
+      raise PG::ServerError, msg
+    end
+  end
 
   # -------- Connection pool --------
   #

--- a/lib/tep/presence.rb
+++ b/lib/tep/presence.rb
@@ -288,32 +288,28 @@ module Tep
       if conn.pgh < 0
         return -1
       end
-      r = conn.exec(Tep::Presence.schema_sql)
-      if !r.ok?
+      # exec raises PG::Error on failure now; degrade gracefully
+      # (close + return -1) rather than letting it escape the worker.
+      begin
+        r = conn.exec(Tep::Presence.schema_sql)
         r.clear
+        # Heartbeat table for the prune-stale-workers path (#47).
+        r = conn.exec(Tep::Presence.worker_schema_sql)
+        r.clear
+      rescue PG::Error
         conn.finish
         return -1
       end
-      r.clear
-      # Heartbeat table for the prune-stale-workers path (#47).
-      r = conn.exec(Tep::Presence.worker_schema_sql)
-      if !r.ok?
-        r.clear
-        conn.finish
-        return -1
-      end
-      r.clear
       Tep::APP.set_presence_pg_conn(conn)
       worker_id = Sock.sphttp_getpid.to_s + "-" + Time.now.to_i.to_s
       Tep::APP.set_presence_pg_worker_id(worker_id)
       Tep::APP.set_presence_pg_enabled(1)
       # Drop any rows from a prior worker that managed to leave
       # stale entries with this same worker_id (unlikely thanks
-      # to the boot-epoch suffix, but defensive).
-      r = conn.exec_params(
+      # to the boot-epoch suffix, but defensive). Best-effort.
+      Tep::Presence.mirror_exec(
         "DELETE FROM tep_presence WHERE worker_id = $1",
         [worker_id])
-      r.clear
       # Register this worker's heartbeat row immediately. Apps
       # refresh it periodically via Tep::Presence.heartbeat;
       # prune_stale_workers deletes rows whose heartbeat is stale.
@@ -325,16 +321,22 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
-        "DELETE FROM tep_presence WHERE worker_id = $1",
-        [Tep::APP.presence_pg_worker_id])
-      r.clear
-      # Remove the heartbeat row so prune_stale_workers doesn't
-      # see this worker as live after we're gone.
-      r = Tep::APP.presence_pg_conn.exec_params(
-        "DELETE FROM tep_presence_worker WHERE worker_id = $1",
-        [Tep::APP.presence_pg_worker_id])
-      r.clear
+      # Best-effort cleanup -- swallow PG errors (we're tearing the
+      # mirror down regardless) and still finish + disable below.
+      begin
+        r = Tep::APP.presence_pg_conn.exec_params(
+          "DELETE FROM tep_presence WHERE worker_id = $1",
+          [Tep::APP.presence_pg_worker_id])
+        r.clear
+        # Remove the heartbeat row so prune_stale_workers doesn't
+        # see this worker as live after we're gone.
+        r = Tep::APP.presence_pg_conn.exec_params(
+          "DELETE FROM tep_presence_worker WHERE worker_id = $1",
+          [Tep::APP.presence_pg_worker_id])
+        r.clear
+      rescue PG::Error
+        # swallow -- shutting the mirror down anyway
+      end
       Tep::APP.presence_pg_conn.finish
       Tep::APP.set_presence_pg_enabled(0)
       0
@@ -389,13 +391,17 @@ module Tep
       if wid.length == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
-        "INSERT INTO tep_presence_worker (worker_id, last_seen_ts) " +
-        "VALUES ($1, $2) " +
-        "ON CONFLICT (worker_id) DO UPDATE SET " +
-        "  last_seen_ts = EXCLUDED.last_seen_ts",
-        [wid, Time.now.to_i.to_s])
-      r.clear
+      begin
+        r = Tep::APP.presence_pg_conn.exec_params(
+          "INSERT INTO tep_presence_worker (worker_id, last_seen_ts) " +
+          "VALUES ($1, $2) " +
+          "ON CONFLICT (worker_id) DO UPDATE SET " +
+          "  last_seen_ts = EXCLUDED.last_seen_ts",
+          [wid, Time.now.to_i.to_s])
+        r.clear
+      rescue PG::Error
+        return 0
+      end
       1
     end
 
@@ -420,22 +426,41 @@ module Tep
       end
       cutoff = Time.now.to_i - ttl_seconds
       conn = Tep::APP.presence_pg_conn
-      # Drop dead heartbeats first; the second DELETE then walks
-      # the worker_id space that's still alive.
-      r1 = conn.exec_params(
-        "DELETE FROM tep_presence_worker WHERE last_seen_ts < $1",
-        [cutoff.to_s])
-      r1.clear
-      # Now drop presence rows whose worker_id isn't in the live
-      # heartbeat table. NOT IN handles both crashed-and-pruned
-      # workers and workers that never registered (legacy rows
-      # from before this prune feature shipped).
-      r2 = conn.exec(
-        "DELETE FROM tep_presence " +
-        "WHERE worker_id NOT IN (SELECT worker_id FROM tep_presence_worker)")
-      n = r2.cmd_tuples
-      r2.clear
+      begin
+        # Drop dead heartbeats first; the second DELETE then walks
+        # the worker_id space that's still alive.
+        r1 = conn.exec_params(
+          "DELETE FROM tep_presence_worker WHERE last_seen_ts < $1",
+          [cutoff.to_s])
+        r1.clear
+        # Now drop presence rows whose worker_id isn't in the live
+        # heartbeat table. NOT IN handles both crashed-and-pruned
+        # workers and workers that never registered (legacy rows
+        # from before this prune feature shipped).
+        r2 = conn.exec(
+          "DELETE FROM tep_presence " +
+          "WHERE worker_id NOT IN (SELECT worker_id FROM tep_presence_worker)")
+        n = r2.cmd_tuples
+        r2.clear
+      rescue PG::Error
+        return 0
+      end
       n
+    end
+
+    # Best-effort mirror write: run an exec_params on the mirror conn
+    # and swallow any PG::Error. The PG mirror is advisory -- local
+    # presence is authoritative -- so a transient mirror failure must
+    # never propagate into the caller's request now that exec raises
+    # (matz/spinel#627 + #1041). Always returns 0.
+    def self.mirror_exec(sql, params)
+      begin
+        r = Tep::APP.presence_pg_conn.exec_params(sql, params)
+        r.clear
+      rescue PG::Error
+        # swallow -- advisory mirror, local presence is authoritative
+      end
+      0
     end
 
     # Mirror a track to PG. Called from track() when the PG
@@ -444,7 +469,7 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
+      Tep::Presence.mirror_exec(
         "INSERT INTO tep_presence " +
         "(worker_id, topic, fd, principal_id, kind, agent_id, " +
         " since_ts, status_state, status_note, status_until) " +
@@ -469,8 +494,6 @@ module Tep
           entry.status_note,
           entry.status_until.to_s
         ])
-      r.clear
-      0
     end
 
     # Mirror an untrack to PG.
@@ -478,12 +501,10 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
+      Tep::Presence.mirror_exec(
         "DELETE FROM tep_presence " +
         "WHERE worker_id = $1 AND topic = $2 AND fd = $3",
         [Tep::APP.presence_pg_worker_id, topic, fd.to_s])
-      r.clear
-      0
     end
 
     # Mirror a status update.
@@ -491,14 +512,12 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
+      Tep::Presence.mirror_exec(
         "UPDATE tep_presence " +
         "SET status_state = $4, status_note = $5, status_until = $6 " +
         "WHERE worker_id = $1 AND topic = $2 AND fd = $3",
         [Tep::APP.presence_pg_worker_id, topic, fd.to_s,
          state.to_s, note, until_ts.to_s])
-      r.clear
-      0
     end
 
     # Cross-worker list: SELECT all entries on `topic` regardless
@@ -511,13 +530,13 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return result
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
-        "SELECT principal_id, kind, agent_id, fd, since_ts, " +
-        "       status_state, status_note, status_until " +
-        "FROM tep_presence WHERE topic = $1 ORDER BY since_ts",
-        [topic])
-      if !r.ok?
-        r.clear
+      begin
+        r = Tep::APP.presence_pg_conn.exec_params(
+          "SELECT principal_id, kind, agent_id, fd, since_ts, " +
+          "       status_state, status_note, status_until " +
+          "FROM tep_presence WHERE topic = $1 ORDER BY since_ts",
+          [topic])
+      rescue PG::Error
         return result
       end
       i = 0
@@ -555,11 +574,11 @@ module Tep
       if Tep::APP.presence_pg_enabled == 0
         return 0
       end
-      r = Tep::APP.presence_pg_conn.exec_params(
-        "SELECT count(*) FROM tep_presence WHERE topic = $1",
-        [topic])
-      if !r.ok?
-        r.clear
+      begin
+        r = Tep::APP.presence_pg_conn.exec_params(
+          "SELECT count(*) FROM tep_presence WHERE topic = $1",
+          [topic])
+      rescue PG::Error
         return 0
       end
       n = r.getvalue(0, 0).to_i

--- a/sig/tep/pg.rbs
+++ b/sig/tep/pg.rbs
@@ -33,10 +33,19 @@ module PG
 
   # Convenience constructor matching ruby-pg's PG.connect. `opts` is a
   # libpq conninfo String ("postgresql://...") or a String=>String Hash.
+  # Unlike ruby-pg, connect does NOT raise on failure -- it returns a
+  # connection-failed Connection (check #connected?) so PG::Pool can
+  # type-seed before a server is reachable. Query methods DO raise.
   def self.connect: (String | Hash[String, String] opts) -> PG::Connection
 
   # libpq version string ("16.2.0" ...). Diagnostic / banner use.
   def self.libpq_version: () -> String
+
+  # Raise the PG::Error subclass mapped from a 5-char SQLSTATE
+  # (unmapped -> PG::ServerError). Called by exec/exec_params via the
+  # error path; exposed for callers that hold a SQLSTATE and want the
+  # same mapping. Always raises (never returns).
+  def self.raise_for_sqlstate: (String state, String msg) -> bot
 
   class Connection
     # `:pgh` rather than `:handle` to avoid the poly-dispatch collision
@@ -72,13 +81,18 @@ module PG
     def last_notify_channel: () -> String
     def last_notify_payload: () -> String
 
-    # Returns a Result. On error the Result's #ok? is false and SQLSTATE
-    # / message mirror to #last_sqlstate / #last_error_message. Routes
-    # through the libpq async surface under Tep::Server::Scheduled.
+    # Returns a Result on success; RAISES the SQLSTATE-mapped PG::Error
+    # subclass on error (ruby-pg / AR shape -- rescue the leaf e.g.
+    # PG::UniqueViolation, or PG::Error for any server error). SQLSTATE
+    # / message stay on #last_sqlstate / #last_error_message for
+    # post-rescue inspection. Routes through the libpq async surface
+    # under Tep::Server::Scheduled (raises identically).
     def exec: (String sql) -> Result
     # `params` is an Array of String / Integer / nil (positional $1..$N).
+    # Same raise-on-error contract as #exec.
     def exec_params: (String sql, Array[String | Integer | nil] params) -> Result
     # Explicit async variants -- always use the libpq non-blocking path.
+    # Same raise-on-error contract.
     def async_exec: (String sql) -> Result
     def async_exec_params: (String sql, Array[String | Integer | nil] params) -> Result
 

--- a/test/test_pg.rb
+++ b/test/test_pg.rb
@@ -258,31 +258,46 @@ class TestPg < TepTest
       "ident=" + out
     end
 
-    # GET /missing_table -- error path; check Result#ok? + sqlstate.
+    # GET /missing_table -- error path; exec raises PG::UndefinedTable.
     get '/missing_table' do
       c = PG.connect(PG_URL)
-      r = c.exec("SELECT * FROM tep_no_such_table_anywhere")
-      out = "ok?=" + (r.ok? ? "yes" : "no") +
-            " sqlstate=" + c.last_sqlstate +
-            " match42P01=" + (c.last_sqlstate == "42P01" ? "yes" : "no")
-      r.clear
+      out = ""
+      begin
+        r = c.exec("SELECT * FROM tep_no_such_table_anywhere")
+        r.clear
+        out = "raised=no"
+      rescue PG::UndefinedTable => e
+        out = "raised=UndefinedTable" +
+              " sqlstate=" + c.last_sqlstate +
+              " match42P01=" + (c.last_sqlstate == "42P01" ? "yes" : "no") +
+              " is_pg_error=" + (e.is_a?(PG::Error) ? "yes" : "no")
+      end
       c.close
       out
     end
 
-    # GET /unique_violation -- INSERT duplicate primary key.
+    # GET /unique_violation -- duplicate PK INSERT raises
+    # PG::UniqueViolation (SQLSTATE 23505).
     get '/unique_violation' do
       c = PG.connect(PG_URL)
+      # Clear any leftover row from a prior crashed run so the first
+      # INSERT below reliably succeeds.
+      rd = c.exec_params("DELETE FROM " + TBL + " WHERE id = $1", ["99001"])
+      rd.clear
       r1 = c.exec_params("INSERT INTO " + TBL + " (id, body) VALUES ($1, $2)",
                          ["99001", "duplicate"])
-      ok1 = r1.ok?
       r1.clear
-      r2 = c.exec_params("INSERT INTO " + TBL + " (id, body) VALUES ($1, $2)",
-                        ["99001", "duplicate"])
-      out = "first_ok=" + (ok1 ? "yes" : "no") +
-            " second_ok=" + (r2.ok? ? "yes" : "no") +
-            " sqlstate=" + c.last_sqlstate
-      r2.clear
+      out = ""
+      begin
+        r2 = c.exec_params("INSERT INTO " + TBL + " (id, body) VALUES ($1, $2)",
+                          ["99001", "duplicate"])
+        r2.clear
+        out = "first_ok=yes second_raised=no"
+      rescue PG::UniqueViolation => e
+        out = "first_ok=yes second_raised=UniqueViolation" +
+              " sqlstate=" + c.last_sqlstate +
+              " is_pg_error=" + (e.is_a?(PG::Error) ? "yes" : "no")
+      end
       r3 = c.exec_params("DELETE FROM " + TBL + " WHERE id = $1", ["99001"])
       r3.clear
       c.close
@@ -562,16 +577,21 @@ class TestPg < TepTest
 
   def test_missing_table_error_path
     res = get("/missing_table")
-    assert_match(/ok\?=no/, res.body)
+    # exec now RAISES PG::UndefinedTable (rescued in the route).
+    assert_match(/raised=UndefinedTable/, res.body)
     assert_match(/sqlstate=42P01/, res.body)
     assert_match(/match42P01=yes/, res.body)
+    # the leaf is a PG::Error (base rescue + is_a? walk the hierarchy).
+    assert_match(/is_pg_error=yes/, res.body)
   end
 
   def test_unique_violation_reports_23505
     res = get("/unique_violation")
+    # the duplicate INSERT raises PG::UniqueViolation; first succeeds.
     assert_match(/first_ok=yes/, res.body)
-    assert_match(/second_ok=no/, res.body)
+    assert_match(/second_raised=UniqueViolation/, res.body)
     assert_match(/sqlstate=23505/, res.body)
+    assert_match(/is_pg_error=yes/, res.body)
   end
 
   def test_escape_literal_quotes_apostrophe

--- a/test/test_presence_pg.rb
+++ b/test/test_presence_pg.rb
@@ -55,10 +55,16 @@ class TestPresencePg < TepTest
 
     get '/reset_pg_table' do
       # Wipe the whole tep_presence table; reused between tests.
+      # Tolerate a not-yet-created table (exec raises now) -> "0".
       c = Tep::APP.presence_pg_conn
-      r = c.exec("DELETE FROM tep_presence")
-      n = r.cmd_tuples
-      r.clear
+      n = 0
+      begin
+        r = c.exec("DELETE FROM tep_presence")
+        n = r.cmd_tuples
+        r.clear
+      rescue PG::Error
+        n = 0
+      end
       n.to_s
     end
 
@@ -160,10 +166,16 @@ class TestPresencePg < TepTest
     end
 
     get '/reset_worker_table' do
+      # Tolerate a not-yet-created table (exec raises now) -> "0".
       c = Tep::APP.presence_pg_conn
-      r = c.exec("DELETE FROM tep_presence_worker")
-      n = r.cmd_tuples
-      r.clear
+      n = 0
+      begin
+        r = c.exec("DELETE FROM tep_presence_worker")
+        n = r.cmd_tuples
+        r.clear
+      rescue PG::Error
+        n = 0
+      end
       n.to_s
     end
 
@@ -250,6 +262,14 @@ class TestPresencePg < TepTest
   def test_heartbeat_is_idempotent
     # Calling heartbeat multiple times shouldn't multiply rows;
     # the upsert keeps it at one per worker_id.
+    #
+    # Establish this worker's heartbeat row FIRST, then measure: setup
+    # resets tep_presence but not tep_presence_worker, so a prior
+    # test's reset_worker_table can leave our row absent. Without this
+    # priming, n_before is taken before our row exists and the first
+    # heartbeat below re-creates it -- a spurious +1 (a pre-existing
+    # isolation gap, not a heartbeat bug).
+    get("/heartbeat")
     n_before = get("/worker_count").body.to_i
     3.times { get("/heartbeat") }
     n_after = get("/worker_count").body.to_i


### PR DESCRIPTION
## What

`Connection#exec` / `#exec_params` now **raise** the SQLSTATE-mapped
`PG::Error` subclass on failure (ruby-pg / ActiveRecord shape) instead of
returning a not-ok `Result`:

```ruby
begin
  c.exec_params("INSERT ...", binds)
rescue PG::UniqueViolation => e   # leaf
  ...                              # e.message + c.last_sqlstate
rescue PG::Error => e             # base catches any server error
  ...
end
```

This closes the stale-doc cruft spotted in the last pass: `exec`'s
docstring claimed module-namespaced `rescue` was unresolved (citing
`matz/spinel#627`) and contradicted the exception-hierarchy comment that
said it was live. Both **#627** (`a291143`, rescue + `is_a?` walk the
hierarchy) and **#1041** (`a98c0df`, namespaced raise + rescue) are in
our pinned spinel — proven by spinel's own `rescue_walks_class_hierarchy`
+ `i1041` tests — so raising is now viable.

## Changes

- **`pg.rb`** — `record_error_if_any` frees the failed result then raises
  via new `PG.raise_for_sqlstate` (literal-class dispatch over the
  AR-coverage SQLSTATE set; unmapped → `PG::ServerError`). Send failures
  → `PG::UnableToSend`. `PG.connect` stays **non-raising** (Pool seeds
  `Connection.new("")` at module load); its false "raises" doc + the two
  other stale `#627` comments corrected.
- **`presence.rb`** — the PG mirror is advisory, so a transient error
  must not 500 the user's request: new `mirror_exec` helper swallows for
  the pure writes; `heartbeat`/`prune`/`enable`/`disable` wrap inline;
  the 4 `!r.ok?` sites become `begin/rescue`.
- **`pg_hello.rb`, `test_pg.rb`** — error routes rescue + assert the leaf
  class **and** `e.is_a?(PG::Error)`.
- **`test_presence_pg.rb`** — reset routes tolerate a missing table; fix
  a **pre-existing** isolation bug in `test_heartbeat_is_idempotent`
  (fails on original code too — `setup` doesn't reset
  `tep_presence_worker`; only ever exercised with a live PG, which CI
  lacks).
- **`sig/tep/pg.rbs`** — raise contract documented; `raise_for_sqlstate`
  added.

## Verification (live PostgreSQL via `docker compose pg`)

- Full suite: **492 runs, 1261 assertions, 0 failures, 0 errors**.
- `test_pg` (27) + `test_presence_pg` (10) green; `pg_hello` compiles
  (namespaced raise/rescue codegen). RBS validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)