### PR TITLE
build: optional spinel-dev tooling hooks (#191)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ examples/*/vendor/
 # Per-project AI assistant context (local-only; the canonical file
 # lives on the Mac and is rsynced to gx10). Public repo doesn't ship it.
 CLAUDE.md
+
+# Optional spinel --emit-rbs output (rake rbs:emit, dev-only)
+sig/.emitted/

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ TEP_PG_LIBS   ?= $(shell \
     (pg_config --libdir 2>/dev/null | sed -e 's|^|-L|' ; echo "-lpq") | tr '\n' ' ')
 export TEP_PG_CFLAGS TEP_PG_LIBS
 
-.PHONY: all clean helper hello sinatra_style bench bench-tep bench-sinatra demo test test-parallel spinel-fresh test-pg vendor-examples
+.PHONY: all clean helper hello sinatra_style bench bench-tep bench-sinatra demo test test-parallel spinel-fresh test-pg vendor-examples doctor
 
 # Vendor each gem example's Gemfile-declared dependencies via
 # bundler-spinel (spinel-compat vendor, from $(SPINELGEMS)) into
@@ -95,6 +95,28 @@ demo: hello
 test: helper
 	@pkill -f tep-test 2>/dev/null; true
 	ruby test/run_all.rb
+
+# `make doctor` -- OPTIONAL, DEV-ONLY inference health check via
+# spinel-dev's `doctor` (compile-probe + emit-rbs untyped scan +
+# value-bisect). Runs on the inlined .tep.rb of a couple of examples
+# (tep apps are FFI, so --no-cruby single-sided). NOT a prerequisite of
+# `all`/`test`/CI -- it self-skips when ../spinel-dev is absent, so tep
+# never gains a hard dependency on the tooling. Run `make all` first to
+# produce the .tep.rb. Override the tool path with DOCTOR=.
+DOCTOR ?= ../spinel-dev/tools/doctor/doctor.sh
+doctor:
+	@if [ ! -x "$(DOCTOR)" ]; then \
+	  echo "make doctor: spinel-dev not found at $(DOCTOR) (optional dev tooling); skipping."; \
+	else \
+	  for tep in examples/.hello.tep.rb examples/.sinatra_style.tep.rb; do \
+	    if [ -f "$$tep" ]; then \
+	      echo "== doctor $$tep =="; \
+	      SPINEL_DIR="$${SPINEL_DIR:-$$HOME/sites/spinel}" "$(DOCTOR)" --no-cruby "$$tep" || true; \
+	    else \
+	      echo "make doctor: $$tep not built (run \`make all\`); skipping it."; \
+	    fi; \
+	  done; \
+	fi
 
 # `make test-parallel` -- dev fast loop. Runs each test/test_*.rb in
 # its own process in parallel (sidestepping the harness's "one thread

--- a/Rakefile
+++ b/Rakefile
@@ -39,6 +39,41 @@ namespace :rbs do
       sh "rbs", *args
     end
   end
+
+  # DEV-ONLY, OPTIONAL. Export spinel's whole-program inferred signatures
+  # as RBS (`spinel --emit-rbs`, available from the f6d5eef pin) so they
+  # can be diffed against the hand-authored sig/ to catch drift / find
+  # surfaces that degraded to `untyped`. This is NOT wired into :test,
+  # :validate, :default, or CI -- it skips cleanly when the spinel on
+  # PATH/$SPINEL lacks the flag or there's no built source, so tep never
+  # acquires a hard dependency on the tooling. Usage:
+  #   make all                       # produce the inlined .tep.rb
+  #   rake rbs:emit                  # -> sig/.emitted/<app>.rbs (gitignored)
+  #   EMIT_SRC=examples/.foo.tep.rb rake rbs:emit
+  task :emit do
+    spinel = ENV["SPINEL"] || "spinel"
+    src    = ENV["EMIT_SRC"] || "examples/.sinatra_style.tep.rb"
+    help   = (`#{spinel} --help 2>&1` rescue "")
+    if !help.include?("--emit-rbs")
+      warn "rbs:emit: `#{spinel}` has no --emit-rbs (needs the f6d5eef+ pin); " \
+           "skipping -- this is optional dev tooling, not a dependency."
+      next
+    end
+    unless File.exist?(src)
+      warn "rbs:emit: #{src} not found -- run `make all` first (or set EMIT_SRC); skipping."
+      next
+    end
+    require "fileutils"
+    FileUtils.mkdir_p("sig/.emitted")
+    out = "sig/.emitted/#{File.basename(src).sub(/\.rb$/, ".rbs")}"
+    sh "#{spinel} --emit-rbs #{src} -o #{out}" do |ok, _|
+      if ok
+        puts "rbs:emit: wrote #{out}. Diff against sig/tep/*.rbs to spot drift / untyped widening."
+      else
+        warn "rbs:emit: emit failed (non-fatal); skipping."
+      end
+    end
+  end
 end
 
 task default: :test


### PR DESCRIPTION
Closes #191. Adds two **dev-only, opt-in** tooling hooks that **never become a hard dependency** — both self-skip when `../spinel-dev` or `--emit-rbs` is absent, and neither is a prerequisite of `all`/`test`/CI.

- **`make doctor`** — runs spinel-dev's `doctor` (compile-probe + emit-rbs untyped scan + value-bisect) on built example `.tep.rb` (`--no-cruby`, since tep is FFI). `DOCTOR=` overrides the path; skips cleanly if spinel-dev is missing.
- **`rake rbs:emit`** — `spinel --emit-rbs` (f6d5eef+ pin) on a built `.tep.rb` → `sig/.emitted/<app>.rbs` (gitignored), to diff against the authored `sig/` and catch drift / `untyped` widening. Probes for the flag; skips otherwise.

Verified both skip gracefully (no spinel-dev / no built source / no flag) and that `all:`/`test:` prerequisites are unchanged. Per your note: strictly dev-time, no hard dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)