### PR TITLE
fix: nil-guard all header/cookie hash reads (fixes #235)

### DIFF
--- a/lib/tep/app.rb
+++ b/lib/tep/app.rb
@@ -187,6 +187,7 @@ module Tep
       secret = Tep.session_secret
       if secret.length > 0
         cv = req.cookies[Tep::COOKIE_NAME]
+        cv = "" if cv.nil?
         if cv.length > 0
           req.session.load_from(cv, secret)
         end

--- a/lib/tep/auth_bearer_token.rb
+++ b/lib/tep/auth_bearer_token.rb
@@ -47,6 +47,7 @@ module Tep
     # signature / expired / malformed payload.
     def self.try(req)
       header = req.req_headers["authorization"]
+      header = "" if header.nil?
       if header.length < 8 || header[0, 7] != "Bearer "
         return nil
       end

--- a/lib/tep/cache.rb
+++ b/lib/tep/cache.rb
@@ -18,8 +18,10 @@ module Tep
       # tag is matched as a substring so a comma-separated list of tags
       # in If-None-Match works.
       etag = res.headers["ETag"]
+      etag = "" if etag.nil?
       if etag.length > 0
         inm = req.headers["if-none-match"]
+        inm = "" if inm.nil?
         if inm.length > 0
           if inm == "*"
             return true
@@ -35,6 +37,7 @@ module Tep
       lm = res.lastmod_epoch
       if lm > 0
         ims = req.headers["if-modified-since"]
+        ims = "" if ims.nil?
         if ims.length > 0
           ims_epoch = Sock.sphttp_parse_http_date(ims)
           if ims_epoch >= 0 && lm <= ims_epoch

--- a/lib/tep/parser.rb
+++ b/lib/tep/parser.rb
@@ -55,8 +55,11 @@ module Tep
       end
 
       # Parse Cookie header into req.cookies. Format: "k=v; k2=v2; ...".
-      # Whitespace around `;` is allowed and stripped.
+      # Whitespace around `;` is allowed and stripped. A request with no
+      # Cookie header reads as nil (don't call methods on it: spinel's
+      # unresolved-call gate raises NoMethodError, same as CRuby).
       cookie_blob = req.req_headers["cookie"]
+      cookie_blob = "" if cookie_blob.nil?
       if cookie_blob.length > 0
         cookie_blob.split(";").each do |pair|
           eq = Tep.str_find(pair, "=", 0)

--- a/lib/tep/request.rb
+++ b/lib/tep/request.rb
@@ -51,11 +51,16 @@ module Tep
     def headers; @req_headers; end
     def body;    @raw_body;    end
 
-    # Spinel's Hash[k] returns "" for missing string keys, not nil --
-    # so an empty Connection header looks the same as no header at all.
-    # We treat both as "use HTTP/1.1 default behaviour".
+    # A missing header reads as nil (CRuby Hash semantics; spinel's
+    # unresolved-call gate raises NoMethodError on nil receivers, same
+    # as CRuby would). Guard before calling String methods; an empty
+    # header and no header both mean "use HTTP/1.1 default behaviour".
+    # NOTE: guard with `x = "" if x.nil?`, not `x || ""` -- the ||-form
+    # mis-compiles at spinel pin f6d5eef (blanks the hit value).
     def keep_alive?
-      lc = @req_headers["connection"].downcase
+      lc = @req_headers["connection"]
+      lc = "" if lc.nil?
+      lc = lc.downcase
       if lc == "close"
         return false
       end
@@ -70,7 +75,9 @@ module Tep
     end
 
     def form?
-      @req_headers["content-type"].downcase.start_with?("application/x-www-form-urlencoded")
+      ct = @req_headers["content-type"]
+      ct = "" if ct.nil?
+      ct.downcase.start_with?("application/x-www-form-urlencoded")
     end
 
     # True when the request body is a multipart/form-data submission
@@ -78,7 +85,9 @@ module Tep
     # or carrying file inputs). Tep::Multipart.parse handles the
     # text fields; file-upload parts are skipped in v1.
     def multipart?
-      @req_headers["content-type"].downcase.start_with?("multipart/form-data")
+      ct = @req_headers["content-type"]
+      ct = "" if ct.nil?
+      ct.downcase.start_with?("multipart/form-data")
     end
 
     # ---- Rack::Request-style accessors (reads only, no .ip yet) ----
@@ -99,6 +108,7 @@ module Tep
     # proxy sets.
     def scheme
       proto = @req_headers["x-forwarded-proto"]
+      proto = "" if proto.nil?
       if proto.length > 0
         return proto.downcase
       end

--- a/lib/tep/websocket/handshake.rb
+++ b/lib/tep/websocket/handshake.rb
@@ -26,13 +26,16 @@ module Tep
         end
 
         # Upgrade + Connection headers (downcased per Tep::Request).
+        # A missing header reads as nil; treat it as absent ("").
         upgrade = req.headers["upgrade"]
+        upgrade = "" if upgrade.nil?
         if Handshake.icontains(upgrade, "websocket") == false
           out.valid = false
           out.reason = "missing/invalid Upgrade"
           return out
         end
         conn = req.headers["connection"]
+        conn = "" if conn.nil?
         if Handshake.icontains(conn, "upgrade") == false
           out.valid = false
           out.reason = "missing/invalid Connection"
@@ -49,6 +52,7 @@ module Tep
 
         # Sec-WebSocket-Key: 24-char base64 (16-byte nonce).
         key = req.headers["sec-websocket-key"]
+        key = "" if key.nil?
         if key.length == 0
           out.valid = false
           out.reason = "missing Sec-WebSocket-Key"
@@ -60,7 +64,9 @@ module Tep
 
         # Parse Sec-WebSocket-Protocol (comma-separated). Handler
         # gets the offered list; can opt-in via Driver.accept_protocol.
-        out.protocols = Handshake.split_csv(req.headers["sec-websocket-protocol"])
+        proto_blob = req.headers["sec-websocket-protocol"]
+        proto_blob = "" if proto_blob.nil?
+        out.protocols = Handshake.split_csv(proto_blob)
         out
       end
 


### PR DESCRIPTION
Fixes #235 — see the issue for the full analysis.

A missing header/cookie reads as nil; the lib called String methods on it directly, which raises at any spinel pin carrying the raise-by-default unresolved-call gate (matz/spinel 1356cb14) — CRuby-correct behavior that was masked by the old silent gate. Every cookieless request crashed the worker at such pins.

- Guard idiom is `v = "" if v.nil?` on purpose; `v || ""` mis-compiles at pin f6d5eef (blanks hit values).
- `content-length.to_i` deliberately unguarded (`NilClass#to_i` is legal in CRuby and modeled by spinel).
- Verified end-to-end at spinel a6b2d0f0 (hello: crashed on first request before, serves/parses cookies/stays alive after) and green at pin f6d5eef (test_cookies, test_cache, test_websocket, test_auth, test_request_methods, test_sessions, test_auth_session_cookie, test_security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)