### PR TITLE
chore(spinel): bump pin a782696 -> f6d5eef

### DIFF
--- a/SPINEL_PIN
+++ b/SPINEL_PIN
@@ -1,4 +1,15 @@
-a782696
+f6d5eef
+
+# f6d5eef (2026-06-03). Bumped from a782696 (+32) onto current master to
+# absorb the spinel-dev tooling surfaces + codegen fixes:
+#   - `spinel --emit-rbs` (#1276, MERGED): whole-program inference -> RBS,
+#     for regenerating/diffing tep's hand-authored sig/.
+#   - `--debug` / `-g` line-mapped builds (#1292, landing): native-debugger
+#     stepping across require_relative.
+#   - codegen: implicit allocation-site specialization (perf), covariant
+#     return dispatch, poly-setter unbox into narrow attr_accessor field.
+# No tep workaround obviated. Instance-method typed-yield (each/each_row/
+# Pool#with) is STILL broken here (no fix upstream); tracked tep#189.
 
 # Pinned matz/spinel commit tep is verified to build + test against.
 # Only the first line (the ref) is read by tools/spinel-fresh.sh.


### PR DESCRIPTION
Bumps `SPINEL_PIN` to current spinel master (+32 commits) to verify tep against latest and enable the `spinel-dev` dev loop.

**Absorbs:** `--emit-rbs` (#1276, merged — RBS regen, see #191), `--debug`/`-g` (#1292), codegen fixes (implicit allocation-site specialization, covariant return dispatch, poly-setter unbox into narrow attr_accessor field).

**No tep workaround obviated, no API/runtime change** — `SPINEL_PIN` governs tep's own CI/dev builds, not the published gem (consumers pin spinel via bundler-spinel). So this is a verification/tooling bump, not a gem release.

Full suite green locally (498/0, rbs clean). Instance-method yield-and-reuse still degrades in the full lib/tep surface (#189); tooling adoption tracked in #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)