### PR TITLE
feat(openai): /v1/embeddings route + Backend#generate_embeddings (#168)

### DIFF
--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -99,6 +99,20 @@ module Tep
         def supports_embeddings?
           false
         end
+
+        # Embedding generation for /v1/embeddings. `token_ids` is the
+        # encoded input (Array[Integer]; this server speaks IDs only,
+        # tokenize client-side, same policy as generate_from_tokens).
+        # Returns the pooled embedding as an Array[Float] of length
+        # d_model -- the backend owns the lookup + pooling strategy
+        # (toy mean-pools per-token embeddings). Base returns an empty
+        # vector so a bare backend compiles; only reached when
+        # supports_embeddings? is true (EmbeddingsHandler gates 501).
+        def generate_embeddings(model, token_ids)
+          empty = [0.0]
+          empty.delete_at(0)
+          empty
+        end
       end
 
       # The mountable server. Class methods because an app wires one
@@ -136,6 +150,9 @@ module Tep
           Tep.get("/v1/models",            Tep::Llm::OpenAI::ModelsHandler.new)
           Tep.post("/v1/completions",      Tep::Llm::OpenAI::CompletionsHandler.new)
           Tep.post("/v1/chat/completions", Tep::Llm::OpenAI::ChatCompletionsHandler.new)
+          # Always mounted; the handler 501s when supports_embeddings?
+          # is false (same gate shape as chat completions).
+          Tep.post("/v1/embeddings",       Tep::Llm::OpenAI::EmbeddingsHandler.new)
           0
         end
       end
@@ -633,6 +650,72 @@ module Tep
               Tep::Json.encode_pair_int("prompt_tokens", comp.prompt_tokens) + "," +
               Tep::Json.encode_pair_int("completion_tokens", comp.completion_tokens) + "," +
               Tep::Json.encode_pair_int("total_tokens", total) +
+            "}" +
+          "}"
+        end
+      end
+
+      # POST /v1/embeddings -- OpenAI embeddings shape. Gated 501 when
+      # backend.supports_embeddings? is false (the default). When a
+      # backend opts in, parses the IDs-only `input` array, asks the
+      # backend for the pooled vector, and formats the standard
+      # embeddings envelope. Mirrors toy's mean-pooled handler -- the
+      # pooling strategy lives in the backend, not here.
+      class EmbeddingsHandler < Tep::Handler
+        def handle(req, res)
+          res.headers["Content-Type"] = "application/json"
+          if !Tep::APP.openai_backend.supports_embeddings?
+            res.set_status(501)
+            return "{" +
+              "\"error\":{" +
+                Tep::Json.encode_pair_str("message",
+                  "embeddings not supported by this backend") + "," +
+                Tep::Json.encode_pair_str("type", "not_implemented") +
+              "}" +
+            "}"
+          end
+          body  = req.raw_body
+          model = Tep::Json.get_str(body, "model")
+          ids   = Tep::Json.get_int_array(body, "input")
+          if ids.length == 0
+            res.set_status(400)
+            return "{" +
+              "\"error\":{" +
+                Tep::Json.encode_pair_str("message",
+                  "input must be a non-empty integer array " +
+                  "(this server speaks token IDs only; tokenize client-side)") + "," +
+                Tep::Json.encode_pair_str("type", "invalid_request_error") +
+              "}" +
+            "}"
+          end
+
+          vec = Tep::APP.openai_backend.generate_embeddings(model, ids)
+
+          # Build the embedding float array by hand: Tep::Json has no
+          # float-array encoder, and Float#to_s yields a JSON number.
+          emb = "["
+          k = 0
+          while k < vec.length
+            if k > 0
+              emb = emb + ","
+            end
+            emb = emb + vec[k].to_s
+            k = k + 1
+          end
+          emb = emb + "]"
+
+          n = ids.length
+          "{" +
+            Tep::Json.encode_pair_str("object", "list") + "," +
+            "\"data\":[{" +
+              Tep::Json.encode_pair_str("object", "embedding") + "," +
+              Tep::Json.encode_pair_int("index", 0) + "," +
+              "\"embedding\":" + emb +
+            "}]," +
+            Tep::Json.encode_pair_str("model", model) + "," +
+            "\"usage\":{" +
+              Tep::Json.encode_pair_int("prompt_tokens", n) + "," +
+              Tep::Json.encode_pair_int("total_tokens", n) +
             "}" +
           "}"
         end

--- a/sig/tep/openai_server.rbs
+++ b/sig/tep/openai_server.rbs
@@ -29,6 +29,9 @@ module Tep
         def device_kind: () -> String
         # When true, gates /v1/embeddings (chunk 7.3).
         def supports_embeddings?: () -> bool
+        # Pooled embedding for /v1/embeddings: token_ids in (IDs only),
+        # an Array[Float] of length d_model out. Backend owns pooling.
+        def generate_embeddings: (String model, Array[Integer] token_ids) -> Array[Float]
       end
 
       # The mountable server. Class methods: one backend per process is
@@ -125,6 +128,10 @@ module Tep
         def handle: (Tep::Request req, Tep::Response res) -> Integer
       end
       class ChatCompletionsHandler < Tep::Handler
+        def handle: (Tep::Request req, Tep::Response res) -> Integer
+      end
+      # /v1/embeddings; 501s unless backend.supports_embeddings?.
+      class EmbeddingsHandler < Tep::Handler
         def handle: (Tep::Request req, Tep::Response res) -> Integer
       end
     end

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -70,6 +70,18 @@ class TestOpenAIServer < TepTest
     assert_match(/chat completions not supported/, body["error"]["message"])
   end
 
+  def test_embeddings_returns_501_when_unsupported
+    # EchoBackend doesn't override supports_embeddings? -> the
+    # /v1/embeddings route is mounted but 501s with an OpenAI-shape
+    # error (same gate as chat completions).
+    res = post("/v1/embeddings", "{\"model\":\"echo-1\",\"input\":[10,20,30]}")
+    assert_equal "501", res.code
+    assert_match(%r{application/json}, res["content-type"])
+    body = JSON.parse(res.body)
+    assert_equal "not_implemented", body["error"]["type"]
+    assert_match(/embeddings not supported/, body["error"]["message"])
+  end
+
   def test_completions_returns_text_completion
     # No temperature / top_p sent -> defaults of 1.0 reach the backend.
     res = post("/v1/completions",
@@ -532,5 +544,55 @@ class TestOpenAIServerChatStreaming < TepTest
     assert_equal "chat-stream", inf["extra"]["model"]
     assert_equal 3,             inf["extra"]["completion_tokens"]
     assert_equal "chatcmpl-tep", inf["extra"]["request_id"]
+  end
+end
+
+# Tep::Llm::OpenAI /v1/embeddings positive path (#168 part A item 3): a
+# backend that opts into embeddings returns an Array[Float]; the handler
+# serializes the OpenAI embeddings envelope. Exercises the float-array
+# return through Spinel end to end.
+class TestOpenAIEmbeddings < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    class EmbedBackend < Tep::Llm::OpenAI::Backend
+      def list_models
+        ["embed-1"]
+      end
+      def supports_embeddings?
+        true
+      end
+      def generate_embeddings(model, token_ids)
+        # Fixed 3-dim vector so the test asserts exact values; a real
+        # backend mean-pools per-token embeddings (toy's shape).
+        [0.5, -0.25, 1.0]
+      end
+    end
+
+    Tep::Llm::OpenAI::Server.use(EmbedBackend.new)
+    Tep::Llm::OpenAI::Server.serve!
+  RB
+
+  def test_embeddings_returns_vector_and_usage
+    res = post("/v1/embeddings", "{\"model\":\"embed-1\",\"input\":[10,20,30,40]}")
+    assert_equal "200", res.code
+    assert_match(%r{application/json}, res["content-type"])
+    body = JSON.parse(res.body)
+    assert_equal "list",    body["object"]
+    assert_equal "embed-1", body["model"]
+    row = body["data"][0]
+    assert_equal "embedding", row["object"]
+    assert_equal 0, row["index"]
+    assert_equal [0.5, -0.25, 1.0], row["embedding"]
+    # prompt/total tokens == input id count (4).
+    assert_equal 4, body["usage"]["prompt_tokens"]
+    assert_equal 4, body["usage"]["total_tokens"]
+  end
+
+  def test_embeddings_empty_input_returns_400
+    res = post("/v1/embeddings", "{\"model\":\"embed-1\",\"input\":[]}")
+    assert_equal "400", res.code
+    body = JSON.parse(res.body)
+    assert_equal "invalid_request_error", body["error"]["type"]
   end
 end


### PR DESCRIPTION
Closes the last battery-parity gap from the toy@0.7 audit (**#168 item 3**). `Tep::Llm::OpenAI` had a `supports_embeddings?` flag but no embeddings surface.

## What
- **`Backend#generate_embeddings(model, token_ids) -> Array[Float]`** — the pooled embedding (IDs-only input, same policy as `generate_from_tokens`; the backend owns lookup + pooling). Base returns an empty vector so a bare backend compiles.
- **`EmbeddingsHandler`** — parses the `input` int array, calls the backend, formats the OpenAI `/v1/embeddings` envelope (`object:list` / `data[0].embedding` + `index` / `usage`). **501** when `supports_embeddings?` is false (same gate as chat). Mirrors toy's mean-pooled handler; pooling stays in the backend.
- `serve!` mounts `POST /v1/embeddings`. `sig/tep/openai_server.rbs` updated.

## Design note
Reverses the earlier "embeddings stay in tep_demo" value call now that toy serves embeddings and the battery should reach parity. The toy-side convergence (toy implementing `generate_embeddings`, dropping its standalone handler) is the deferred **#168 Part B** — I'll file it toy-side.

## Tests
501-when-unsupported, 400-on-empty-input, and a positive path with a backend returning a fixed `Array[Float]` → asserts the exact vector + usage round-trip (exercises the float-array return through Spinel's poly-dispatch). Full suite: **496 runs, 0 failures**.

Addresses #168 (Part A complete with this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)