### PR TITLE
test(shutdown): no-events SIGTERM regression guard (#188)

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -87,6 +87,39 @@ module TepHarness
     @running.delete(s)
   end
 
+  # Like terminate, but RETURNS the Process::Status of the SIGTERM'd
+  # process (or nil if not found) so a test can assert on how it exited
+  # -- e.g. that a no-events server doesn't SIGSEGV on shutdown (the #186
+  # regression: termsig == SEGV => exit 139). Bounded: escalates to
+  # SIGKILL after `timeout` so a wedged server can't hang the suite.
+  def self.terminate_status(port, timeout: 5.0)
+    s = find_by_port(port)
+    return nil unless s
+    pid = s[:pid]
+    signal_group(pid, "TERM")
+    deadline = Time.now + timeout
+    status = nil
+    loop do
+      begin
+        got, st = Process.waitpid2(pid, Process::WNOHANG)
+        if got
+          status = st
+          break
+        end
+      rescue Errno::ECHILD
+        break
+      end
+      if Time.now > deadline
+        signal_group(pid, "KILL")
+        _, status = (Process.waitpid2(pid) rescue [nil, nil])
+        break
+      end
+      sleep 0.02
+    end
+    @running.delete(s)
+    status
+  end
+
   def self.kill_all
     @running.each do |s|
       reap(s[:pid])

--- a/test/test_shutdown.rb
+++ b/test/test_shutdown.rb
@@ -1,0 +1,40 @@
+require_relative "helper"
+
+# #188 regression guard for the #186 fix.
+#
+# A server that does NOT mount the OpenAI events surface (the common case)
+# must not SIGSEGV on SIGTERM. The #186 bug: App#initialize never set
+# @openai_events, so Tep.on_shutdown's unconditional `openai_events.enabled?`
+# was a null-receiver deref -- a hard SIGSEGV under Spinel (exit 139) on a
+# clean `kill -TERM`. #186 (0.11.2) initialises @openai_events to a disabled
+# default, so on_shutdown is a safe no-op for apps that never call
+# Tep::Llm::OpenAI::Server.serve!.
+#
+# The events-mounted path is already covered by
+# test_openai_server#test_sigterm_emits_run_end; this is the no-events path
+# that the original bug actually hit. We assert the exit is NOT a SEGV.
+# Whether the clean exit is 143 (signal-terminated) or 0 (graceful return)
+# is the build/timing-sensitive residual tracked in #188 and is acceptable
+# here -- only a SIGSEGV is the regression.
+class TestShutdownNoEvents < TepTest
+  app_source <<~RB
+    require 'sinatra'
+
+    get '/ping' do
+      "pong"
+    end
+  RB
+
+  def test_sigterm_on_no_events_app_does_not_segv
+    assert_equal "pong", get("/ping").body, "server should be live before SIGTERM"
+
+    status = TepHarness.terminate_status(@port)
+    refute_nil status, "spawned server not found / never reaped"
+
+    segv = Signal.list["SEGV"] # 11 -> exit 139
+    crashed = status.signaled? && status.termsig == segv
+    refute crashed,
+           "no-events app SIGSEGV'd on SIGTERM (the #186 regression) -- " \
+           "termsig=#{status.termsig.inspect} exitstatus=#{status.exitstatus.inspect}"
+  end
+end


### PR DESCRIPTION
Addresses #188. Adds the missing **no-events SIGTERM regression test** for the #186 fix, and clarifies the 143-vs-0 residual.

- `TepHarness.terminate_status(port)` surfaces the `Process::Status` (bounded, SIGKILL-escalating) so tests can assert *how* a server exited.
- `test_shutdown` boots a no-OpenAI-events app, SIGTERMs it, and asserts the exit is **not** a SIGSEGV (the #186 null-`@openai_events` deref → exit 139). The events path was already covered by `test_sigterm_emits_run_end`; this is the path the original bug actually hit.

**On the 143-vs-0 residual:** it's spinel-side, not tep's. `sphttp_accept` delegates to `sp_net` (libspinel_rt, #161), so whether the accept-EINTR path rechecks the shutdown flag before re-blocking is sp_net's behavior. `143` (signal-terminated) is the normal exit and is acceptable; only a SEGV is a regression, which this test guards. Suggest **closing #188** once this merges (the test ships; the residual is sp_net's domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)