### PR TITLE
fix(sphttp): wire OpenSSL via pkg_config so the TLS ext builds on macOS (#208)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,16 @@ TEP_PG_LIBS   ?= $(shell \
     (pg_config --libdir 2>/dev/null | sed -e 's|^|-L|' ; echo "-lpq") | tr '\n' ' ')
 export TEP_PG_CFLAGS TEP_PG_LIBS
 
+# OpenSSL cflags / libs for sphttp.c's outbound-TLS include (#148). On Linux
+# the headers/libs are on the default search path so this is usually empty;
+# on macOS Homebrew keeps openssl@3 keg-only (/opt/homebrew/opt/openssl@3),
+# off the default path, so pkg-config supplies the -I (compile) and -L/-lssl
+# /-lcrypto (link). If pkg-config can't find openssl, fall back to the bare
+# libs and let the include path come from the system default.
+TEP_SPHTTP_CFLAGS ?= $(shell pkg-config --cflags openssl 2>/dev/null)
+TEP_SPHTTP_LIBS   ?= $(shell pkg-config --libs openssl 2>/dev/null || echo "-lssl -lcrypto")
+export TEP_SPHTTP_CFLAGS TEP_SPHTTP_LIBS
+
 .PHONY: all clean helper hello sinatra_style bench bench-tep bench-sinatra demo test test-parallel spinel-fresh test-pg vendor-examples vendor-spinelkit doctor
 
 # Re-sync the vendored SpinelKit lib (lib/spinel_kit/, sig/spinel_kit/) from the
@@ -73,7 +83,7 @@ all: spinel-fresh helper hello sinatra_style bench
 helper: spinel-fresh $(LIB_DIR)/sphttp.o $(LIB_DIR)/tep_sqlite.o $(LIB_DIR)/tep_pg.o
 
 $(LIB_DIR)/sphttp.o: $(LIB_DIR)/sphttp.c
-	cc -O2 -c $< -o $@
+	cc -O2 -c $(TEP_SPHTTP_CFLAGS) $< -o $@
 
 $(LIB_DIR)/tep_sqlite.o: $(LIB_DIR)/tep_sqlite.c
 	cc -O2 -c $< -o $@

--- a/bin/tep
+++ b/bin/tep
@@ -1947,7 +1947,11 @@ def tep_ext_subs
     else
       cflags       = ENV.fetch(env_var, "")
       libs_var     = env_var.sub(/_CFLAGS\z/, "_LIBS")
-      default_libs = entry["pkg_config"] ? "-l" + entry["pkg_config"].sub(/\Alib/, "") : ""
+      # Prefer an explicit pkg_config_fallback (e.g. openssl -> "-lssl
+      # -lcrypto"); the bare "-l<pkg_config>" derivation is only right when
+      # the lib name matches the .pc name (libpq -> -lpq), not for openssl.
+      default_libs = entry["pkg_config_fallback"] ||
+                     (entry["pkg_config"] ? "-l" + entry["pkg_config"].sub(/\Alib/, "") : "")
       libs         = ENV.fetch(libs_var, default_libs)
       subs[placeholder] = "#{cflags} #{libs}".strip
     end
@@ -1979,7 +1983,16 @@ def resolve_ext_o(entry, entries, env_var)
   entries.each do |sib|
     next unless sib["name"] == entry["name"] && sib["pkg_config"]
     pc = `pkg-config --cflags #{sib["pkg_config"]} 2>/dev/null`
-    $?.success? ? cflags.concat(pc.split) : (missing = sib["pkg_config"])
+    if $?.success?
+      cflags.concat(pc.split)
+    elsif sib["pkg_config_fallback"]
+      # pkg-config can't find a .pc (e.g. openssl on a host without it):
+      # assume the headers are on the default include path -- the
+      # historical behavior before this sibling existed -- and let the
+      # link use the fallback libs. Don't fail an otherwise-fine compile.
+    else
+      missing = sib["pkg_config"]
+    end
   end
   if missing
     return "" if entry["optional"]

--- a/lib/tep/net.rb
+++ b/lib/tep/net.rb
@@ -12,9 +12,14 @@ module Sock
   # libssl/libcrypto. Linked for every app (like sqlite3 elsewhere);
   # the plaintext path never calls into it, so apps that make no HTTPS
   # requests pay only the link cost, not runtime. See tep#148.
-  # (When OpenSSL is off the default path -- macOS/Homebrew -- the build
-  # finds it via CPATH/LIBRARY_PATH in the environment, not a cflag
-  # here; spinel's ffi_cflags rejects an empty-string placeholder.)
+  #
+  # OpenSSL include/lib paths come via @TEP_SPHTTP_CFLAGS@ (the
+  # pkg_config sibling in spinel-ext.json -- `pkg-config openssl`,
+  # fallback `-lssl -lcrypto`), mirroring @TEP_PG_CFLAGS@. On Linux it's
+  # often just the libs (headers on the default path); on macOS/Homebrew
+  # it supplies the keg-only -I/-L too, so sphttp.c compiles + the
+  # ffi_lib "ssl"/"crypto" below resolve. See tep#208.
+  ffi_cflags "@TEP_SPHTTP_CFLAGS@"
   ffi_lib "ssl"
   ffi_lib "crypto"
 

--- a/spinel-ext.json
+++ b/spinel-ext.json
@@ -6,6 +6,12 @@
     "cflags": ["-O2"]
   },
   {
+    "name": "sphttp",
+    "placeholder": "@TEP_SPHTTP_CFLAGS@",
+    "pkg_config": "openssl",
+    "pkg_config_fallback": "-lssl -lcrypto"
+  },
+  {
     "name": "sqlite",
     "placeholder": "@TEP_SQLITE_O@",
     "source": "lib/tep/tep_sqlite.c",


### PR DESCRIPTION
Closes #208. `sphttp.c` grew an outbound-TLS include (#148) but the build never supplied OpenSSL's paths — fine on Linux (default search path), broken on macOS where Homebrew keeps `openssl@3` keg-only, so the compile (`openssl/ssl.h not found`) and link (`ffi_lib "ssl"/"crypto"`) fail (blocks toy#27 serve on macOS).

Mirrors the `pg` `@TEP_PG_O@`/`@TEP_PG_CFLAGS@` split:
- **spinel-ext.json**: `@TEP_SPHTTP_CFLAGS@` sibling (`pkg_config: openssl`, fallback `-lssl -lcrypto`).
- **net.rb**: `ffi_cflags "@TEP_SPHTTP_CFLAGS@"`.
- **Makefile**: `TEP_SPHTTP_CFLAGS/LIBS` from `pkg-config openssl`; fed into the `sphttp.o` compile.
- **bin/tep**: default-libs honors `pkg_config_fallback` (openssl → `-lssl -lcrypto`, not the wrong `-lopenssl`); the sibling-cflags fold no longer fatals when pkg-config lacks a `.pc` but a fallback exists.

**Linux regression check (gx10):** `make helper`/`make hello` green; `@TEP_SPHTTP_CFLAGS@` resolves to `-lssl -lcrypto` (0 literals left). macOS validated by inspection — mirrors `pg`, and the reporter confirmed `pkg-config openssl` resolves on Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)