### PR TITLE
docs: current release pointer → v0.11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SQLite, opt-in PostgreSQL, WebSockets, Broadcast + Presence + LiveView,
 an MCP tool catalog, TLS, a pooled HTTP client, and an OpenAI-compatible
 LLM client + server.
 
-> **Current release:** [v0.11.6](https://github.com/OriPekelman/tep/releases/tag/v0.11.6)
+> **Current release:** [v0.11.7](https://github.com/OriPekelman/tep/releases/tag/v0.11.7)
 > on [RubyGems](https://rubygems.org/gems/tep) — `gem install tep`.
 > Pre-alpha; API still in motion.
 


### PR DESCRIPTION
Bookkeeping for the v0.11.7 maintenance cut (from 2b3fc55d, the fd87f45b-green lib/-shaped tree — see the release notes and tep#245). version.rb deliberately untouched on main; the spin-shaped line owns the next version number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)