### PR TITLE
fix(compose): bind the Postgres host port to 127.0.0.1 (#210)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
     # Exposed on a non-standard host port so we don't fight a
-    # local PG install if one exists.
+    # local PG install if one exists. Bound to loopback so the
+    # default-credentialed dev DB isn't reachable off-host (defense
+    # in depth; don't rely on a host firewall). For tailnet access,
+    # bind an explicit tailscale IP rather than all interfaces.
     ports:
-      - "54329:5432"
+      - "127.0.0.1:54329:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
       interval: 1s


### PR DESCRIPTION
Closes #210. `docker-compose.yml`'s `ports: "54329:5432"` binds `0.0.0.0` (and `::`), so the default-credentialed (`postgres`/`postgres`) dev Postgres listened on **every** host interface. Pin the publish to loopback:

```yaml
ports:
  - "127.0.0.1:54329:5432"
```

Non-standard host port unchanged → local clients on `127.0.0.1:54329` are unaffected. `docker compose config` confirms `host_ip: 127.0.0.1`. Tailnet access, if ever needed, should bind an explicit tailscale IP rather than all interfaces. Defense-in-depth — don't rely on a host firewall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)