### PR TITLE
feat(gem): stock-Ruby require guard + gemspec publish polish (#156)

### DIFF
--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -16,6 +16,25 @@
 # `bin/tep build app.rb`, which translates blocks into Handler
 # subclasses before invoking spinel.
 
+# --- stock-Ruby guard --------------------------------------------------
+# tep's lib/ is Spinel-AOT source: it's COMPILED into a native binary
+# (or inlined by `tep build`), not run under CRuby. A plain
+# `require "tep"` on MRI/JRuby/TruffleRuby has no FFI runtime and would
+# otherwise die with a cryptic `undefined method 'ffi_cflags'` deep in a
+# sub-file. RUBY_ENGINE is defined on every stock Ruby but NOT in a
+# Spinel binary, so this fires only under a real `require` and stays a
+# dead no-op once compiled (it inlines harmlessly into every app).
+if defined?(RUBY_ENGINE)
+  raise "tep is a Spinel-AOT framework, not a CRuby library -- " \
+        "`require \"tep\"` has no runtime here. tep compiles your " \
+        "Sinatra-style app to a native binary; build it with the " \
+        "translator:\n" \
+        "    tep build app.rb && ./app -p 4567\n" \
+        "or declare `gem \"tep\"` in a bundler-spinel (spinelgems) " \
+        "Gemfile and let `spinel-compat vendor` inline it. " \
+        "See https://github.com/OriPekelman/tep"
+end
+
 require_relative "tep/version"
 require_relative "tep/url"
 require_relative "tep/multipart"

--- a/tep.gemspec
+++ b/tep.gemspec
@@ -16,10 +16,24 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.homepage    = "https://github.com/OriPekelman/tep"
   s.metadata    = {
-    "source_code_uri"   => "https://github.com/OriPekelman/tep",
-    "bug_tracker_uri"   => "https://github.com/OriPekelman/tep/issues",
-    "documentation_uri" => "https://github.com/OriPekelman/tep#readme",
+    "source_code_uri"      => "https://github.com/OriPekelman/tep",
+    "bug_tracker_uri"      => "https://github.com/OriPekelman/tep/issues",
+    "documentation_uri"    => "https://github.com/OriPekelman/tep#readme",
+    "rubygems_mfa_required" => "true",
   }
+
+  # Shown on `gem install tep`. The gem is Spinel-AOT source, not a
+  # CRuby library -- reinforce the model the lib/tep.rb stock-Ruby guard
+  # also enforces at require-time, so a `gem install` user isn't left
+  # guessing why `require "tep"` raises.
+  s.post_install_message = <<~MSG
+    tep is a Spinel-AOT framework: it compiles your Sinatra-style app to
+    a native binary -- there is no `require "tep"` runtime under CRuby.
+      build an app:   tep build app.rb && ./app -p 4567
+      or vendor it:   declare `gem "tep"` in a bundler-spinel (spinelgems)
+                      Gemfile, then `spinel-compat vendor`.
+    Docs: https://github.com/OriPekelman/tep
+  MSG
 
   # Runtime target is Spinel's Ruby level (3.2.x — the gx10 host Ruby
   # and toy's `ruby "3.2.3"` engine marker both sit here). Was 3.4.0,


### PR DESCRIPTION
Re #156 ("how do I install this as a gem"). tep already ships a mature gemspec (`lib/**` + `bin/tep` + `spinel-ext.json` at root, `prism` dev-only) built for the **bundler-spinel / spinelgems vendor model**. This smooths two rough edges so the gem behaves correctly when published + consumed.

## 1. Stock-Ruby `require` guard

`require "tep"` on CRuby died with a cryptic `undefined method 'ffi_cflags'` deep in `lib/tep/net.rb` — tep's `lib/` is Spinel-AOT source, there's no FFI runtime under MRI. Now it raises a clear message:

```
tep is a Spinel-AOT framework, not a CRuby library -- `require "tep"` has
no runtime here. tep compiles your Sinatra-style app to a native binary;
build it with the translator:
    tep build app.rb && ./app -p 4567
or declare `gem "tep"` in a bundler-spinel (spinelgems) Gemfile and let
`spinel-compat vendor` inline it. See https://github.com/OriPekelman/tep
```

**Mechanism:** `RUBY_ENGINE` is defined on every stock Ruby but **not** in a Spinel binary (verified by probe). So `if defined?(RUBY_ENGINE)` fires only under a real `require` and is a **dead no-op once compiled** — it inlines harmlessly into every app. Confirmed: full suite + a from-scratch `hello` build/serve still pass with the guard present.

## 2. Gemspec publish polish

- `rubygems_mfa_required` metadata.
- `post_install_message` reinforcing the model for a `gem install` user.

`gem build tep.gemspec` → `tep-0.10.0.gem` cleanly. **Not pushing to rubygems** here (credentialed release step); this makes the gem correct for when it is.

Addresses #156. The remaining publish steps (the actual `gem push`, optional release CI) are noted on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)