### PR TITLE
fix(bench): opt-in PG require in pg_bench/pg_pool_bench (#216 CI break)

### DIFF
--- a/bench/pg_bench.rb
+++ b/bench/pg_bench.rb
@@ -16,6 +16,7 @@
 #     ./bench/pg_bench -p 4567 -w 8
 #   wrk -t8 -c256 -d10s 'http://127.0.0.1:4567/users/42'
 require 'sinatra'
+require "tep/pg"          # opt-in PG backend (#216)
 
 PG_URL = ENV["PG_URL"] != nil && ENV["PG_URL"].length > 0 ? ENV["PG_URL"] : "postgresql:///postgres"
 

--- a/bench/pg_pool_bench.rb
+++ b/bench/pg_pool_bench.rb
@@ -12,6 +12,7 @@
 #   PG_URL='...' POOL_SIZE=8 ./bench/pg_pool_bench -p 4567 -w 4
 #   wrk -t8 -c256 -d10s 'http://127.0.0.1:4567/users/42'
 require 'sinatra'
+require "tep/pg"          # opt-in PG backend (#216)
 
 # Scheduled + cooperative Tep::PG + pool-with-waiter-queue: the
 # shape where the pool's multiple conns become real concurrency.


### PR DESCRIPTION
**Fixes the red `test` job.** #216 made PG opt-in (`require "tep/pg"`), but `bench/pg_bench.rb` (built by `make all` → `bench-tep`) still used `PG::Connection` without it, so pg.rb wasn't inlined → `error: unknown type name 'sp_PG_Connection'`. `build-matrix` stayed green; only `make all` in the `test` job broke. Local `make hello`/`sinatra_style` missed it (no PG).

Adds `require "tep/pg"` to `bench/pg_bench.rb` + `bench/pg_pool_bench.rb`. `bench/sinatra_pg.rb` left alone — it's a CRuby Sinatra baseline (`require 'pg'`/`'json'`), not tep-compiled.

Verified: `make all` EXIT=0 at the pin; `pg_bench` builds with 63 `tep_pg_` symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)