### PR TITLE
chore(spin): inert spin.toml + require-root shims (#234 groundwork)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,10 @@ CLAUDE.md
 
 # Optional spinel --emit-rbs output (rake rbs:emit, dev-only)
 sig/.emitted/
+
+# spin (tep#234): libraries don't commit spin.lock (version selection
+# belongs to consuming applications); vendor/ and build/ are spin's
+# fetch/output trees.
+spin.lock
+vendor/packages/
+build/

--- a/spin.toml
+++ b/spin.toml
@@ -1,0 +1,19 @@
+# spin manifest (matz/spinel's package manager) — tep#234 groundwork.
+#
+# INERT at the current SPINEL_PIN (f6d5eef predates spin): the Makefile /
+# spinel-ext.json build path is still the one that builds tep. This
+# manifest exists so the dependency graph and layout are already
+# spin-shaped when the re-pin (tep#196, gated on matz/spinel#1842) makes
+# `spin build`/`spin test` viable. See tep#234 for the migration plan
+# (carried-C mapping, mirror-audit of the C shims, serve revalidation).
+#
+# Publishing note: the package name is the require string ("tep"); the
+# repo keeps its name. Libraries do not commit spin.lock — version
+# selection belongs to consuming applications (docs/internals/spin.md R5).
+
+[package]
+name = "tep"
+version = "0.11.6"
+
+[dependencies]
+spinel_kit = { git = "https://github.com/OriPekelman/spinelkit" }

--- a/tep.rb
+++ b/tep.rb
@@ -1,0 +1,6 @@
+# spin require-root shim (tep#234). Under spin, the package root is the
+# require root: `require "tep"` resolves here. The library itself stays
+# under lib/ (gem layout, Makefile/spinel-ext.json build path) until the
+# spin migration completes; this shim just bridges the two layouts.
+# Inert at the current pin — nothing on the Makefile path requires it.
+require_relative "lib/tep"

--- a/tep/pg.rb
+++ b/tep/pg.rb
@@ -1,0 +1,4 @@
+# spin require-root shim (tep#234): `require "tep/pg"` — the PG opt-in
+# (tep#216) — resolves to <package root>/tep/pg.rb under spin. Bridges
+# to the real feature under lib/ until the spin migration completes.
+require_relative "../lib/tep/pg"


### PR DESCRIPTION
First checkbox groundwork for #234, everything inert at the current pin (the Makefile/spinel-ext.json path is untouched):

- `spin.toml` with `[package] tep 0.11.6` and the `spinel_kit` git dependency (0.3.0 tree is a spin package per spinelkit#3).
- Require-root shims `tep.rb` / `tep/pg.rb` — spin resolves `require "tep"` at the package root; the shims bridge to `lib/` so the tree doesn't have to move yet.
- `.gitignore` for `spin.lock` (library: consuming apps own version selection per docs/internals/spin.md R5), `vendor/packages/`, `build/`.

**Validated with spin at master `f9a81b1d`:** `spin lock` resolves spinel_kit 0.3.0 to a full SHA, `list`/`tree` walk the graph, `vendor` + `SPIN_OFFLINE=1` resolution works. `spin build`/`spin test` stay blocked on matz/spinel#1842 (tep can't compile at any spin-era master). Gem contents unchanged (gemspec globs don't include the new root files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)