### PR TITLE
ci(build-matrix): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual re-trigger. The aarch64 leg runs on the gx10 self-hosted
+  # runner; if a run was queued while that runner was offline (or the
+  # runner registers after the fact), GitHub won't always re-dispatch
+  # the stuck job -- workflow_dispatch lets us kick a fresh run that
+  # lands on the now-online runner without an empty commit. See
+  # OriPekelman/gx10#4.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds a manual re-trigger to build-matrix. The aarch64 leg runs on the gx10 self-hosted runner (OriPekelman/gx10#4); a job queued while that runner was offline won't reliably re-dispatch when it comes online, and without `workflow_dispatch` the only way to kick a fresh run is an empty commit. Also serves as the first real exercise of the now-online runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)