### PR TITLE
chore(gemspec): declare spinel_kit as a runtime dependency (#217 step 1)

### DIFF
--- a/tep.gemspec
+++ b/tep.gemspec
@@ -85,4 +85,13 @@ Gem::Specification.new do |s|
   # Spinel can't compile, so the compat probe would (correctly)
   # reject it. Keeping it dev-only leaves the consumer's lock clean.
   s.add_development_dependency "prism", "~> 1.0"
+
+  # spinel_kit is a RUNTIME dependency (contrast prism above): a pure-Ruby
+  # gem whose Json/Url/Hex/Log surfaces tep's lib compiles in. Unlike prism
+  # (a native C-ext kept dev-only), spinel_kit is spinel-inlinable, so a
+  # consumer vendoring tep via spinel-compat composes it transitively
+  # (spinelgems#19) -- one shared copy, no double-bundle (tep#213). Declaring
+  # it retires the hand-copied lib/spinel_kit/ interim (tep#217); the copies +
+  # tep's own build switching to the composed dep land with that migration.
+  s.add_dependency "spinel_kit", "~> 0.2"
 end


### PR DESCRIPTION
First, safe step of #217 (un-vendor spinel_kit). tep's lib compiles in `SpinelKit::Json`/`Url`/`Hex`/`Log` but the gemspec never declared the dependency — so spinel-compat's convention audit flags tep as a hand-copied producer that will drift.

Declares `spinel_kit "~> 0.2"` as a **runtime** dep (contrast `prism`, dev-only as a native C-ext). spinel_kit is pure-Ruby + spinel-inlinable, so a consumer vendoring tep via spinel-compat composes it transitively (spinelgems#19) — one shared copy, retiring the double-bundle (#213).

**Metadata-only** — the AOT build is unchanged (`lib/spinel_kit/` still present + inlined; `gem build` green; suite unaffected). Deleting the hand-copies + switching tep's *own* build to the composed dep is the follow-on migration (it touches the shared vendor flow, so left to coordinate — see the #217 thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)