### PR TITLE
chore(gem): 0.11.2 — fix SIGTERM SEGV (#186)

### DIFF
--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.11.1"
+  VERSION = "0.11.2"
 end


### PR DESCRIPTION
Release 0.11.2.

**Why a patch now:** 0.11.1 shipped *with* the SIGTERM SEGV that #186 fixes. It bites **every tep server that does not mount the OpenAI server** (i.e. most of them) on a clean `kill -TERM`. `@openai_events` was only ever set by `Llm::OpenAI::Server.serve!`, so it was null at shutdown, and `Tep.on_shutdown` dereferenced it unconditionally → hard SEGV (exit 139) under Spinel.

- Fix: #186 (already merged to main).
- Closes #175.
- Corrects matz/spinel#1259 (was misfiled as a runtime-teardown bug; it is this tep null-deref).

Only change in this PR is the `version.rb` bump; the code fix is already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)