### PR TITLE
fix: initialize @openai_events so SIGTERM shutdown doesn't SEGV

### DIFF
--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -102,6 +102,13 @@ module Tep
       # load order means PG::Connection isn't safely callable from
       # App#initialize when this is loaded before pg.rb's full surface.
       @nf_handler     = Handler.new
+      # No-op default so a never-mounted OpenAI server doesn't leave
+      # @openai_events null. Tep.on_shutdown calls openai_events.enabled?
+      # unconditionally; under Spinel a null receiver is a hard null-deref
+      # (not a NoMethodError), so any app that doesn't call
+      # Tep::Llm::OpenAI::Server.serve! would SEGV on shutdown after a
+      # SIGTERM. "" => enabled? is false (zero I/O). (matz/spinel#1259)
+      @openai_events  = Tep::Events.new("")
       @asset_bodies   = Tep.str_hash # path -> bytes (filled at boot
       @asset_mimes    = Tep.str_hash # by Tep::Assets._add lines
                                      # the bin/tep translator emits)


### PR DESCRIPTION
## Problem

A Spinel-compiled tep server that catches SIGTERM and exits **segfaults on process exit (139)** — reproduced with `examples/hello.rb` on aarch64-Linux. Filed upstream as matz/spinel#1259, originally hypothesized to be a Spinel runtime *exit-teardown* bug.

## Root cause (localized via ASAN)

An `-fsanitize=address` build pins it precisely — it's **not** the runtime teardown:

```
#0 sp_Tep_Events_enabled_p   ← READ of *(NULL+0x8)   (@path on a null self)
#1 sp_Tep_cls_on_shutdown
#2 sp_Tep_Server_run          (accept loop, after sphttp_accept returned -1 on SIGTERM)
#3 sp_Tep_cls_run_bang
#4 main
```

`Tep.on_shutdown` calls `APP.openai_events.enabled?` unconditionally, but `App#initialize` gives a no-op default to every *other* heap ivar (`@before_filter = Filter.new`, the seeded registries, …) and **never initializes `@openai_events`** — that slot is only set by `Tep::Llm::OpenAI::Server.serve!`. Any app that doesn't mount the OpenAI server (like `hello`) leaves it **null** at shutdown.

Under Spinel a method call on a null heap receiver is a hard null-deref (not a `NoMethodError`), and a defensive `openai_events == nil` guard is *elided* because the static type is non-nullable `Tep::Events`. The crash only surfaces after SIGTERM because `on_shutdown` runs only when the accept loop breaks — which also explains the 139↔143 build/timing sensitivity noted upstream (whether the kill lands before vs. after reaching `on_shutdown`). No `at_exit`/`END`/Fiber is involved.

## Fix

Initialize `@openai_events` to a disabled `Tep::Events.new("")` (`enabled?` is false, zero I/O), mirroring the other no-op defaults.

## Verification

`examples/hello.rb`, compiled and SIGTERM'd on aarch64-Linux:

- before: exit **139** (SEGV)
- after:  exit **0** (clean shutdown)

See matz/spinel#1259 for the full upstream localization and the Spinel-side discussion (null-receiver deref + nil-guard elision).