### PR TITLE
docs(readme): sync current-release banner to v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 A Sinatra-flavoured web framework that compiles to a native binary
 via [Spinel][spinel].
 
-> **Current release:** [v0.9.0](https://github.com/OriPekelman/tep/releases/tag/v0.9.0)
-> — the MCP battery (agent-as-driver) on top of the four-battery
-> agentic surface (Auth, Broadcast, Presence, LiveView).
+> **Current release:** [v0.10.0](https://github.com/OriPekelman/tep/releases/tag/v0.10.0)
+> — the Proxy + OpenAI-server + Events batteries on top of the agentic
+> surface (Auth, Broadcast, Presence, LiveView, MCP).
 > Pre-alpha; API still in motion.
 
 > **Why Tep exists.** Two complementary goals:


### PR DESCRIPTION
README advertised v0.9.0 while the gem + latest release are **v0.10.0**. Bumps the banner + battery summary to match.

Getting-started rewrite for the Gemfile / bundler-spinel onboarding is deferred until that flow is installable end-to-end (OriPekelman/spinelgems#9: publish bundler-spinel + `spinel-compat install-engine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)