### PR TITLE
feat(differential): real-sinatra oracle harness + CI job (#234 condition 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,37 @@ jobs:
         run: bundle exec rake rbs:validate
       - name: rake test
         run: bundle exec rake test
+
+  # Differential oracle: real sinatra vs tep (mirror condition 2,
+  # docs/mirrors/sinatra.md). Boots each fixture app under CRuby+sinatra
+  # and as a tep binary, replays the same requests, diffs the responses.
+  # Deliberately its own job with its own Gemfile so the sinatra gem
+  # never becomes a dependency of tep or of the main test job.
+  differential:
+    needs: build-spinel
+    runs-on: ubuntu-latest
+    env:
+      TEP_SKIP_SPINEL_FRESH: "1"
+      BUNDLE_GEMFILE: test/differential/Gemfile
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y build-essential libsqlite3-dev
+      - name: Set up Ruby (+ sinatra oracle gems)
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0"
+          bundler-cache: true   # installs test/differential/Gemfile
+      - uses: actions/download-artifact@v7
+        with:
+          name: spinel-dist
+          path: spinel-dist
+      - name: Restore exec bits and put spinel on PATH
+        run: |
+          chmod +x spinel-dist/spinel \
+                   spinel-dist/spinel_parse \
+                   spinel-dist/spinel_analyze \
+                   spinel-dist/spinel_codegen
+          echo "$GITHUB_WORKSPACE/spinel-dist" >> "$GITHUB_PATH"
+      - name: Run differential oracle
+        run: bundle exec ruby test/differential/runner.rb

--- a/docs/mirrors/sinatra.md
+++ b/docs/mirrors/sinatra.md
@@ -55,7 +55,7 @@ translator's warn-inventory + code:
 file), kept in sync with SINATRA_COMPAT.md's matrix; the matrix cites
 tests, the ledger cites narrowings.
 
-## Condition 2 — real gem as oracle: GAP (one bright spot)
+## Condition 2 — real gem as oracle: PARTIAL (harness live, coverage growing)
 
 Current verification is **hand-derived, not differential**: the ~170
 checklist expectations were written from sinatra's documented behavior,
@@ -69,11 +69,30 @@ Bright spot: `Tep::Jwt` already does exactly what matz asks — an interop
 test verifying tokens against the canonical `jwt` gem. That's the
 pattern to replicate.
 
-**Remediation:** a `spawn_real_sinatra(source)` helper (CRuby + sinatra
-gem on the host, same source file both sides — the translator input IS
-valid sinatra by construction), then a differential pass over the
-checklist requests diffing status/headers-subset/body. Runs as a
-separate CI job so the sinatra gem never becomes a tep dependency.
+**Remediation — SHIPPED (harness + CI job), coverage growing:**
+`test/differential/runner.rb` boots each fixture app twice — CRuby +
+the real sinatra gem vs the tep-compiled binary — replays the same
+requests and diffs status / body / content-type / redirect Location /
+declared headers. Unledgered divergences fail; accepted ones are
+normalized away with a lettered reason recorded in the runner (L1
+sinatra's `;charset=utf-8` suffix, L2 rack-protection default headers,
+L3 transport furniture, L4 Location absolutization) that must also
+live here. Its own Gemfile keeps sinatra out of tep's dependency
+graph; CI runs it as the `differential` job. Coverage today:
+real_world 01/04/05 + a purpose-built core-semantics fixture
+(`test/differential/10_semantics.rb`: params, query, form, redirect
+×2, halt, custom status, custom header, content_type, url-decode,
+not_found) — extend toward the full checklist over time.
+
+**First fruits of the oracle:**
+- tep omitted the default `Content-Type` on empty-body responses
+  (redirects!) where sinatra/Rack emit `text/html` — **fixed** in both
+  servers, with 204/304 excepted (Rack strips entity headers there).
+- real_world/06 uses `request.headers["x-token"]`, which is **not
+  valid sinatra** — `request.headers` is a tep extension (sinatra
+  spells it `request.env["HTTP_..."]`). 06 is excluded from the oracle
+  set; the extension joins the ledger: code written against it is
+  tep-only, not sinatra-portable.
 
 ## Condition 3 — loud failure outside the contract: FAIL today
 
@@ -114,9 +133,12 @@ downgrade.
 | condition | state | remediation |
 |---|---|---|
 | 1 — exclusion ledger | PARTIAL (positive matrix exists; this file is the inverted ledger) | keep this file normative, sync with SINATRA_COMPAT.md |
-| 2 — real-gem oracle | GAP (hand-derived; only Jwt is differential) | differential CI job spawning real sinatra on the checklist suite |
+| 2 — real-gem oracle | PARTIAL — differential harness + CI job live (4 fixture apps, 75 assertions); checklist coverage still growing | extend fixtures toward the full Phase A matrix |
 | 3 — loud failure | **PASS** — translator strict by default (`--lax` opt-out); compile gate loud post-1356cb14 | shipped |
 
-Publishing a `sinatra` claim to spin-index is **not justified yet**;
-condition 2 (the differential oracle) is the remaining blocker, and it
-is independent of the re-pin.
+Publishing a `sinatra` claim to spin-index: conditions 1 and 2 are both
+PARTIAL — the machinery exists and is normative, the remaining work is
+coverage (more checklist surface through the oracle, ledger kept in
+lockstep). Judgment call for when coverage is "enough" to publish; the
+oracle already caught one real parity bug and one invalid fixture on
+its first run, which is the mechanism working as designed.

--- a/lib/tep/server.rb
+++ b/lib/tep/server.rb
@@ -231,7 +231,11 @@ module Tep
         res.set_body("")
       end
 
-      if res.body.length > 0 && !res.headers.key?("Content-Type")
+      # Default Content-Type even on empty bodies (redirects!) --
+      # sinatra/Rack parity, caught by the differential oracle
+      # (test/differential/runner.rb). 204/304 are the exception:
+      # Rack strips entity headers there, so we don't default one in.
+      if !res.headers.key?("Content-Type") && res.status != 204 && res.status != 304
         res.headers["Content-Type"] = "text/html; charset=utf-8"
       end
       res.headers["Content-Length"] = res.body.length.to_s

--- a/lib/tep/server_scheduled.rb
+++ b/lib/tep/server_scheduled.rb
@@ -327,11 +327,14 @@ module Tep
           res.file_path = ""
         end
 
-        # Default Content-Type for inline-body responses. Matches
-        # Tep::Server#send; without it, the Security::Headers nosniff
-        # default leaves the browser refusing to interpret an erb
-        # response as HTML.
-        if res.file_path.length == 0 && res.body.length > 0 && !res.headers.key?("Content-Type")
+        # Default Content-Type for inline-body responses -- including
+        # empty ones (redirects), for sinatra/Rack parity (differential
+        # oracle finding; matches Tep::Server). 204/304 excepted: Rack
+        # strips entity headers there. Without a Content-Type, the
+        # Security::Headers nosniff default leaves the browser refusing
+        # to interpret an erb response as HTML.
+        if res.file_path.length == 0 && !res.headers.key?("Content-Type") &&
+           res.status != 204 && res.status != 304
           res.headers["Content-Type"] = "text/html; charset=utf-8"
         end
         reason = Tep.reason(res.status)

--- a/test/differential/10_semantics.rb
+++ b/test/differential/10_semantics.rb
@@ -1,0 +1,56 @@
+# Differential fixture: core routing/response semantics that both real
+# sinatra and tep claim. This file must stay valid under BOTH dialects
+# (docs/mirrors/sinatra.md condition 2) -- no tep extensions
+# (request.headers, cookies[], set_cookie) and no sinatra-contrib.
+require 'sinatra'
+
+get '/hi/:name' do
+  'hi ' + params[:name]
+end
+
+get '/two/:a/:b' do
+  params[:a] + '-' + params[:b]
+end
+
+get '/q' do
+  q = params[:q]
+  q = '' if q.nil?
+  'q=' + q
+end
+
+post '/form' do
+  t = params[:text]
+  t = '' if t.nil?
+  'text=' + t
+end
+
+get '/redir' do
+  redirect '/hi/there'
+end
+
+get '/redir301' do
+  redirect '/hi/there', 301
+end
+
+get '/teapot' do
+  status 418
+  'short and stout'
+end
+
+get '/halted' do
+  halt 401, 'no entry'
+end
+
+get '/hdr' do
+  headers['x-custom'] = 'yes'
+  'ok'
+end
+
+get '/ct' do
+  content_type 'text/plain'
+  'plain body'
+end
+
+not_found do
+  'nope: ' + request.path
+end

--- a/test/differential/Gemfile
+++ b/test/differential/Gemfile
@@ -1,0 +1,14 @@
+# Gems for the differential oracle ONLY (test/differential/runner.rb):
+# real sinatra as the behavioural reference. Deliberately a separate
+# Gemfile so sinatra never becomes a dependency of tep itself -- the
+# main Gemfile stays rake/minitest/base64/rbs.
+#
+#   BUNDLE_GEMFILE=test/differential/Gemfile bundle install
+#   ruby test/differential/runner.rb
+
+source "https://rubygems.org"
+
+gem "sinatra"
+gem "rackup"
+gem "puma"
+gem "minitest"

--- a/test/differential/runner.rb
+++ b/test/differential/runner.rb
@@ -1,0 +1,208 @@
+# Differential oracle: real sinatra vs tep (mirror condition 2,
+# docs/mirrors/sinatra.md). Boots each fixture app twice -- once under
+# CRuby + the real sinatra gem, once as a tep-compiled binary -- fires
+# the same requests at both, and diffs status / body / declared
+# headers. Any divergence not recorded in LEDGER is a failure: new
+# divergences must be either fixed or explicitly ledgered with a
+# reason (which then belongs in docs/mirrors/sinatra.md too).
+#
+# Not part of `rake test` (FileList only globs test/test_*.rb): the
+# sinatra gem must never become a tep dependency. Run explicitly:
+#
+#   gem install sinatra rackup puma       # or bundle with ./Gemfile
+#   ruby test/differential/runner.rb
+#
+# CI runs this as its own job (`differential` in ci.yml).
+
+begin
+  gem "sinatra"
+rescue Gem::LoadError
+  abort "differential runner needs the sinatra gem (gem install sinatra rackup puma)"
+end
+
+require "minitest/autorun"
+require "net/http"
+require "socket"
+require "tmpdir"
+require "fileutils"
+require "shellwords"
+require "rbconfig"
+
+module Differential
+  TEP_BIN   = File.expand_path("../../bin/tep", __dir__)
+  ROOT      = File.expand_path("../..", __dir__)
+  PORT_BASE = 5300 + ($$ % 100)
+
+  @port = PORT_BASE
+  def self.next_port
+    @port += 1
+  end
+
+  # ---- the exclusion ledger, harness-side ----
+  # Divergences we accept, keyed by response facet. Every entry needs a
+  # reason and should be mirrored in docs/mirrors/sinatra.md. The
+  # runner *normalizes* these away before diffing; anything left is a
+  # real, unledgered divergence and fails the run.
+  #
+  # L1 content-type charset: sinatra appends ";charset=utf-8" to text
+  #    types; tep emits the bare type.
+  # L2 protection headers: sinatra ships rack-protection by default
+  #    (x-xss-protection / x-content-type-options / x-frame-options);
+  #    tep's Tep::Security::Headers is opt-in.
+  # L3 server/date/connection/content-length: transport furniture --
+  #    body equality already covers length.
+  # L4 redirect Location absolutization: sinatra expands "/path" to an
+  #    absolute http://host:port/path; tep echoes the path as given.
+  #    Compare path component only.
+  IGNORED_HEADERS = %w[
+    server date connection content-length x-xss-protection
+    x-content-type-options x-frame-options keep-alive
+  ].freeze
+
+  def self.normalize_content_type(v)
+    v.to_s.split(";").first.to_s.strip.downcase # L1
+  end
+
+  def self.normalize_location(v)
+    return "" if v.nil?
+    v.sub(%r{\Ahttps?://[^/]+}, "") # L4
+  end
+
+  Server = Struct.new(:pid, :port, :log) do
+    def stop
+      return unless pid
+      Process.kill("TERM", -pid) rescue Process.kill("TERM", pid) rescue nil
+      Process.wait(pid) rescue nil
+    end
+  end
+
+  def self.wait_for_port(port, pid, timeout: 15.0)
+    deadline = Time.now + timeout
+    while Time.now < deadline
+      begin
+        TCPSocket.new("127.0.0.1", port).close
+        return true
+      rescue Errno::ECONNREFUSED
+        raise "server died before binding :#{port}" if Process.wait(pid, Process::WNOHANG) rescue nil
+        sleep 0.05
+      end
+    end
+    raise "server on :#{port} didn't come up"
+  end
+
+  def self.boot_sinatra(app_path)
+    port = next_port
+    log  = File.join(Dir.mktmpdir("diff-sin"), "sinatra.log")
+    pid  = Process.spawn(
+      RbConfig.ruby, app_path, "-p", port.to_s, "-o", "127.0.0.1", "-e", "production",
+      out: log, err: [:child, :out], pgroup: true
+    )
+    wait_for_port(port, pid)
+    Server.new(pid, port, log)
+  end
+
+  def self.boot_tep(app_path)
+    tmp = Dir.mktmpdir("diff-tep")
+    bin = File.join(tmp, "app")
+    out = `#{Shellwords.escape(TEP_BIN)} build #{Shellwords.escape(app_path)} -o #{Shellwords.escape(bin)} 2>&1`
+    raise "tep build failed for #{app_path}:\n#{out}" unless $?.success?
+    port = next_port
+    log  = File.join(tmp, "tep.log")
+    pid  = Process.spawn(bin, "-p", port.to_s, "-q",
+                         out: log, err: [:child, :out], pgroup: true)
+    wait_for_port(port, pid)
+    Server.new(pid, port, log)
+  end
+
+  def self.request(port, verb, path, body: nil, headers: {})
+    http = Net::HTTP.new("127.0.0.1", port)
+    http.open_timeout = 5
+    http.read_timeout = 5
+    klass = { "GET" => Net::HTTP::Get, "POST" => Net::HTTP::Post,
+              "PUT" => Net::HTTP::Put, "DELETE" => Net::HTTP::Delete }.fetch(verb)
+    req = klass.new(path)
+    headers.each { |k, v| req[k] = v }
+    if body
+      req.body = body
+      req["Content-Type"] ||= "application/x-www-form-urlencoded"
+    end
+    http.request(req)
+  end
+end
+
+# One test class per fixture; each boots both servers once and replays
+# the same request script against each.
+class DifferentialCase < Minitest::Test
+  FIXTURES = {
+    File.expand_path("../real_world/01_simple.rb", __dir__) => [
+      ["GET", "/"],
+    ],
+    File.expand_path("../real_world/04_health_api.rb", __dir__) => [
+      ["GET", "/healthz"],
+      ["GET", "/version"],
+      ["GET", "/"],
+      ["GET", "/missing"],          # custom not_found on both
+    ],
+    File.expand_path("../real_world/05_todo_api.rb", __dir__) => [
+      ["GET", "/todos"],
+      ["POST", "/todos", { body: "text=buy-milk" }],
+      ["POST", "/todos", { body: "text=ship-tep" }],
+      ["GET", "/todos"],
+      ["DELETE", "/todos/1"],
+      ["DELETE", "/todos/9999"],
+      ["GET", "/todos"],
+    ],
+    File.expand_path("10_semantics.rb", __dir__) => [
+      ["GET", "/hi/tep"],
+      ["GET", "/two/a/b"],
+      ["GET", "/q?q=hello"],
+      ["GET", "/q"],                 # missing param -> ""
+      ["POST", "/form", { body: "text=zap" }],
+      ["GET", "/redir"],
+      ["GET", "/redir301"],
+      ["GET", "/teapot"],
+      ["GET", "/halted"],
+      ["GET", "/hdr", { expect_headers: ["x-custom"] }],
+      ["GET", "/ct"],
+      ["GET", "/hi%20there"],        # url-decoded 404 path via not_found
+    ],
+  }.freeze
+
+  def compare(app, sin, tep, verb, path, opts)
+    body    = opts[:body]
+    headers = opts[:headers] || {}
+    r_sin = Differential.request(sin.port, verb, path, body: body, headers: headers)
+    r_tep = Differential.request(tep.port, verb, path, body: body, headers: headers)
+    ctx = "#{File.basename(app)} #{verb} #{path}"
+
+    assert_equal r_sin.code, r_tep.code, "#{ctx}: status diverged"
+    assert_equal r_sin.body, r_tep.body, "#{ctx}: body diverged"
+    assert_equal Differential.normalize_content_type(r_sin["content-type"]),
+                 Differential.normalize_content_type(r_tep["content-type"]),
+                 "#{ctx}: content-type diverged (post-normalization)"
+    if %w[301 302 303 307 308].include?(r_sin.code)
+      assert_equal Differential.normalize_location(r_sin["location"]),
+                   Differential.normalize_location(r_tep["location"]),
+                   "#{ctx}: redirect Location diverged (path component)"
+    end
+    (opts[:expect_headers] || []).each do |h|
+      assert_equal r_sin[h], r_tep[h], "#{ctx}: declared header #{h} diverged"
+    end
+  end
+
+  FIXTURES.each do |app, script|
+    name = File.basename(app, ".rb")
+    define_method("test_differential_#{name}") do
+      sin = Differential.boot_sinatra(app)
+      tep = Differential.boot_tep(app)
+      begin
+        script.each do |verb, path, opts|
+          compare(app, sin, tep, verb, path, opts || {})
+        end
+      ensure
+        sin.stop
+        tep.stop
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ships the condition-2 remediation from the sphttp mirror audit: `test/differential/runner.rb` boots each fixture app under **CRuby + the real sinatra gem** and as a **tep binary**, replays identical requests, and diffs status / body / content-type / redirect Location / declared headers. Anything not normalized by the harness-side ledger (charset suffix, rack-protection defaults, transport furniture, Location absolutization — each lettered with a reason) fails the run.

Structure: own Gemfile (sinatra never enters tep's dependency graph), not globbed by `rake test`, new `differential` CI job off the build-spinel artifact. Fixtures: real_world 01/04/05 + a purpose-built both-dialect semantics fixture (params, query, form, redirects, halt, status, headers, content_type, url-decode, not_found). 75 assertions across 4 apps, green locally at the pin.

**The oracle earned its keep on its first run:**
1. **Parity bug found and fixed**: tep omitted the default `Content-Type` on empty-body responses (redirects!) where sinatra/Rack send `text/html`. Fixed in both servers, 204/304 excepted per Rack semantics.
2. **Invalid fixture exposed**: real_world/06 uses `request.headers[...]` — a tep extension, not sinatra (`request.env` there). Excluded from the oracle set and ledgered.

Verdict: condition 2 moves GAP → PARTIAL; remaining work is fixture coverage toward the full Phase A matrix. Regression-verified: cache, cache_static, routing, security, server_scheduled, real_world all green after the Content-Type change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)