### PR TITLE
chore(gem): 0.11.0 + publish-readiness (drop build artifacts, prism guard)

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -23,7 +23,22 @@
 # Spinel-incompatible patterns (template engines, helpers blocks,
 # rack middleware, etc.) get warned about; they don't translate.
 
-require "prism"
+# The translator parses the user's Sinatra source with Prism. Prism
+# ships with Ruby 3.4+, but tep keeps it a *development-only* gem
+# dependency (it's a C extension Spinel can't compile, so a runtime dep
+# would drag it into a spinelgems consumer's lock + fail the compat
+# gate). So on a `gem install tep` under Ruby 3.2/3.3 it may be absent
+# -- fail with an actionable message instead of a bare LoadError.
+begin
+  require "prism"
+rescue LoadError
+  abort "tep: the translator needs the `prism` parser, which isn't " \
+        "available here.\n" \
+        "  - Ruby 3.4+ bundles it (no action needed).\n" \
+        "  - On Ruby 3.2/3.3:  gem install prism\n" \
+        "Prism is a build-time-only dep (a C extension Spinel can't " \
+        "compile), so tep deliberately doesn't pull it into your lock."
+end
 require "fileutils"
 require "tmpdir"
 require "pathname"

--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.10.0"
+  VERSION = "0.11.0"
 end

--- a/tep.gemspec
+++ b/tep.gemspec
@@ -46,6 +46,14 @@ Gem::Specification.new do |s|
   # concern, not a gem-install constraint.
   s.required_ruby_version = ">= 3.2.0"
 
+  # Ship only git-TRACKED files matching these globs. Intersecting with
+  # `git ls-files` is what keeps gitignored build artifacts OUT: the
+  # compiled C objects (lib/tep/*.o) and the native example binaries
+  # (examples/hello, pg_hello, ...) land in-tree after `make`, and a bare
+  # Dir glob would scoop ~1.7 MB of stale, platform-specific junk into
+  # the gem. The `.reject` is a belt-and-suspenders for a no-git build
+  # (e.g. from an unpacked source tree).
+  tracked = (`git ls-files -z`.split("\x0") rescue [])
   s.files = Dir[
     "README.md", "LICENSE", "SINATRA_COMPAT.md",
     "Makefile",
@@ -58,7 +66,8 @@ Gem::Specification.new do |s|
     "examples/**/*",
     "public/**/*",
     "test/**/*"
-  ].reject { |f| File.directory?(f) }
+  ].reject { |f| File.directory?(f) || f =~ /\.(o|so|a|dylib|bundle)$/ }
+   .select { |f| tracked.empty? || tracked.include?(f) }
 
   s.bindir              = "bin"
   s.executables         = ["tep"]


### PR DESCRIPTION
Full pre-publish sanity pass on the gem (refs #181). **The actual `gem push` is gated on build-matrix going green (#180)** and is the maintainer's MFA step; this makes the gem correct for when it's pushed.

## Version: 0.10.0 → 0.11.0
v0.10.0 was tagged 2026-05-28 and **~13 feature PRs landed after it** (TLS battery, caching battery, connection pooling, PG::Pool + PG raise-on-error, `/v1/embeddings`, 64-bit SQLite, the gem packaging). Publishing main *as* 0.10.0 would mean gem ≠ tag — 0.11.0 is the honest number. (We're not bound to the 0.10.0 the issue proposed.)

## Stop shipping build artifacts (621 KB → 337 KB)
`Dir["lib/**/*","examples/**/*"]` scooped, off disk after `make`:
- compiled C objects `lib/tep/*.o` (~60 KB)
- **four native example binaries** `examples/{hello,pg_hello,sinatra_style,websocket_echo}` (~1.65 MB)

— stale, platform-specific, and present only if you'd built (non-deterministic gem contents). Now `s.files` intersects with `git ls-files`, so only tracked source ships.

## bin/tep: graceful Prism guard
Prism is **dev-only** (a C ext Spinel can't compile → keeps a spinelgems consumer's lock clean). On `gem install tep` under Ruby 3.2/3.3 it may be absent; the bare `require "prism"` died with a cryptic `LoadError`. Now it aborts with "Ruby 3.4+ bundles it / on 3.2–3.3 `gem install prism`".

## Verified
- `gem build` clean at 0.11.0.
- **End-to-end**: `gem install tep-0.11.0.gem` → `tep` on PATH → runs from the installed gem (resolves `lib/` + `spinel-ext.json` from the gem root; the Prism guard fires correctly on this no-Prism Ruby 3.2 host).

## Flagged (not fixed here — consumer/scaffold concern)
A `gem "tep"` in a Gemfile with default `require: true` + `Bundler.require` would trip the stock-Ruby guard. Consumers should use `gem "tep", require: false`; the bundler-spinel scaffold's Gemfile should emit that.

Refs #181.