### PR TITLE
perf(crypto): getbyte(i) not bytes[i] in hot compare/parse loops

### DIFF
--- a/lib/tep/json.rb
+++ b/lib/tep/json.rb
@@ -73,9 +73,9 @@ module Tep
         elsif c == "\f"
           out = out + "\\f"
         elsif c < " "
-          # Other control byte -- emit \u00XX. c.bytes[0] is the
+          # Other control byte -- emit \u00XX. c.getbyte(0) is the
           # raw byte value, mapped to two hex digits.
-          b = c.bytes[0]
+          b = c.getbyte(0)
           out = out + "\\u00" + Json.hex2(b)
         else
           out = out + c
@@ -454,13 +454,13 @@ module Tep
 
     def self.hex_nibble(c)
       if c >= "0" && c <= "9"
-        return c.bytes[0] - "0".bytes[0]
+        return c.getbyte(0) - "0".getbyte(0)
       end
       if c >= "a" && c <= "f"
-        return c.bytes[0] - "a".bytes[0] + 10
+        return c.getbyte(0) - "a".getbyte(0) + 10
       end
       if c >= "A" && c <= "F"
-        return c.bytes[0] - "A".bytes[0] + 10
+        return c.getbyte(0) - "A".getbyte(0) + 10
       end
       -1
     end
@@ -506,7 +506,7 @@ module Tep
       while pos < s.length
         c = s[pos]
         if c >= "0" && c <= "9"
-          n = n * 10 + (c.bytes[0] - "0".bytes[0])
+          n = n * 10 + (c.getbyte(0) - "0".getbyte(0))
           saw_digit = true
           pos += 1
         else

--- a/lib/tep/jwt.rb
+++ b/lib/tep/jwt.rb
@@ -113,7 +113,11 @@ module Tep
       i = 0
       n = a.length
       while i < n
-        diff = diff | (a.bytes[i] ^ b.bytes[i])
+        # getbyte(i), NOT bytes[i] -- the same O(n^2)-allocation +
+        # GC-pressure hazard fixed in Tep::Session.timing_safe_eq
+        # (allocation storm can free the FFI-returned signature local
+        # mid-compare; #1052-family spinel rooting gap, see tep#157).
+        diff = diff | (a.getbyte(i) ^ b.getbyte(i))
         i += 1
       end
       diff == 0

--- a/lib/tep/session.rb
+++ b/lib/tep/session.rb
@@ -77,8 +77,20 @@ module Tep
     end
     diff = 0
     i = 0
-    while i < a.length
-      diff = diff | (a.bytes[i] ^ b.bytes[i])
+    n = a.length
+    while i < n
+      # getbyte(i), NOT bytes[i]: `String#bytes` allocates a fresh
+      # array on EVERY iteration (O(n^2) garbage). Besides being slow,
+      # that allocation storm drives the GC hard enough to free `b` --
+      # the HMAC string returned from the Crypto FFI call, held only in
+      # an argument local -- mid-loop, so a valid cookie fails its
+      # signature check ~5% of the time under load (a #1052-family
+      # heap-local rooting gap in spinel, open on master cc94707; the
+      # real fix is upstream, tracked at tep#157). getbyte allocates
+      # nothing, removing the dominant GC trigger here (cuts the flake
+      # ~3x); the residual lives at other unrooted-local sites in the
+      # decode path and clears only when spinel roots heap locals.
+      diff = diff | (a.getbyte(i) ^ b.getbyte(i))
       i += 1
     end
     diff == 0

--- a/lib/tep/url.rb
+++ b/lib/tep/url.rb
@@ -42,7 +42,7 @@ module Tep
            c == "_" || c == "~"
           out = out + c
         else
-          b = c.bytes[0]
+          b = c.getbyte(0)
           hi = b / 16
           lo = b % 16
           out = out + "%" + Url.hex_char(hi) + Url.hex_char(lo)
@@ -54,20 +54,20 @@ module Tep
 
     def self.hex_char(n)
       if n < 10
-        return ("0".bytes[0] + n).chr
+        return ("0".getbyte(0) + n).chr
       end
-      ("A".bytes[0] + n - 10).chr
+      ("A".getbyte(0) + n - 10).chr
     end
 
     def self.hex_nibble(c)
       if c >= "0" && c <= "9"
-        return c.bytes[0] - "0".bytes[0]
+        return c.getbyte(0) - "0".getbyte(0)
       end
       if c >= "a" && c <= "f"
-        return c.bytes[0] - "a".bytes[0] + 10
+        return c.getbyte(0) - "a".getbyte(0) + 10
       end
       if c >= "A" && c <= "F"
-        return c.bytes[0] - "A".bytes[0] + 10
+        return c.getbyte(0) - "A".getbyte(0) + 10
       end
       -1
     end


### PR DESCRIPTION
## What

`String#bytes` allocates a fresh array on **every** call, so `a.bytes[i]` inside a loop is O(n²) garbage. This pattern sat in:

- `Tep::Session.timing_safe_eq` + `Tep::JWT.timing_safe_eq` — the constant-time HMAC **signature compare** loops.
- `Tep::Url` / `Tep::Json` per-character hex/number decode (`.bytes[0]` per char).

All hot, all in the request path. `getbyte(i)` reads one byte with **zero allocation**.

## Why it matters beyond perf (tep#157)

The allocation storm was the **dominant trigger** for the load-sensitive `test_auth_session_cookie` flake. Reproduced by replaying a *fixed, known-good* session cookie 16,000× under 8-way CPU load (so: not transport, not capture, not concurrency — the app is 1-worker serial):

| compare | spurious-anonymous rate |
|---|---|
| `bytes[i]` (before) | **879 / 16000 = 5.5%** |
| `getbyte(i)` (after) | **319 / 16000 = 2.0%** (~3× fewer) |

Mechanism: the per-iteration garbage drove GC hard enough to free the FFI-returned HMAC string — held in a Ruby local across the compare — mid-loop, so a valid cookie failed its signature check → anonymous fallback.

## Not a complete fix

The **residual** is a still-open spinel heap-local GC-rooting gap (sibling of the closed #1052 / #1068) at other unrooted-local sites in the decode path — it only clears when spinel roots heap-typed locals across internal GC. This PR removes the dominant trigger and is a correct, standalone perf fix; the root cause stays tracked at #157.

## Verification
Full suite green: **492 runs, 0 failures, 0 errors**. Build clean (spinel compiles `getbyte` across all four files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)