### PR TITLE
chore(spinel): re-pin f6d5eef → fd87f45b — blockers cleared, suite green (#196)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
   # non-blocking "spinel master canary" job can restore the early-warning
   # without gating the suite.)
   #
-  # The `spinel` shell wrapper resolves spinel_parse / spinel_analyze /
-  # spinel_codegen / lib/ relative to its own directory, so the tree
+  # The unified bin/spinel resolves its runtime (lib/) and the bundled
+  # stdlib packages/ relative to its own directory, so the staged tree
   # ships as a unit.
   build-spinel:
     runs-on: ubuntu-latest
@@ -37,15 +37,16 @@ jobs:
       - name: make all
         run: make -C spinel-src all
       - name: Stage artifact tree
+        # Unified layout (post spinelc->spinel refactor): one binary at
+        # bin/spinel resolving its runtime at bin/../lib, plus the
+        # bundled stdlib packages/ beside it. No root wrapper is staged
+        # (artifacts don't preserve symlinks); consumers put
+        # spinel-dist/bin on PATH.
         run: |
-          mkdir spinel-dist
-          cp spinel-src/spinel             spinel-dist/
-          cp spinel-src/spinel_parse       spinel-dist/
-          cp spinel-src/spinel_analyze     spinel-dist/
-          cp spinel-src/spinel_codegen     spinel-dist/
-          cp spinel-src/spinel_analyze.rb  spinel-dist/
-          cp spinel-src/spinel_codegen.rb  spinel-dist/
-          cp -R spinel-src/lib             spinel-dist/lib
+          mkdir -p spinel-dist/bin
+          cp spinel-src/bin/spinel spinel-dist/bin/
+          cp -R spinel-src/lib      spinel-dist/lib
+          cp -R spinel-src/packages spinel-dist/packages
       - name: Upload spinel toolchain
         uses: actions/upload-artifact@v7
         with:
@@ -77,11 +78,8 @@ jobs:
           path: spinel-dist
       - name: Restore exec bits and put spinel on PATH
         run: |
-          chmod +x spinel-dist/spinel \
-                   spinel-dist/spinel_parse \
-                   spinel-dist/spinel_analyze \
-                   spinel-dist/spinel_codegen
-          echo "$GITHUB_WORKSPACE/spinel-dist" >> "$GITHUB_PATH"
+          chmod +x spinel-dist/bin/spinel
+          echo "$GITHUB_WORKSPACE/spinel-dist/bin" >> "$GITHUB_PATH"
       - name: make all
         run: make all
       - name: rake rbs:validate
@@ -115,10 +113,7 @@ jobs:
           path: spinel-dist
       - name: Restore exec bits and put spinel on PATH
         run: |
-          chmod +x spinel-dist/spinel \
-                   spinel-dist/spinel_parse \
-                   spinel-dist/spinel_analyze \
-                   spinel-dist/spinel_codegen
-          echo "$GITHUB_WORKSPACE/spinel-dist" >> "$GITHUB_PATH"
+          chmod +x spinel-dist/bin/spinel
+          echo "$GITHUB_WORKSPACE/spinel-dist/bin" >> "$GITHUB_PATH"
       - name: Run differential oracle
         run: bundle exec ruby test/differential/runner.rb

--- a/SPINEL_PIN
+++ b/SPINEL_PIN
@@ -1,4 +1,27 @@
-f6d5eef
+fd87f45b
+
+# fd87f45b (2026-07-12). Bumped from f6d5eef (+~2100) onto current master
+# after the last two blockers landed upstream (tep#196):
+#   - matz/spinel#1842 (fe955423): analyzer infer_call/infer_type blowup
+#     from the explicit-receiver Kernel-conversion arm -- tep whole-
+#     programs compile again (hello: 8s at tip vs non-terminating).
+#   - matz/spinel#1866 (b4f4da70): SIGSEGV in sp_bigint_cmp -- an early
+#     `return 0` literal emitted through a bigint-promoted return slot
+#     (NULL pointer); killed Tep::Proxy's retry-after-503 path. Proxy
+#     repro verified green at this pin (200/200, worker alive).
+# BUILD-LAYOUT NOTE: this pin has the unified `bin/spinel` (no more
+# spinel_parse/spinel_analyze/spinel_codegen or .rb drivers; the root
+# `spinel` is a make-created symlink to bin/spinel). tools/
+# spinel-fresh.sh + ci.yml staging updated to match in the same PR.
+# Workaround status at this pin (probed 2026-07-12):
+#   - `x || ""` hit-value blanking: FIXED (probe green); the explicit
+#     nil-guard idiom in lib/ stays -- it is equally correct and the
+#     ||-form gains nothing.
+#   - pg_hello `e.is_a?(PG::Error)` namespaced-exception rescue: STILL
+#     unsupported (`is_a?` on rescued local, probe fails identically);
+#     the hardcoded stub stays. Tracked in tep#196 notes.
+#   - PG::Pool#with typed yield (tep#189): deferral kept, pending its
+#     own verification pass.
 
 # f6d5eef (2026-06-03). Bumped from a782696 (+32) onto current master to
 # absorb the spinel-dev tooling surfaces + codegen fixes:

--- a/bin/tep
+++ b/bin/tep
@@ -1615,8 +1615,12 @@ def rewrite_block(src, force_string: true)
   # `headers["X"] = "y"` -> `res.headers[...]` when not already qualified
   s = s.gsub(/(?<![\w.])headers\[/, "res.headers[")
 
-  # `cookies["k"]` -> `req.cookies["k"]` when not already qualified
-  s = s.gsub(/(?<![\w.])cookies\[/, "req.cookies[")
+  # `cookies["k"] = v` (write) -> direct hash write; `cookies["k"]`
+  # (read) -> Tep.cookie(req, "k"), which nil-guards the miss: the
+  # documented cookies[] contract is ""-on-miss (test_cookies pins
+  # it), but the underlying hash reads nil for a missing key.
+  s = s.gsub(/(?<![\w.])cookies\[([^\]]*)\]\s*=(?![=~])/, 'req.cookies[\1] =')
+  s = s.gsub(/(?<![\w.])cookies\[([^\]]*)\]/, 'Tep.cookie(req, \1)')
 
   # `erb :name`              -> `tep_view_name(Tep.str_hash, req.ivars)`
   # `erb :name, locals: {a: "b", c: "d"}` -> build a String=>String
@@ -1715,6 +1719,12 @@ def rewrite_block(src, force_string: true)
   # Spinel doesn't poly-convert symbols to strings inside Hash[]; rewrite
   # to string keys.
   s = s.gsub(/(req\.params)\[:(\w+)\]/, '\1["\2"]')
+
+  # Read form -> Tep.param(req, k), which nil-guards the miss: tep's
+  # documented params[] contract is ""-on-miss (test_params pins it;
+  # ledgered as a sinatra divergence -- sinatra reads nil). Writes
+  # (assignment) stay direct hash writes.
+  s = s.gsub(/req\.params\[([^\]]*)\](?!\s*=[^=~])/, 'Tep.param(req, \1)')
 
   # `"#{params['x']}"` interpolation works fine after the params rewrite.
 

--- a/docs/mirrors/sinatra.md
+++ b/docs/mirrors/sinatra.md
@@ -45,6 +45,9 @@ translator's warn-inventory + code:
 | splat `*` | last-segment only (sinatra spans segments: `/files/a/b` matches `/files/*` there, 404s here); splat *value* not exposed (sinatra: `params['splat']` array) | **oracle-pinned** (runner L5 `diverge:` assertion) |
 | regex routes | ≤9 captures → `params["1".."9"]` (sinatra: `params['captures']` / block args); tep also accepts `^`/`$`-anchored regexes that sinatra's mustermann *rejects at boot* — anchor-free is the portable form | narrowing + anchor asymmetry, documented (runner L6) |
 | sessions | signed-cookie store only | narrowing, documented |
+| `params[k]` on a missing key | `""` (test_params pins it; the translator routes DSL reads through `Tep.param`) — sinatra reads nil | deliberate divergence, documented |
+| `session[k]` on a missing key | `""` (test_sessions pins it; `Session#get` guards the miss) — sinatra reads nil | deliberate divergence, documented |
+| `cookies[k]` on a missing cookie | `""` (test_cookies pins it; DSL reads route through `Tep.cookie`) — sinatra-contrib reads nil | deliberate divergence, documented |
 | `error do ... end` blocks, route conditions (`provides:`, `agent:`), `register`/extensions | not claimed | mostly unresolved at compile; not individually diagnosed |
 | unrecognized top-level calls | — | ⚠️ warn + **ignored** |
 

--- a/examples/blog/app.rb
+++ b/examples/blog/app.rb
@@ -332,6 +332,7 @@ end
 post '/api/posts' do
   res.headers["Content-Type"] = "application/json"
   auth = req.req_headers["authorization"]
+  auth = "" if auth.nil?     # missing header reads as nil (tep#235)
   bearer = ""
   if auth.length > 7 && auth[0, 7] == "Bearer "
     bearer = auth[7, auth.length - 7]

--- a/examples/experiments/app.rb
+++ b/examples/experiments/app.rb
@@ -218,7 +218,9 @@ end
 # baked in. Here, accept an X-Demo-Cap-Run header as the
 # capability source so humans can drive the demo with curl.
 before do
-  if req.req_headers["x-demo-cap-run"].length > 0
+  cap = req.req_headers["x-demo-cap-run"]
+  cap = "" if cap.nil?     # missing header reads as nil (tep#235)
+  if cap.length > 0
     req.identity = Tep::Identity.new(
       "user:demo", nil, [:run_experiments])
   end

--- a/lib/tep.rb
+++ b/lib/tep.rb
@@ -129,6 +129,28 @@ module Tep
     h
   end
 
+  # Read a request cookie. A missing cookie reads as "" -- that is the
+  # documented `cookies["k"]` DSL contract (test_cookies pins it) --
+  # while the underlying hash reads nil for a missing key. bin/tep
+  # rewrites `cookies[k]` reads to this call.
+  def self.cookie(req, k)
+    v = req.cookies[k]
+    v = "" if v.nil?
+    v
+  end
+
+  # Read a request param. A missing param reads as "" -- tep's
+  # documented `params[k]` DSL contract (test_params pins it; a
+  # deliberate divergence from sinatra's nil, ledgered in
+  # docs/mirrors/sinatra.md). bin/tep rewrites `params[k]` reads to
+  # this call; direct `req.params[...]` access keeps raw Hash
+  # semantics (nil on miss).
+  def self.param(req, k)
+    v = req.params[k]
+    v = "" if v.nil?
+    v
+  end
+
   # str_find -- naive substring search returning the int position of
   # `needle` in `s` starting from `start`, or -1 if not found.
   #

--- a/lib/tep/auth_session_cookie.rb
+++ b/lib/tep/auth_session_cookie.rb
@@ -84,12 +84,16 @@ module Tep
     # if the session has no identity (no prior #set call, or after
     # #clear) or the stored identity is expired.
     def self.try(req)
+      # Session#get on a missing key reads as nil (sinatra-parity Hash
+      # semantics; same class as tep#235) -- guard before String calls.
       sub = req.session.get("identity_sub")
+      sub = "" if sub.nil?
       if sub.length == 0
         return nil
       end
 
       exp_str = req.session.get("identity_exp")
+      exp_str = "" if exp_str.nil?
       if exp_str.length > 0
         exp = exp_str.to_i
         if exp > 0 && Time.now.to_i >= exp
@@ -98,9 +102,11 @@ module Tep
       end
 
       caps_str = req.session.get("identity_caps")
+      caps_str = "" if caps_str.nil?
       caps = Tep::AuthBearerToken.parse_caps(caps_str)
 
       delegate_str = req.session.get("identity_delegate")
+      delegate_str = "" if delegate_str.nil?
       delegation = Tep::AuthBearerToken.parse_delegate(delegate_str)
 
       Tep::Identity.new(sub, delegation, caps)

--- a/lib/tep/openai_server.rb
+++ b/lib/tep/openai_server.rb
@@ -141,7 +141,10 @@ module Tep
         def self.serve!(events_jsonl = "")
           events = Tep::Events.new(events_jsonl)
           Tep::APP.set_openai_events(events)
+          # ENV[] reads nil for an unset variable (CRuby semantics) --
+          # guard before String calls (same class as tep#235).
           host = ENV["HOSTNAME"]
+          host = "" if host.nil?
           if host.length == 0
             host = "tep"
           end

--- a/lib/tep/pg.rb
+++ b/lib/tep/pg.rb
@@ -190,6 +190,16 @@ module PG
       @last_sqlstate = ""
       @last_error_message = ""
       @last_result_rh = -1
+      # Never-connected sentinel: PG::Connection.new("") is the
+      # type-seeding shape (see the _tep_seed_pg_* block). Exec on a
+      # seed conn returns the empty-Result sentinel instead of
+      # raising -- a REAL failed connect (non-empty conninfo) still
+      # raises PG::UnableToSend on first exec, per the documented
+      # non-raising-connect / raising-exec contract.
+      @seed_conn = false
+      if opts.is_a?(String) && opts.length == 0
+        @seed_conn = true
+      end
       if opts.is_a?(String)
         if Tep::Scheduler.scheduled_context?
           h = Connection.async_connect(opts)
@@ -382,6 +392,9 @@ module PG
       Pg.tep_pg_set_nonblocking(@pgh, 1)
       ok = Pg.tep_pg_send_query(@pgh, sql)
       if ok != 1
+        if @seed_conn
+          return PG::Result.new(-1)
+        end
         Connection.raise_send_failure(self)
       end
       Connection.drain_send(@pgh)
@@ -421,6 +434,9 @@ module PG
       Pg.tep_pg_set_nonblocking(@pgh, 1)
       ok = Pg.tep_pg_send_query_params(@pgh, sql)
       if ok != 1
+        if @seed_conn
+          return PG::Result.new(-1)
+        end
         Connection.raise_send_failure(self)
       end
       Connection.drain_send(@pgh)

--- a/lib/tep/session.rb
+++ b/lib/tep/session.rb
@@ -24,7 +24,15 @@ module Tep
     # exposes only named methods; the translator rewrites
     # `session[k] = v` to `session.set(k, v)` and `session[k]` to
     # `session.get(k)` for source compatibility with Sinatra.
-    def get(k);    @data[k];                          end
+    # A missing key reads as "" -- the documented `session[k]` DSL
+    # contract (test_sessions pins it; a deliberate divergence from
+    # sinatra's nil-on-miss, ledgered in docs/mirrors/sinatra.md).
+    # The raw @data hash reads nil for a miss.
+    def get(k)
+      v = @data[k]
+      v = "" if v.nil?
+      v
+    end
     def set(k, v); @data[k] = v; @dirty = true;       end
     def has?(k);   @data.key?(k);                     end
     def length;    @data.length;                      end

--- a/test/test_broadcast_pg.rb
+++ b/test/test_broadcast_pg.rb
@@ -111,8 +111,12 @@ class TestBroadcastPg < TepTest
   end
 
   def test_poll_returns_zero_on_timeout
-    # With no preceding publish + no other publisher on the channel,
-    # poll should time out cleanly.
+    # Test order is randomized and the LISTEN channel is shared:
+    # another test's publish can leave an unconsumed NOTIFY queued.
+    # Drain first, then assert a clean timeout.
+    5.times do
+      break if get("/poll?timeout=50").body == "0"
+    end
     res = get("/poll?timeout=100")
     assert_equal "0", res.body
   end

--- a/test/test_live_view.rb
+++ b/test/test_live_view.rb
@@ -18,8 +18,10 @@ class TestLiveView < TepTest
       end
       def mount(req)
         # Pull a seed value from the request's params if present;
-        # otherwise leave at 0.
+        # otherwise leave at 0. A missing param reads as nil
+        # (sinatra-parity) -- guard before String calls.
         seed = req.params["seed"]
+        seed = "" if seed.nil?
         if seed.length > 0
           @count = seed.to_i
         end

--- a/test/test_mcp.rb
+++ b/test/test_mcp.rb
@@ -12,7 +12,9 @@ class TestMCP < TepTest
     # paths -- we just override req.identity with a synthetic one
     # so req.identity.may?(:admin) returns true on demand.
     before do
-      if req.req_headers["x-test-cap-admin"].length > 0
+      cap = req.req_headers["x-test-cap-admin"]
+      cap = "" if cap.nil?
+      if cap.length > 0
         req.identity = Tep::Identity.new(
           "user:42", nil, [:admin])
       end

--- a/test/test_pg.rb
+++ b/test/test_pg.rb
@@ -268,10 +268,22 @@ class TestPg < TepTest
         r.clear
         out = "raised=no"
       rescue PG::UndefinedTable => e
+        # Hierarchy proof via a nested rescue arm instead of
+        # `e.is_a?(PG::Error)`: is_a? on a rescued local is
+        # unsupported at the current spinel pin (typed-rescue local
+        # widens; tracked in the SPINEL_PIN notes). Re-raising e and
+        # catching it with the PARENT class proves the subclass
+        # relation just as strictly.
+        hier = "no"
+        begin
+          raise e
+        rescue PG::Error
+          hier = "yes"
+        end
         out = "raised=UndefinedTable" +
               " sqlstate=" + c.last_sqlstate +
               " match42P01=" + (c.last_sqlstate == "42P01" ? "yes" : "no") +
-              " is_pg_error=" + (e.is_a?(PG::Error) ? "yes" : "no")
+              " is_pg_error=" + hier
       end
       c.close
       out
@@ -295,9 +307,16 @@ class TestPg < TepTest
         r2.clear
         out = "first_ok=yes second_raised=no"
       rescue PG::UniqueViolation => e
+        # Same nested-rescue hierarchy proof as /missing_table.
+        hier = "no"
+        begin
+          raise e
+        rescue PG::Error
+          hier = "yes"
+        end
         out = "first_ok=yes second_raised=UniqueViolation" +
               " sqlstate=" + c.last_sqlstate +
-              " is_pg_error=" + (e.is_a?(PG::Error) ? "yes" : "no")
+              " is_pg_error=" + hier
       end
       r3 = c.exec_params("DELETE FROM " + TBL + " WHERE id = $1", ["99001"])
       r3.clear

--- a/test/test_request_methods.rb
+++ b/test/test_request_methods.rb
@@ -24,7 +24,13 @@ class TestRequestMethods < TepTest
     end
 
     get '/accept-and-ct' do
-      "accept=" + request.accept + " ct=" + request.content_type
+      # Absent headers read as nil through the Rack-parity accessors
+      # (sinatra too) -- guard before concatenation.
+      a = request.accept
+      a = "" if a.nil?
+      ct = request.content_type
+      ct = "" if ct.nil?
+      "accept=" + a + " ct=" + ct
     end
   RB
 

--- a/tools/spinel-fresh.sh
+++ b/tools/spinel-fresh.sh
@@ -88,27 +88,21 @@ else
     fi
 fi
 
-# Rebuild the analyze + codegen binaries if either source is newer
-# than its built artifact, OR an artifact is missing. Skip when
-# up-to-date so this script stays cheap on the fast path (`make test`
-# after a no-op fetch).
-#
-# BOTH stages must track the checked-out commit. The `spinel` wrapper
-# prefers the compiled spinel_analyze / spinel_codegen over the .rb
-# fallbacks, so refreshing only codegen silently pairs a new codegen
-# with a stale analyzer -- old type inference + new emission. That
-# mismatch produces subtly broken code (e.g. a stale analyzer that
-# predates a method's return-type support types the result as mrb_int,
-# and the new codegen then emits pointer accessors against an int
-# slot). Rebuild them together so the pair always matches.
-need_rebuild=0
-for stage in spinel_analyze spinel_codegen; do
-    if [ ! -x "$stage" ] || [ "$stage.rb" -nt "$stage" ]; then
-        need_rebuild=1
-    fi
+# Rebuild spinel if the checked-out tree is newer than the built
+# binary. Since the unified-build refactor there is one artifact --
+# bin/spinel (the root `spinel` is a make-created symlink to it) --
+# so a plain incremental `make` keeps the binary tracking the
+# checkout; a no-op make is cheap on the fast path. Cross-era
+# checkouts (old wrapper layout <-> unified) can leave stale
+# generated files behind, so clear the known old-layout artifacts
+# before building.
+for stale in spinel_parse spinel_analyze spinel_codegen; do
+    [ -f "$stale" ] && rm -f "$stale"
 done
-
-if [ "$need_rebuild" = "1" ]; then
-    echo "tep: rebuilding spinel_analyze + spinel_codegen (slow -- CRuby bootstrap, ~5min)..." >&2
-    make -j8 spinel_analyze spinel_codegen >&2
+if [ -f spinel ] && [ ! -L spinel ]; then
+    rm -f spinel     # old-layout root wrapper; make recreates the symlink
 fi
+if [ ! -x bin/spinel ]; then
+    echo "tep: building spinel (bin/spinel missing -- full build, ~5min)..." >&2
+fi
+make -j"$(nproc)" >&2


### PR DESCRIPTION
The re-pin, at last. Both blockers landed upstream within days of being filed with repros (matz/spinel#1842 `fe955423`, #1866 `b4f4da70`); the proxy retry-after-503 path is verified green in-suite at the new pin.

**Layout:** the pin crosses the spinelc→spinel unified-build refactor — `tools/spinel-fresh.sh` and ci.yml's build-spinel staging now handle the single `bin/spinel` + `lib/` + `packages/` tree (no more phase binaries or `.rb` drivers).

**CRuby-strictness fallout** (missing-key reads and out-of-range slices are nil now — both CRuby-correct): the `params[]`/`cookies[]`/`session[]` DSL reads keep tep's *documented, test-pinned* `""`-on-miss contracts via `Tep.param`/`Tep.cookie`/`Session#get` guards — all three ledgered as deliberate sinatra divergences in docs/mirrors/sinatra.md. Lib guards added where the auth chain and openai server read possibly-absent values; two example apps and four test apps fixed.

**PG battery resurrection** — the notable find: the PG suite was broken at the *old* pin too (CI never runs it, so nobody saw): the load-time type seeds call `async_exec` on a never-connected connection, and the raising-exec path threw `PG::UnableToSend` at boot for every `tep/pg` app. Seed conns (empty conninfo) now return the empty-Result sentinel; real failed connects keep the documented raising contract. Also: `e.is_a?(PG::Error)` on typed-rescued locals stopped compiling at the new pin (rescued-local widening — noted in SPINEL_PIN for upstream follow-up); test_pg proves the hierarchy via a nested rescue arm instead.

**Verification at fd87f45b:** 60+ test files green foreground (auth trio, mcp 122 asserts, openai 128, real_world 120, proxy 49), PG trio green against postgres:16 (first time in weeks), differential oracle 5 apps / 107 assertions green.

Workaround status probed and recorded in the SPINEL_PIN annotation: `x || ""` blanking FIXED upstream (guard idiom kept — equally correct); pg_hello `is_a?` stub STAYS; PG::Pool#with typed-yield deferral (tep#189) kept pending its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)