### PR TITLE
feat(openai): backend-controllable Completion#id + 0.11.4 (#209)

### DIFF
--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -272,9 +272,16 @@ module Tep
       # Text backends leave token_ids empty and the ids field is omitted.
       # finish_reason defaults to "stop"; a fixed-length greedy backend
       # sets "length".
+      #
+      # id is the completion id echoed as the response `id` (and the
+      # inference event's request_id). It defaults to "cmpl-tep"; a backend
+      # that mints its own per-request ids (e.g. so a downstream byte-exact
+      # ingest keeps unique ids) sets it. Leaving it default keeps existing
+      # consumers byte-identical.
       class Completion
         attr_accessor :text, :prompt_tokens, :completion_tokens
         attr_accessor :token_ids, :finish_reason
+        attr_accessor :id
 
         def initialize
           @text              = ""
@@ -285,6 +292,7 @@ module Tep
           @token_ids         = [0]
           @token_ids.delete_at(0)
           @finish_reason     = "stop"
+          @id                = "cmpl-tep"
         end
       end
 
@@ -581,7 +589,7 @@ module Tep
           # the auth-filter populated identity (anonymous if none).
           wall_us = (Time.now.to_i - t0) * 1_000_000
           extra = "{" +
-            SpinelKit::Json.encode_pair_str("request_id", "cmpl-tep") + "," +
+            SpinelKit::Json.encode_pair_str("request_id", comp.id) + "," +
             SpinelKit::Json.encode_pair_str("principal_id", req.identity.subject) +
           "}"
           Tep::APP.openai_events.inference(
@@ -597,7 +605,7 @@ module Tep
           end
 
           "{" +
-            SpinelKit::Json.encode_pair_str("id", "cmpl-tep") + "," +
+            SpinelKit::Json.encode_pair_str("id", comp.id) + "," +
             SpinelKit::Json.encode_pair_str("object", "text_completion") + "," +
             SpinelKit::Json.encode_pair_int("created", Time.now.to_i) + "," +
             SpinelKit::Json.encode_pair_str("model", model) + "," +

--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.11.3"
+  VERSION = "0.11.4"
 end

--- a/sig/tep/openai_server.rbs
+++ b/sig/tep/openai_server.rbs
@@ -75,6 +75,9 @@ module Tep
         attr_accessor token_ids: Array[Integer]
         # choices[0].finish_reason (default "stop").
         attr_accessor finish_reason: String
+        # Response/event completion id (default "cmpl-tep"); a backend may
+        # mint per-request ids for byte-exact downstream ingest.
+        attr_accessor id: String
         def initialize: () -> void
       end
 

--- a/test/test_openai_server.rb
+++ b/test/test_openai_server.rb
@@ -89,6 +89,8 @@ class TestOpenAIServer < TepTest
     assert_equal "200", res.code
     body = JSON.parse(res.body)
     assert_equal "text_completion", body["object"]
+    # Backend leaves Completion#id default -> "cmpl-tep" (back-compat).
+    assert_equal "cmpl-tep", body["id"]
     assert_equal "echo-1", body["model"]
     assert_equal "echoed 3 tokens t=1.0 p=1.0", body["choices"][0]["text"]
     assert_equal "stop", body["choices"][0]["finish_reason"]
@@ -131,6 +133,9 @@ class TestOpenAIServerEvents < TepTest
         c.text              = "echoed " + token_ids.length.to_s + " tokens"
         c.prompt_tokens     = token_ids.length
         c.completion_tokens = sampling.max_tokens
+        # Backend-minted per-request id (#209): must surface as the
+        # response `id` AND the inference event's request_id.
+        c.id                = "cmpl-evt-" + token_ids.length.to_s
         c
       end
     end
@@ -168,6 +173,8 @@ class TestOpenAIServerEvents < TepTest
     res = post("/v1/completions",
                "{\"model\":\"echo-1\",\"prompt\":[1,2,3,4],\"max_tokens\":7}")
     assert_equal "200", res.code
+    # Backend-minted id (#209) surfaces as the response `id`.
+    assert_equal "cmpl-evt-4", JSON.parse(res.body)["id"]
 
     lines2 = File.readlines(EVENTS_PATH).map { |l| JSON.parse(l) }
     # #136: inference events are kind:"eval"+name:"request"; per-request
@@ -182,7 +189,9 @@ class TestOpenAIServerEvents < TepTest
     assert_equal 7,        extra["completion_tokens"]
     assert_kind_of Integer, extra["latency_us"]
     assert extra["latency_us"] >= 0
-    assert_equal "cmpl-tep", extra["request_id"]
+    # request_id tracks the backend-minted Completion#id, same value as
+    # the response `id` above (the request_id == response id invariant).
+    assert_equal "cmpl-evt-4", extra["request_id"]
     assert_match(/\Auser:/, extra["principal_id"])
   end
 end


### PR DESCRIPTION
Resolves #209.

## Context
#209's stated gap — "the battery's `Completion` only carries `text`, no `ids`" — was already closed by **0.11.3** (`c81e597`): `Completion` carries `token_ids` → `choices[0].ids`, plus `finish_reason` and `model_owner`. #209 was written against the pre-0.11.3 file (its `:261`/`:574` line cites). Field-by-field, the battery's `/v1/completions` wire is **structurally identical** to toy's hand-rolled wire (incl. `text:""` + `ids` + `finish_reason`), so #209's proposed `emits_token_ids?`/"ids in place of text" is moot — toy already emits `text:""` alongside `ids`.

## The one real remaining gap: the completion `id`
A `ToyBackend` can already set text/token_ids/finish_reason/usage via `Completion`, but the formatter **hardcoded `"cmpl-tep"`** for both the response `id` and the inference event's `request_id` — so a token-ID-native consumer (toy → tao ingest) couldn't keep its per-request ids.

- `Completion` gains `attr_accessor :id` (default `"cmpl-tep"`).
- The non-stream `/v1/completions` formatter emits `comp.id` as the response `id` **and** the event `request_id` (preserving the documented "request_id matches the response id" invariant).
- Default is unchanged, so every existing consumer stays **byte-identical**.

Chat (`chatcmpl-tep`) and the streaming completions path are out of #209's non-stream scope and unchanged.

## Verification (spinel pin `f6d5eef`)
`test_openai_server` **17 runs / 128 assertions / 0 failures** (+2 new: default `id` stays `cmpl-tep`; a backend-set `comp.id` surfaces in **both** the response `id` and the event `request_id` → `cmpl-evt-4`).

Bumps `VERSION` 0.11.3 → **0.11.4** for publish (toy consumes tep via the gem).

Follow-up: a "byte-equal" issue will track the remaining non-`id` wire deltas (trailing `\n`, models `created` vs `owned_by`) + a systematic audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)