### PR TITLE
docs(events): retire stale kind:"inference" + tep_demo refs (#168 part A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ lives in [`docs/BATTERIES-DESIGN.md`](docs/BATTERIES-DESIGN.md).
   chat, agent-spawn with OAuth2-style delegation. ~270 lines.
 - **[`examples/chatbot/`](examples/chatbot/app.rb)** — minimalistic
   OpenWebUI-style client backed by any OpenAI-compatible endpoint
-  (Ollama / OpenAI / [toy](https://github.com/OriPekelman/toy/tree/main/tep_demo))
+  (Ollama / OpenAI / [toy](https://github.com/OriPekelman/toy)'s `toy serve`)
   exercising the full pre-agentic battery surface
   (`Tep::Server::Scheduled` + `Tep::Llm` + `Tep::SQLite` +
   `Tep::Streamer` + `Tep::Session` + `Tep::Password` + `Tep::Jwt` +

--- a/examples/chatbot/README.md
+++ b/examples/chatbot/README.md
@@ -32,7 +32,7 @@ Three backends interchangeable via env var:
 # Ollama (default)
 CHAT_BACKEND=http://localhost:11434 CHAT_MODEL=llama3 /tmp/chatbot
 
-# toy/tep_demo/openai_api (sibling project's GPT-2 / DistilGPT2 server)
+# toy serve (sibling project's OpenAI-compatible server)
 CHAT_BACKEND=http://localhost:8080 CHAT_MODEL=gpt-2 /tmp/chatbot
 
 # OpenAI proper

--- a/examples/chatbot/app.rb
+++ b/examples/chatbot/app.rb
@@ -2,8 +2,9 @@
 # OpenAI-compatible chat backend.
 #
 # Talks to Ollama / OpenAI / [toy](https://github.com/OriPekelman/toy)'s
-# tep_demo/openai_api.rb via a uniform wire protocol. Single-user,
-# first-boot password setup, conversation persistence in SQLite.
+# `toy serve` (its OpenAI-compatible server, lib/toy/serve/openai/) via
+# a uniform wire protocol. Single-user, first-boot password setup,
+# conversation persistence in SQLite.
 #
 # Distinct from examples/chat/ -- that one is a multi-user SSE chat
 # (people talking to people). This one is a user-to-LLM chatbot.
@@ -21,7 +22,7 @@
 # -----------------
 # `CHAT_BACKEND` env var sets the LLM base_url. Defaults to Ollama
 # on localhost:11434. Other values:
-#   - http://localhost:8080  (toy/tep_demo/openai_api)
+#   - http://localhost:8080  (toy serve -- toy's OpenAI server)
 #   - https://api.openai.com (real OpenAI; needs CHAT_API_KEY)
 #
 # `CHAT_MODEL` picks the model. Default is "llama3" for Ollama.

--- a/examples/llm_gateway/app.rb
+++ b/examples/llm_gateway/app.rb
@@ -2,8 +2,9 @@
 #
 # Fronts a remote OpenAI-compatible upstream: swaps the client's
 # credential for the server-side key, streams the SSE response back
-# unchanged, and emits ONE toy/v1 `inference` telemetry event per
-# request at end-of-stream (via Tep::Events). This is the payoff of
+# unchanged, and emits ONE toy/v1 serving event (kind:eval,
+# phase:serve, name:request) per request at end-of-stream (via
+# Tep::Events#inference). This is the payoff of
 # the proxy streaming battery (chunk 6.2) + the events emitter --
 # token-count + latency telemetry with the right cardinality (one
 # event per request, not per chunk), using on_stream_end as the
@@ -14,12 +15,13 @@
 #   EVENTS_JSONL=/tmp/gateway.events.jsonl \
 #     bin/tep build examples/llm_gateway/app.rb -o /tmp/gw && /tmp/gw -p 4567
 #
-#   # streaming chat completion -> SSE passthrough + one inference event
+#   # streaming chat completion -> SSE passthrough + one serving event
 #   curl -s localhost:4567/v1/chat/completions -H 'content-type: application/json' \
 #     -d '{"model":"gpt-4o-mini","stream":true,"messages":[{"role":"user","content":"hi"}]}'
 #   tail -1 /tmp/gateway.events.jsonl
-#   # {"kind":"inference","phase":"serve","t":3,"model":"gpt-4o-mini",
-#   #  "prompt_tokens":0,"completion_tokens":42,"wall_us":3000000,"extra":{...}}
+#   # {"kind":"eval","phase":"serve","t":3,"name":"request","extra":{
+#   #   "model":"gpt-4o-mini","prompt_tokens":0,"completion_tokens":42,
+#   #   "latency_us":3000000, ...}}
 require 'sinatra'
 
 # Streaming proxying needs the cooperative server (the pump parks on

--- a/lib/tep/events.rb
+++ b/lib/tep/events.rb
@@ -2,10 +2,11 @@
 #
 # Appends newline-delimited JSON (JSONL) in the toy/v1 envelope
 # (`docs/events-schema.md` in the toy project): one `run_start` at
-# boot, one `inference` per served request, one `run_end` at
-# shutdown. The serving stream is structurally indistinguishable
-# from a training stream, so a single downstream ingest (the
-# research-lab orchestrator) consumes both.
+# boot, one serving event (`kind:"eval"`, `phase:"serve"`,
+# `name:"request"`) per served request, one `run_end` at shutdown.
+# The serving stream is structurally indistinguishable from a
+# training stream, so a single downstream ingest (the research-lab
+# orchestrator) consumes both.
 #
 # Standalone on purpose: any tep handler can emit (the chatbot's
 # existing OpenAI-compat endpoint, a future Tep::Llm::OpenAI::Server,
@@ -23,12 +24,15 @@
 #   # ... at shutdown:
 #   EVENTS.run_end("ok")
 #
-# Schema choice (was #79): per-request telemetry is `kind:"inference",
-# phase:"serve"` -- a distinct kind, NOT an overload of toy/v1's
-# `eval` (reserved for held-out training evaluation: loss/ppl/
-# samples). tao's recommendation; a served completion shares none of
-# eval's defining fields, and overloading `eval` would break tao's
-# ingest (which keys the "final eval" on `kind` alone).
+# Schema (supersedes #79): per-request serving telemetry is
+# `kind:"eval", phase:"serve", name:"request"`. The original #79
+# decision used a distinct `kind:"inference"` to avoid overloading
+# toy/v1's `eval` (held-out training evaluation: loss/ppl/samples);
+# that disambiguator moved onto `phase`/`name` instead -- a served
+# completion is `eval`+`phase:"serve"`+`name:"request"`, training eval
+# is `eval`+`phase:"eval"`, so tao keys on the (kind, phase, name)
+# triple rather than `kind` alone. `inference` is retired. See
+# `#inference` below for the emitted shape.
 #
 # Integer-only number fields by design (a tep choice, NOT a spinel
 # constraint -- spinel supports Float fully; this module deliberately

--- a/lib/tep/llm.rb
+++ b/lib/tep/llm.rb
@@ -7,7 +7,7 @@
 # {model, messages:[{role,content}...]} -- whether the backend is
 # Ollama, OpenAI proper, vLLM, Anthropic-via-litellm, or tep's
 # sibling project [toy](https://github.com/OriPekelman/toy)'s
-# tep_demo/openai_api.rb. Hand-rolling that JSON + the parse for
+# `toy serve` (lib/toy/serve/openai/). Hand-rolling that JSON + the parse for
 # every app is twenty lines of awkward escape-handling each time.
 # `Tep::Llm` is the Faraday-shape one-call client; backends are
 # config, not code.
@@ -39,7 +39,7 @@
 #
 # Three backends interchangeable via base_url:
 #   "http://localhost:11434" -- Ollama (default)
-#   "http://localhost:8080"  -- toy/tep_demo/openai_api
+#   "http://localhost:8080"  -- toy serve (toy's OpenAI server)
 #   "https://api.openai.com" -- OpenAI proper (needs api_key)
 module Tep
   class Llm

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -293,7 +293,8 @@ module Tep
       # Runs one streaming completion. Subclass of Tep::Streamer so the
       # server pumps `pump(out)` cooperatively; we own the SSE shape
       # end-to-end: drive the backend through StreamSink, write the
-      # terminating data:[DONE], then emit the toy/v1 inference event.
+      # terminating data:[DONE], then emit the toy/v1 serving event
+      # (kind:eval, phase:serve, name:request) via Events#inference.
       class CompletionsStreamer < Tep::Streamer
         attr_accessor :model, :token_ids, :sampling
         attr_accessor :prompt_tokens, :t0, :request_id, :principal_id
@@ -416,8 +417,8 @@ module Tep
       # Runs one streaming chat completion. Subclass of Tep::Streamer.
       # Drives backend.chat_completion_stream through ChatStreamSink,
       # writes the terminating data:[DONE], then emits the toy/v1
-      # inference event with sink.completion_count (mirrors
-      # CompletionsStreamer's #128 shape).
+      # serving event (kind:eval, phase:serve, name:request) with
+      # sink.completion_count (mirrors CompletionsStreamer's #128 shape).
       class ChatCompletionsStreamer < Tep::Streamer
         attr_accessor :req_ref, :model, :prompt_tokens
         attr_accessor :t0, :request_id, :principal_id


### PR DESCRIPTION
Doc/comment-only cleanup from the toy@0.7 hand-off audit — **#168 Part A**. No behavior change (the emitter was already correct).

## Schema drift
`Tep::Events#inference` emits `kind:"eval", phase:"serve", name:"request"` (verified at `events.rb:132-138`), but the header still documented the **superseded** #79 decision (`kind:"inference"`, "NOT eval"). The training-vs-serving disambiguator moved from a distinct `kind` onto `phase`/`name`. Updated to match what's actually written:
- `events.rb` header (the example + the #79 rationale block)
- `openai_server.rb` — the two streamer "toy/v1 inference event" comments
- `examples/llm_gateway/app.rb` — the wire-shape sample (now `kind:"eval"` with `latency_us` inside `extra`)

The `Events#inference` **method name** is the public API and stays.

## Retired-path pointers
toy moved its OpenAI server out of the now-deleted `tep_demo/openai_api*.rb` into `toy serve` (`lib/toy/serve/openai/`). Repointed: `examples/chatbot` (app + README), `examples/llm_gateway`, `lib/tep/llm.rb`, top-level `README.md`.

## Deferred (not here)
- **#168 Part B** — collapsing toy's hand-rolled handlers onto a `Tep::Llm::OpenAI::Backend` subclass. The issue marks this toy's call, gated on toy stabilising.
- **Gated `/v1/embeddings` route** — reverses the earlier "embeddings stay in tep_demo" value call ([memory]) and needs a new `Backend` contract method; worth a design confirm first.

Addresses #168 (Part A). Leaves #168 open for Part B + embeddings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)