### PR TITLE
fix(proxy): single Tep::Proxy class opening (fixes block-DSL override dispatch at master)

### DIFF
--- a/lib/tep/proxy.rb
+++ b/lib/tep/proxy.rb
@@ -62,7 +62,7 @@ module Tep
   # wins (whichever setter you called second).
   #
   # Default shape: max_attempts=1 (no retry, back-compat).
-  class Proxy
+  class Proxy < Tep::Handler
     class RetryPolicy
       attr_accessor :max_attempts, :base_backoff_ms, :backoff_multiplier
       attr_accessor :retry_on_status
@@ -125,7 +125,7 @@ module Tep
     end
   end
 
-  class Proxy < Tep::Handler
+  class Proxy
     attr_accessor :upstream, :timeout
     # Body size caps (chunk 6.6). max_request_body_bytes bounds the
     # inbound body the proxy will accept (over -> 413 Payload Too


### PR DESCRIPTION
Root-caused with matz on matz/spinel#1477: `Tep::Proxy` was opened twice (bare `class Proxy` for nested classes, then `class Proxy < Tep::Handler` for methods). Under spinel whole-program inference at recent master, the synthesized `TepProxy_<n> < Tep::Proxy` block-DSL subclass resolves its parent to the *bare* opening → `is_descendant` misses → `forward`'s virtual hook dispatch binds the base statically (override never runs; `/guard` 200 not 403).

Declare the superclass on the first opening. Verified: proxy green at the pin (test_proxy_dsl + test_proxy) AND **fixes test_proxy_dsl at master 2d1204e4 (5 fail → 0)** — removes one of the two remaining re-pin blockers (the other is matz/spinel#1478, templates). Spinel-side sensitivity stays tracked at matz/spinel#1477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)