### PR TITLE
feat(translator): strict by default — dropped constructs fail the build (--lax opts out)

### DIFF
--- a/bin/tep
+++ b/bin/tep
@@ -86,7 +86,14 @@ def fatal(msg)
 end
 
 # Build the translated Ruby source from a Sinatra-style file.
-def translate(input_path)
+#
+# Strict by default (mirror condition 3, docs/mirrors/sinatra.md):
+# any construct the translator would drop -- Rack `use`, `helpers`,
+# unknown `set` keys, on_stop, malformed DSL blocks, missing views --
+# is a fatal error, because building anyway produces a binary that
+# silently diverges from what the same source does under real
+# sinatra. `--lax` (or TEP_LAX=1) restores warn-and-continue.
+def translate(input_path, lax: ENV["TEP_LAX"] == "1")
   raw_source = File.read(input_path)
 
   # Split off `__END__` inline templates. Sinatra's convention is
@@ -909,7 +916,19 @@ def translate(input_path)
   RB
   out << ""
 
-  warnings.each { |w| warn "tep: #{w}" }
+  if warnings.any?
+    if lax
+      warnings.each { |w| warn "tep: #{w}" }
+      warn "tep: --lax: built with #{warnings.length} dropped construct(s); " \
+           "behaviour diverges from real sinatra where they applied"
+    else
+      warnings.each { |w| warn "tep: error: #{w}" }
+      fatal "#{warnings.length} unsupported construct(s) -- refusing to build " \
+            "a binary that silently diverges (docs/mirrors/sinatra.md, " \
+            "condition 3). Re-run with --lax (or TEP_LAX=1) to drop them " \
+            "with a warning instead."
+    end
+  end
 
   out.join("\n")
 end
@@ -2176,23 +2195,25 @@ def cmd_build(args)
   input    = nil
   out_path = nil
   c_only   = false
+  lax      = ENV["TEP_LAX"] == "1"
   i = 0
   while i < args.length
     a = args[i]
     case a
     when "-o" then out_path = args[i + 1]; i += 2
     when "-c" then c_only = true; i += 1
+    when "--lax" then lax = true; i += 1
     when /^-/ then fatal "unknown option: #{a}"
     else
       input ||= a
       i += 1
     end
   end
-  fatal "usage: tep build app.rb [-o out] [-c]" unless input
+  fatal "usage: tep build app.rb [-o out] [-c] [--lax]" unless input
 
   base = File.basename(input, ".rb")
   out_path ||= File.join(File.dirname(input), base)
-  translated = translate(input)
+  translated = translate(input, lax: lax)
 
   # Spinel's require_relative resolves against the source file's
   # directory and chokes on absolute paths. Drop the generated file
@@ -2230,8 +2251,10 @@ def cmd_run(args)
 end
 
 def cmd_translate(args)
-  input = args.first or fatal "usage: tep translate app.rb"
-  puts translate(input)
+  lax = ENV["TEP_LAX"] == "1"
+  lax = true if args.delete("--lax")
+  input = args.first or fatal "usage: tep translate app.rb [--lax]"
+  puts translate(input, lax: lax)
 end
 
 case ARGV.shift
@@ -2243,9 +2266,14 @@ when nil, "-h", "--help"
     tep -- Sinatra-flavoured framework that compiles to a native binary.
 
     Usage:
-      tep build app.rb [-o out] [-c]    translate + spinel-compile
-      tep run   app.rb [-p PORT] [-w N] build then exec
-      tep translate app.rb               print the translated Ruby
+      tep build app.rb [-o out] [-c] [--lax]  translate + spinel-compile
+      tep run   app.rb [-p PORT] [-w N]       build then exec
+      tep translate app.rb [--lax]            print the translated Ruby
+
+    Strict by default: source constructs tep would have to drop
+    (Rack `use`, `helpers do`, unknown `set` keys, ...) fail the
+    build rather than silently diverging from real sinatra.
+    `--lax` (or TEP_LAX=1) downgrades them to warnings.
 
     Source compatibility: top-level `get '/path' do ... end`,
     `post`, `put`, `patch`, `delete`, `before`, `after`, `not_found`,

--- a/docs/mirrors/sinatra.md
+++ b/docs/mirrors/sinatra.md
@@ -89,10 +89,14 @@ Two regimes:
   invocations, `request.ip`) now raises NoMethodError / fails the gate.
   This half is already mirror-grade at spin-era pins.
 
-**Remediation:** promote translator warnings to hard errors by default
-(`tep build --lax` as the opt-out), mirroring spinel-redis's
-unknown-command-is-a-compile-error. Mechanically small: the nine
-`warnings <<` sites route through one strictness switch.
+**Remediation — SHIPPED:** the translator is strict by default: any
+would-be-dropped construct fails the build with an error naming this
+document, and `tep build --lax` (or `TEP_LAX=1`) restores
+warn-and-continue. All `warnings <<` sites route through one emission
+point in `translate`, so the switch covers every drop path, not just
+the nine cataloged ones. `test/test_unsupported.rb` asserts the
+refusals (`use`, `helpers`, unknown `set`, `on_stop`) and the `--lax`
+downgrade.
 
 ## Non-claims, for completeness
 
@@ -111,8 +115,8 @@ unknown-command-is-a-compile-error. Mechanically small: the nine
 |---|---|---|
 | 1 — exclusion ledger | PARTIAL (positive matrix exists; this file is the inverted ledger) | keep this file normative, sync with SINATRA_COMPAT.md |
 | 2 — real-gem oracle | GAP (hand-derived; only Jwt is differential) | differential CI job spawning real sinatra on the checklist suite |
-| 3 — loud failure | FAIL at translator (9 warn-and-ignore paths); PASS at compile gate post-1356cb14 | strict-by-default translator, `--lax` opt-out |
+| 3 — loud failure | **PASS** — translator strict by default (`--lax` opt-out); compile gate loud post-1356cb14 | shipped |
 
 Publishing a `sinatra` claim to spin-index is **not justified yet**;
-conditions 2 and 3 are the blockers. Both remediations are independent
-of the re-pin and can land now.
+condition 2 (the differential oracle) is the remaining blocker, and it
+is independent of the re-pin.

--- a/test/test_real_world.rb
+++ b/test/test_real_world.rb
@@ -30,10 +30,14 @@ class TestRealWorld < TepTest
     PORT_BASE + 100 + @@port_counter
   end
 
-  def with_app(example_filename)
+  # lax: true builds with --lax for fidelity copies of upstream apps
+  # that use out-of-contract DSL on purpose (02_lifecycle's `on_stop`)
+  # -- the strict default (mirror condition 3) would rightly refuse.
+  def with_app(example_filename, lax: false)
     src = File.join(EXAMPLES_DIR, example_filename)
     bin = Dir.mktmpdir + "/app"
-    out = `#{Shellwords.escape(File.expand_path("../bin/tep", __dir__))} build #{Shellwords.escape(src)} -o #{Shellwords.escape(bin)} 2>&1`
+    lax_flag = lax ? " --lax" : ""
+    out = `#{Shellwords.escape(File.expand_path("../bin/tep", __dir__))} build#{lax_flag} #{Shellwords.escape(src)} -o #{Shellwords.escape(bin)} 2>&1`
     raise "build failed:\n#{out}" unless $?.success?
     port = TestRealWorld.next_port
     pid = Process.spawn(bin, "-p", port.to_s, "-q",
@@ -73,7 +77,8 @@ class TestRealWorld < TepTest
   # ---- 02: lifecycle ----
 
   def test_02_lifecycle_root_renders
-    with_app("02_lifecycle.rb") do
+    # upstream example uses `on_stop` (no tep shutdown path) -> --lax
+    with_app("02_lifecycle.rb", lax: true) do
       res = get("/")
       assert_equal "200", res.code
       assert_match(/lifecycle events/, res.body)

--- a/test/test_unsupported.rb
+++ b/test/test_unsupported.rb
@@ -29,4 +29,51 @@ class TestUnsupported < TepTest
 
   # send_file, configure, pass, multiple filters, optional segments
   # have all moved into supported and have their own test files.
+
+  # ---- strict-by-default translator (mirror condition 3) ----
+  # Out-of-contract constructs must FAIL the build, not silently
+  # drop (docs/mirrors/sinatra.md). These assert at translate level,
+  # so no spinel compile is needed. `--lax` restores warn-and-continue.
+
+  def translate_out(source, flags: "")
+    tmp = Dir.mktmpdir("tep-strict")
+    src = File.join(tmp, "app.rb")
+    File.write(src, "require 'sinatra'\n" + source + "\nget('/') { 'ok' }\n")
+    out = `#{TepHarness::TEP_BIN} translate #{flags} #{src} 2>&1 >/dev/null`
+    [$?.success?, out]
+  ensure
+    FileUtils.remove_entry(tmp) if tmp
+  end
+
+  def assert_strict_refusal(source, message_fragment)
+    ok, out = translate_out(source)
+    refute ok, "expected strict translate to fail, but it succeeded"
+    assert_match(/error: .*#{Regexp.escape(message_fragment)}/, out)
+    assert_match(/--lax/, out, "refusal should mention the --lax escape hatch")
+  end
+
+  def test_strict_rejects_rack_use
+    assert_strict_refusal(%(use Rack::Session::Cookie, secret: "x"),
+                          "unsupported `use`")
+  end
+
+  def test_strict_rejects_helpers_block
+    assert_strict_refusal(%(helpers do\n  def shout(s); s.upcase; end\nend),
+                          "unsupported `helpers do ... end`")
+  end
+
+  def test_strict_rejects_unknown_set_key
+    assert_strict_refusal(%(set :sessions, true), "unsupported `set :sessions`")
+  end
+
+  def test_strict_rejects_on_stop
+    assert_strict_refusal(%(on_stop do\n  puts "bye"\nend), "on_stop")
+  end
+
+  def test_lax_downgrades_to_warning
+    ok, out = translate_out("use Rack::Head", flags: "--lax")
+    assert ok, "expected --lax translate to succeed, got:\n#{out}"
+    assert_match(/unsupported `use`/, out)
+    refute_match(/error:/, out)
+  end
 end


### PR DESCRIPTION
Ships the condition-3 remediation from the sphttp mirror audit (#238 — stacked on that branch; will retarget to main when it merges).

**Behavior change:** `tep build`/`translate` now refuse when the source uses anything the translator would have to drop (Rack `use`, `helpers do`, unknown `set` keys, `on_stop`, malformed DSL blocks, missing views, external requires). The refusal lists every offending construct, cites `docs/mirrors/sinatra.md`, and names the escape hatch: `--lax` (or `TEP_LAX=1`) restores warn-and-continue with a divergence summary.

Implementation is one strictness switch at the single warnings-emission point in `translate`, so every drop path is covered — including future ones — not just the nine cataloged in the audit.

**Fallout was minimal:** only real_world/02 (fidelity copy of sinatra's `lifecycle_events.rb`, uses `on_stop`) needed `lax: true` in its test. `test_unsupported.rb` graduates from skip-only to real assertions (4 strict refusals + the `--lax` downgrade).

Verified at pin f6d5eef: test_unsupported, test_real_world, test_routing, test_sessions, test_erb, test_mcp, test_websocket all green. Full suite runs in CI.

With this, the sinatra-claim scorecard is: ledger PARTIAL, oracle GAP (the remaining spin-index blocker), loud-failure **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)