### PR TITLE
fix(sqlite): 64-bit col_int / bind_int (closes #171)

### DIFF
--- a/lib/tep/sqlite.rb
+++ b/lib/tep/sqlite.rb
@@ -57,10 +57,17 @@ module Sqlite
   ffi_func :tep_sqlite_prepare,           [:int, :str],    :int
   ffi_func :tep_sqlite_prepare_cached,    [:int, :str],    :int
   ffi_func :tep_sqlite_bind_str,          [:int, :str],    :int
-  ffi_func :tep_sqlite_bind_int,          [:int, :int],    :int
+  # bind_int / col_int are 64-bit: the value arg + return use the FFI
+  # `:long` (64-bit on LP64) routed through sqlite3_bind_int64 /
+  # sqlite3_column_int64, so an integer column > 2^31 round-trips
+  # without the 32-bit truncation that wrapped large values negative
+  # (issue #171). Spinel's mrb_int is pointer-width, so the Ruby side
+  # holds the full range. `:long` still maps to the `int` Spinel token,
+  # so callers see an Integer exactly as before.
+  ffi_func :tep_sqlite_bind_int,          [:int, :long],   :int
   ffi_func :tep_sqlite_step,              [],              :int
   ffi_func :tep_sqlite_col_str,           [:int],          :str
-  ffi_func :tep_sqlite_col_int,           [:int],          :int
+  ffi_func :tep_sqlite_col_int,           [:int],          :long
   ffi_func :tep_sqlite_col_count,         [],              :int
   ffi_func :tep_sqlite_finalize,          [],              :int
   ffi_func :tep_sqlite_reset,             [],              :int

--- a/lib/tep/tep_sqlite.c
+++ b/lib/tep/tep_sqlite.c
@@ -241,9 +241,12 @@ int tep_sqlite_bind_str(int idx, const char *value) {
                 == SQLITE_OK ? 0 : -1;
 }
 
-int tep_sqlite_bind_int(int idx, int value) {
+/* 64-bit bind. `long` is the FFI `:long` type (64-bit on the LP64
+ * targets Spinel compiles for); routed through sqlite3_bind_int64 so a
+ * value > 2^31 isn't truncated on the way in (issue #171). */
+int tep_sqlite_bind_int(int idx, long value) {
     if (!tep_sqlite_stmt) return -1;
-    return sqlite3_bind_int(tep_sqlite_stmt, idx, value) == SQLITE_OK ? 0 : -1;
+    return sqlite3_bind_int64(tep_sqlite_stmt, idx, (sqlite3_int64)value) == SQLITE_OK ? 0 : -1;
 }
 
 /* 1 -> row available, 0 -> done (no more rows), -1 -> error */
@@ -268,9 +271,14 @@ const char *tep_sqlite_col_str(int idx) {
     return buf;
 }
 
-int tep_sqlite_col_int(int idx) {
+/* 64-bit column read. sqlite3_column_int (32-bit) silently wrapped a
+ * value > 2^31 negative -- e.g. a 3.4e9 download count read back as
+ * -867422609 (issue #171). sqlite3_column_int64 + a `long` (FFI
+ * `:long`, 64-bit) return path preserves the full range; mrb_int is
+ * pointer-width so the Ruby side holds it losslessly. */
+long tep_sqlite_col_int(int idx) {
     if (!tep_sqlite_stmt) return 0;
-    return sqlite3_column_int(tep_sqlite_stmt, idx);
+    return (long)sqlite3_column_int64(tep_sqlite_stmt, idx);
 }
 
 int tep_sqlite_col_count(void) {

--- a/test/test_sqlite.rb
+++ b/test/test_sqlite.rb
@@ -69,6 +69,26 @@ class TestSqlite < TepTest
       db.close
       "inserted=" + id.to_s
     end
+
+    # 64-bit round-trip (issue #171): bind a value > 2^31 via bind_int,
+    # read it back via col_int. With the old 32-bit path this wrapped
+    # negative (3427544687 -> -867422609); now it must survive intact.
+    get '/bigint' do
+      db = Tep::SQLite.new
+      db.open("#{TMP_DB}")
+      db.exec("CREATE TABLE IF NOT EXISTS bignums (n INTEGER)")
+      db.exec("DELETE FROM bignums")
+      db.prepare("INSERT INTO bignums (n) VALUES (?)")
+      db.bind_int(1, 3427544687)
+      db.step
+      db.finalize
+      db.prepare("SELECT n FROM bignums LIMIT 1")
+      db.step
+      n = db.col_int(0)
+      db.finalize
+      db.close
+      "n=" + n.to_s
+    end
   RB
 
   Minitest.after_run do
@@ -116,5 +136,13 @@ class TestSqlite < TepTest
 
     res2 = get("/note/#{inserted_id}")
     assert_match(/body=via-test/, res2.body)
+  end
+
+  def test_bind_and_col_int_round_trip_64bit
+    # 3,427,544,687 > 2^31-1. The old 32-bit bind/col path truncated it
+    # to -867,422,609 (issue #171); 64-bit bind_int/col_int preserve it.
+    res = get("/bigint")
+    assert_equal "200", res.code
+    assert_equal "n=3427544687", res.body
   end
 end


### PR DESCRIPTION
## The bug

`Tep::SQLite#col_int` / `#bind_int` were **32-bit** — bound through `sqlite3_column_int` / `sqlite3_bind_int` with an `:int` FFI signature, so any integer column `> 2³¹−1` silently truncated and wrapped negative. SQLite stores it as 64-bit; the loss was entirely in the tep binding.

Real consumer (from #171): spinelgems.org's catalog rendered `bundler … −867,422,609 downloads` for a stored **3,427,544,687**.

## The fix

Widen both paths **in place** (no `col_int64`/`bind_int64` siblings) — a truncating reader/writer is never what a caller wants, and it's backward-compatible:

- **C:** `sqlite3_column_int64` / `sqlite3_bind_int64`, with a `long` return / value arg (64-bit on the LP64 targets Spinel compiles for).
- **FFI:** the value arg + return become `:long`. Spinel's `ffi_type_of` maps `:long` to the same `int` token as `:int` (`mrb_int` is pointer-width / 64-bit on aarch64), so the **Ruby-side inferred type is unchanged** — callers still get a plain `Integer`, values that fit in 32 bits are identical, and large values now survive.

No spinel prerequisite needed — `:long` is already a supported FFI spec.

## Verification

New test binds `3,427,544,687` via `bind_int` and reads it back via `col_int` → asserts it equals (not the `−867,422,609` wrap). Full suite green: **493 runs, 0 failures, 0 errors** in the dev container.

Closes #171. (#172 is an identical duplicate — can be closed too.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)