### PR TITLE
chore(release): bump to 0.11.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SQLite, opt-in PostgreSQL, WebSockets, Broadcast + Presence + LiveView,
 an MCP tool catalog, TLS, a pooled HTTP client, and an OpenAI-compatible
 LLM client + server.
 
-> **Current release:** [v0.11.5](https://github.com/OriPekelman/tep/releases/tag/v0.11.5)
+> **Current release:** [v0.11.6](https://github.com/OriPekelman/tep/releases/tag/v0.11.6)
 > on [RubyGems](https://rubygems.org/gems/tep) — `gem install tep`.
 > Pre-alpha; API still in motion.
 

--- a/lib/tep/version.rb
+++ b/lib/tep/version.rb
@@ -1,3 +1,3 @@
 module Tep
-  VERSION = "0.11.5"
+  VERSION = "0.11.6"
 end


### PR DESCRIPTION
Release 0.11.6 — ships the fixes that landed after v0.11.5 (all pin-independent, pure Ruby; validated green on CI full-suite-at-pin + build-matrix ubuntu/macos):

- **fix(proxy)** Tep::Proxy superclass on first opening (#228) — block-DSL proxy guards (`before_forward`/`pick_upstream`) were silently bypassed under recent spinel inference (guarded route returned 200 instead of 403). matz/spinel#1477.
- **fix(erb/mustache)** build the locals hash inside the render arg (#231, matz/spinel#1478).
- **shell** `Tep::Shell.read`/`read_limited` rescue `File.read` — preserve the never-raise contract now that spinel's `File.read` raises `Errno` (#232).
- **pg** restore the Hash-conninfo kv-pack loop in `PG.connect` (#1434 fixed).

Decoupled from the spinel re-pin (still blocked on matz/spinel#1606).

🤖 Generated with [Claude Code](https://claude.com/claude-code)