### PR TITLE
feat(differential): matrix fixture + executable ledger pins (#234)

### DIFF
--- a/docs/mirrors/sinatra.md
+++ b/docs/mirrors/sinatra.md
@@ -42,8 +42,8 @@ translator's warn-inventory + code:
 | `request.ip` / `remote_ip` | not implemented (needs peer-addr C helper) | unresolved at compile |
 | multipart file-upload parts | text fields only, files skipped | silent narrowing (documented) |
 | unknown `set :key` | recognized keys only | ⚠️ warn + ignored |
-| splat `*` | last-segment only | narrowing, no diagnostic |
-| regex routes | ≤9 captures → `params["1".."9"]` | narrowing, documented |
+| splat `*` | last-segment only (sinatra spans segments: `/files/a/b` matches `/files/*` there, 404s here); splat *value* not exposed (sinatra: `params['splat']` array) | **oracle-pinned** (runner L5 `diverge:` assertion) |
+| regex routes | ≤9 captures → `params["1".."9"]` (sinatra: `params['captures']` / block args); tep also accepts `^`/`$`-anchored regexes that sinatra's mustermann *rejects at boot* — anchor-free is the portable form | narrowing + anchor asymmetry, documented (runner L6) |
 | sessions | signed-cookie store only | narrowing, documented |
 | `error do ... end` blocks, route conditions (`provides:`, `agent:`), `register`/extensions | not claimed | mostly unresolved at compile; not individually diagnosed |
 | unrecognized top-level calls | — | ⚠️ warn + **ignored** |
@@ -78,11 +78,17 @@ normalized away with a lettered reason recorded in the runner (L1
 sinatra's `;charset=utf-8` suffix, L2 rack-protection default headers,
 L3 transport furniture, L4 Location absolutization) that must also
 live here. Its own Gemfile keeps sinatra out of tep's dependency
-graph; CI runs it as the `differential` job. Coverage today:
-real_world 01/04/05 + a purpose-built core-semantics fixture
-(`test/differential/10_semantics.rb`: params, query, form, redirect
-×2, halt, custom status, custom header, content_type, url-decode,
-not_found) — extend toward the full checklist over time.
+graph; CI runs it as the `differential` job. Coverage today (5 apps,
+107 assertions): real_world 01/04/05 + two purpose-built fixtures —
+`10_semantics.rb` (params, query, form, redirect ×2, halt, custom
+status, custom header, content_type, url-decode, not_found) and
+`11_matrix.rb` (PUT/PATCH, splat, regex route, after-filter header
+mutation, `%xx`/`+` query decoding, multipart text fields, bare
+halt). The harness also supports **executable ledger pins**: a
+request marked `diverge:` asserts the two servers *disagree* as
+documented (splat multi-segment, L5) — if the divergence ever heals,
+the assertion flips and the ledger entry gets cleaned up. Extend
+toward the full checklist over time.
 
 **First fruits of the oracle:**
 - tep omitted the default `Content-Type` on empty-body responses

--- a/test/differential/11_matrix.rb
+++ b/test/differential/11_matrix.rb
@@ -1,0 +1,63 @@
+# Differential fixture: broader Phase A matrix coverage. Valid under
+# BOTH real sinatra and tep (docs/mirrors/sinatra.md condition 2).
+# Divergent read-APIs (splat value, regex captures, cookies DSL) are
+# deliberately NOT read here -- routes only exercise surface both
+# dialects share; the known divergences are pinned by the runner's
+# ledgered-divergence assertions instead.
+require 'sinatra'
+
+put '/verb' do
+  'put-ok'
+end
+
+patch '/verb' do
+  'patch-ok'
+end
+
+# Splat: single-segment matches in both dialects. The VALUE is not
+# read (sinatra: params['splat'] array; tep: no exposed value) and
+# multi-segment matching diverges -- see runner ledger L5.
+get '/files/*' do
+  'file-route'
+end
+
+# Regex route, no capture reads (sinatra: params['captures']; tep:
+# params["1"] -- runner ledger L6). Unanchored on purpose: sinatra's
+# mustermann raises at boot on ^/$ anchors (it anchors implicitly),
+# while tep accepts them -- anchored regex routes are tep-only (L6).
+get %r{/rx/\d+} do
+  'rx-route'
+end
+
+# after-filter mutating a response header; both dialects claim it.
+after do
+  headers['x-after'] = 'ran'
+end
+
+get '/afterhdr' do
+  'body'
+end
+
+# Query-string URL decoding: %xx and `+` as space.
+get '/dec' do
+  v = params[:v]
+  v = '' if v.nil?
+  'v=[' + v + ']'
+end
+
+# Multipart/form-data: text fields merge into params in both dialects
+# (file parts are tep-ledgered as skipped; not exercised here).
+post '/mp' do
+  f = params[:field]
+  f = '' if f.nil?
+  'field=[' + f + ']'
+end
+
+# Bare halt (status only, empty body).
+get '/gone' do
+  halt 410
+end
+
+not_found do
+  'nf: ' + request.path
+end

--- a/test/differential/runner.rb
+++ b/test/differential/runner.rb
@@ -54,6 +54,16 @@ module Differential
   # L4 redirect Location absolutization: sinatra expands "/path" to an
   #    absolute http://host:port/path; tep echoes the path as given.
   #    Compare path component only.
+  # L5 splat scope: sinatra's `*` spans path segments; tep's matches a
+  #    single trailing segment. Pinned per-request via `diverge:`.
+  # L6 divergent read APIs, not exercised by fixtures: regex captures
+  #    (sinatra params['captures'] / block args vs tep params["1".."9"]),
+  #    splat value (params['splat'] array vs none), request.headers
+  #    (tep extension), bare set_cookie/cookies[] (tep mirrors
+  #    contrib-style helpers), and ^/$-anchored regex routes (tep
+  #    accepts; sinatra's mustermann raises at boot -- anchor-free
+  #    regexes are the portable form). Fixtures avoid these; the
+  #    ledger in docs/mirrors/sinatra.md records them.
   IGNORED_HEADERS = %w[
     server date connection content-length x-xss-protection
     x-content-type-options x-frame-options keep-alive
@@ -119,7 +129,8 @@ module Differential
     http.open_timeout = 5
     http.read_timeout = 5
     klass = { "GET" => Net::HTTP::Get, "POST" => Net::HTTP::Post,
-              "PUT" => Net::HTTP::Put, "DELETE" => Net::HTTP::Delete }.fetch(verb)
+              "PUT" => Net::HTTP::Put, "PATCH" => Net::HTTP::Patch,
+              "DELETE" => Net::HTTP::Delete }.fetch(verb)
     req = klass.new(path)
     headers.each { |k, v| req[k] = v }
     if body
@@ -152,6 +163,24 @@ class DifferentialCase < Minitest::Test
       ["DELETE", "/todos/9999"],
       ["GET", "/todos"],
     ],
+    File.expand_path("11_matrix.rb", __dir__) => [
+      ["PUT", "/verb"],
+      ["PATCH", "/verb"],
+      ["GET", "/files/one"],
+      # L5: sinatra's splat spans segments (/files/a/b matches); tep's
+      # splat is last-segment-only (404s). Pinned divergence.
+      ["GET", "/files/a/b", { diverge: { "status" => "L5 splat last-segment-only" } }],
+      ["GET", "/rx/123"],
+      ["GET", "/rx/abc"],               # regex miss -> not_found on both
+      ["GET", "/afterhdr", { expect_headers: ["x-after"] }],
+      ["GET", "/dec?v=a%20b+c"],        # %xx and + decoding
+      ["POST", "/mp", {
+        body: "--XDIFFB\r\nContent-Disposition: form-data; name=\"field\"\r\n\r\nzap-mp\r\n--XDIFFB--\r\n",
+        headers: { "Content-Type" => "multipart/form-data; boundary=XDIFFB" },
+      }],
+      ["GET", "/gone"],                 # bare halt 410
+      ["GET", "/nowhere"],
+    ],
     File.expand_path("10_semantics.rb", __dir__) => [
       ["GET", "/hi/tep"],
       ["GET", "/two/a/b"],
@@ -174,6 +203,19 @@ class DifferentialCase < Minitest::Test
     r_sin = Differential.request(sin.port, verb, path, body: body, headers: headers)
     r_tep = Differential.request(tep.port, verb, path, body: body, headers: headers)
     ctx = "#{File.basename(app)} #{verb} #{path}"
+
+    # Ledgered per-request divergences (opts[:diverge] = {facet =>
+    # "Ln reason"}): the divergence is EXPECTED and pinned -- if the
+    # two servers ever agree again, the assertion flips, telling us to
+    # clean the ledger entry (and docs/mirrors/sinatra.md). A status
+    # divergence short-circuits the body/content-type diff: different
+    # routes answered, comparing their bodies is meaningless.
+    diverge = opts[:diverge] || {}
+    if diverge.key?("status")
+      refute_equal r_sin.code, r_tep.code,
+                   "#{ctx}: ledgered status divergence (#{diverge["status"]}) healed -- remove from ledger"
+      return
+    end
 
     assert_equal r_sin.code, r_tep.code, "#{ctx}: status diverged"
     assert_equal r_sin.body, r_tep.body, "#{ctx}: body diverged"


### PR DESCRIPTION
Extends the differential oracle from 75 to **107 assertions across 5 apps**.

New fixture `11_matrix.rb`: PUT/PATCH verb routing, splat routes, a regex route, after-filter header mutation, `%xx`/`+` query decoding, multipart text-field parsing, bare `halt 410`.

Two mechanism upgrades:
- **Executable ledger pins** — a request marked `diverge:` asserts the two servers *disagree* as documented; if the divergence ever heals, the assertion flips and forces a ledger cleanup. First pin: splat scope (sinatra's `*` spans segments so `/files/a/b` matches, tep is last-segment-only and 404s).
- **New oracle finding**: tep accepts `^`/`$`-anchored regex routes; sinatra's mustermann **raises at boot** on them (anchoring is implicit there). tep's own regex tests use anchored patterns, so this was invisible until the oracle tried to boot the fixture under real sinatra. Ledgered; anchor-free regexes are the portable form.

Green locally at pin f6d5eef: 5 runs / 107 assertions / 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)